### PR TITLE
feat(metrics): persist CCR observability state in Redis

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ regex = "1.11"
 ratatui = "0.30"
 crossterm = "0.29"
 zstd = "0.13"
+redis = "0.32"
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["async_tokio"] }

--- a/README.md
+++ b/README.md
@@ -83,6 +83,16 @@ Create `~/.claude-code-router/config.json`:
 }
 ```
 
+Optional persistence (recommended for long-running dashboards/metrics):
+
+```json
+"Persistence": {
+    "mode": "redis",
+    "redis_url": "redis://127.0.0.1:6379/0",
+    "redis_prefix": "ccr-rust:persistence:v1"
+}
+```
+
 **What each field means:**
 
 | Field | Description |
@@ -94,6 +104,9 @@ Create `~/.claude-code-router/config.json`:
 | `Router.default` | Primary tier—requests go here first |
 | `Router.think` | Used for reasoning-heavy tasks |
 | `Router.longContext` | Used when token count exceeds `longContextThreshold` |
+| `Persistence.mode` | `none` (default) or `redis` for restart-safe observability state |
+| `Persistence.redis_url` | Redis connection URL (or `CCR_REDIS_URL`) |
+| `Persistence.redis_prefix` | Redis key prefix used by CCR persistence |
 
 ### 3. Start the Server
 

--- a/config.example.json
+++ b/config.example.json
@@ -2,6 +2,12 @@
     "PORT": 3456,
     "HOST": "127.0.0.1",
     "API_TIMEOUT_MS": 600000,
+    "Persistence": {
+        "_comment": "Optional metrics/dashboard persistence. Set mode=redis to survive server restarts.",
+        "mode": "none",
+        "redis_url": "redis://127.0.0.1:6379/0",
+        "redis_prefix": "ccr-rust:persistence:v1"
+    },
     "Providers": [
         {
             "name": "deepseek",

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -14,7 +14,7 @@ ccr-rust [GLOBAL_OPTIONS] <COMMAND> [COMMAND_OPTIONS]
 
 | Option | Short | Environment | Default | Description |
 |--------|-------|-------------|---------|-------------|
-| `--config` | `-c` | `CCR_CONFIG` | `~/.ccr/config.toml` | Path to CCR config file |
+| `--config` | `-c` | `CCR_CONFIG` | `~/.claude-code-router/config.json` | Path to CCR config file |
 
 ## Commands
 
@@ -86,6 +86,23 @@ ccr-rust validate --config ~/custom.toml
 ccr-rust version
 ```
 
+## Redis Persistence
+
+To keep observability data across CCR restarts (dashboard usage, token drift, and restored histogram offsets), add:
+
+```json
+"Persistence": {
+  "mode": "redis",
+  "redis_url": "redis://127.0.0.1:6379/0",
+  "redis_prefix": "ccr-rust:persistence:v1"
+}
+```
+
+Notes:
+- `mode`: `none` (default) or `redis`
+- `redis_url`: required when `mode=redis` (or set `CCR_REDIS_URL`)
+- `redis_prefix`: Redis key namespace for CCR persistence records
+
 ## HTTP Endpoints
 
 Once running, the server exposes the following endpoints:
@@ -98,6 +115,8 @@ Once running, the server exposes the following endpoints:
 | `/v1/latencies` | GET | Latency metrics per backend |
 | `/v1/usage` | GET | Usage statistics |
 | `/v1/token-drift` | GET | Token drift metrics |
+| `/v1/token-audit` | GET | Recent pre-request token audit entries |
+| `/v1/frontend-metrics` | GET | Per-frontend request/latency metrics |
 | `/health` | GET | Health check |
 | `/metrics` | GET | Prometheus-style metrics |
 

--- a/src/dashboard.rs
+++ b/src/dashboard.rs
@@ -257,7 +257,10 @@ fn run_loop<B: Backend>(
     host: String,
     port: u16,
     shared_state: SharedDashboardState,
-) -> Result<()> {
+) -> Result<()>
+where
+    <B as Backend>::Error: std::error::Error + Send + Sync + 'static,
+{
     let mut last_tick = Instant::now();
     let mut ui_state = UiState::default();
     let session_info = SessionInfo::collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,6 +123,7 @@ async fn run_server(
     tracing::info!("Shutdown timeout: {}s", shutdown_timeout);
 
     let ewma_tracker = std::sync::Arc::new(EwmaTracker::new());
+    metrics::init_persistence(config.persistence(), &ewma_tracker)?;
     let transformer_registry = std::sync::Arc::new(TransformerRegistry::new());
     let ratelimit_tracker = std::sync::Arc::new(RateLimitTracker::new());
     let state = AppState {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,3 +1,4 @@
+use anyhow::{anyhow, Context, Result};
 use axum::response::IntoResponse;
 use axum::Json;
 use lazy_static::lazy_static;
@@ -8,14 +9,20 @@ use prometheus::{
     register_histogram_vec, Counter, CounterVec, Encoder, Gauge, GaugeVec, HistogramVec,
     TextEncoder,
 };
+use redis::Commands;
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, VecDeque};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::sync::OnceLock;
+use std::thread;
 use std::time::SystemTime;
 use tiktoken_rs::cl100k_base;
-use tracing::info;
+use tracing::{info, warn};
 
+use crate::config::{PersistenceConfig, PersistenceMode};
 use crate::frontend::FrontendType;
+use crate::ratelimit::restore_rate_limit_backoff_counter;
 use crate::routing::EwmaTracker;
 
 lazy_static! {
@@ -164,6 +171,32 @@ lazy_static! {
     static ref BPE: tiktoken_rs::CoreBPE = cl100k_base().expect("failed to load cl100k_base tokenizer");
 }
 
+const METRIC_REQUESTS_TOTAL: &str = "ccr_requests_total";
+const METRIC_REQUEST_DURATION_SECONDS: &str = "ccr_request_duration_seconds";
+const METRIC_FRONTEND_REQUESTS_TOTAL: &str = "ccr_frontend_requests_total";
+const METRIC_FRONTEND_REQUEST_DURATION_SECONDS: &str = "ccr_frontend_request_duration_seconds";
+const METRIC_FAILURES_TOTAL: &str = "ccr_failures_total";
+const METRIC_PEAK_ACTIVE_STREAMS: &str = "ccr_peak_active_streams";
+const METRIC_STREAM_BACKPRESSURE_TOTAL: &str = "ccr_stream_backpressure_total";
+const METRIC_REJECTED_STREAMS_TOTAL: &str = "ccr_rejected_streams_total";
+const METRIC_INPUT_TOKENS_TOTAL: &str = "ccr_input_tokens_total";
+const METRIC_OUTPUT_TOKENS_TOTAL: &str = "ccr_output_tokens_total";
+const METRIC_CACHE_READ_TOKENS_TOTAL: &str = "ccr_cache_read_tokens_total";
+const METRIC_CACHE_CREATION_TOKENS_TOTAL: &str = "ccr_cache_creation_tokens_total";
+const METRIC_PRE_REQUEST_TOKENS_TOTAL: &str = "ccr_pre_request_tokens_total";
+const METRIC_PRE_REQUEST_TOKENS: &str = "ccr_pre_request_tokens";
+const METRIC_RATE_LIMIT_HITS_TOTAL: &str = "ccr_rate_limit_hits_total";
+const METRIC_RATE_LIMIT_BACKOFFS_TOTAL: &str = "ccr_rate_limit_backoffs_total";
+const METRIC_TIER_EWMA_LATENCY_SECONDS: &str = "ccr_tier_ewma_latency_seconds";
+const METRIC_TOKEN_DRIFT_ABSOLUTE: &str = "ccr_token_drift_absolute";
+const METRIC_TOKEN_DRIFT_PCT: &str = "ccr_token_drift_pct";
+const METRIC_TOKEN_DRIFT_ALERTS_TOTAL: &str = "ccr_token_drift_alerts_total";
+
+const REQUEST_DURATION_BUCKETS: &[f64] = &[0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0];
+const PRE_REQUEST_TOKENS_BUCKETS: &[f64] = &[
+    100.0, 500.0, 1000.0, 2000.0, 5000.0, 10000.0, 25000.0, 50000.0, 100000.0, 200000.0,
+];
+
 // Per-tier token drift state: tracks running totals for local estimates vs upstream reported.
 // Fields: (local_estimate_sum, upstream_reported_sum, sample_count, last_drift_pct)
 static TOKEN_DRIFT_STATE: RwLock<Option<HashMap<String, TokenDriftEntry>>> = RwLock::new(None);
@@ -173,6 +206,8 @@ const AUDIT_LOG_CAPACITY: usize = 1024;
 
 /// Ring buffer holding the most recent pre-request token audit entries.
 static AUDIT_LOG: RwLock<Option<VecDeque<PreRequestAuditEntry>>> = RwLock::new(None);
+
+static REDIS_RUNTIME: OnceLock<RedisRuntime> = OnceLock::new();
 
 /// A single pre-request token audit record capturing the estimated token
 /// breakdown for a request before it is dispatched to a backend tier.
@@ -190,11 +225,81 @@ pub struct PreRequestAuditEntry {
     pub total_tokens: u64,
 }
 
+#[derive(Debug)]
+struct RedisRuntime {
+    sender: Sender<PersistEvent>,
+    histogram_offsets: HistogramOffsetStore,
+}
+
+#[derive(Debug, Clone)]
+enum PersistEvent {
+    CounterInc {
+        metric: &'static str,
+        labels: String,
+        by: f64,
+    },
+    GaugeSet {
+        metric: &'static str,
+        labels: String,
+        value: f64,
+    },
+    GaugeMax {
+        metric: &'static str,
+        labels: String,
+        value: f64,
+    },
+    HistogramObserve {
+        metric: &'static str,
+        labels: String,
+        value: f64,
+    },
+    TokenDriftStateSet {
+        tier: String,
+        entry: TokenDriftEntry,
+    },
+    TokenAuditPush {
+        entry: PreRequestAuditEntry,
+    },
+    EwmaStateSet {
+        tier: String,
+        ewma: f64,
+        samples: u64,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PersistedEwmaState {
+    ewma: f64,
+    samples: u64,
+}
+
+#[derive(Debug, Clone, Default)]
+struct RedisSnapshot {
+    counters: HashMap<&'static str, HashMap<String, f64>>,
+    gauges: HashMap<&'static str, HashMap<String, f64>>,
+    histogram_offsets: HistogramOffsetStore,
+    token_drift_state: HashMap<String, TokenDriftEntry>,
+    token_audit_log: Vec<PreRequestAuditEntry>,
+    ewma_state: HashMap<String, PersistedEwmaState>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct HistogramOffsetStore {
+    by_metric: HashMap<&'static str, HashMap<String, HistogramOffset>>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct HistogramOffset {
+    sample_sum: f64,
+    sample_count: u64,
+    cumulative_buckets: HashMap<String, u64>,
+}
+
 /// Percentage thresholds for drift severity classification.
 const DRIFT_WARN_PCT: f64 = 10.0;
 const DRIFT_ALERT_PCT: f64 = 25.0;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct TokenDriftEntry {
     local_sum: u64,
     upstream_sum: u64,
@@ -209,6 +314,730 @@ pub static TOTAL_INPUT_TOKENS: AtomicU64 = AtomicU64::new(0);
 pub static TOTAL_OUTPUT_TOKENS: AtomicU64 = AtomicU64::new(0);
 pub static TOTAL_REQUESTS: AtomicU64 = AtomicU64::new(0);
 pub static TOTAL_FAILURES: AtomicU64 = AtomicU64::new(0);
+
+/// Initialize optional metrics persistence.
+///
+/// When `Persistence.mode = "redis"`, CCR-Rust restores counters/gauges,
+/// token drift state, audit log, EWMA state, and histogram offsets from Redis.
+pub fn init_persistence(config: &PersistenceConfig, ewma_tracker: &EwmaTracker) -> Result<()> {
+    if config.mode != PersistenceMode::Redis {
+        return Ok(());
+    }
+    if REDIS_RUNTIME.get().is_some() {
+        return Ok(());
+    }
+
+    let redis_url = config
+        .redis_url
+        .clone()
+        .or_else(|| std::env::var("CCR_REDIS_URL").ok())
+        .ok_or_else(|| anyhow!("Persistence.mode=redis requires Persistence.redis_url"))?;
+    let redis_prefix = config.redis_prefix.clone();
+
+    let client = redis::Client::open(redis_url.as_str())
+        .with_context(|| format!("Failed to create Redis client for {}", redis_url))?;
+    let mut conn = client
+        .get_connection()
+        .context("Failed to connect to Redis for persistence snapshot load")?;
+    let snapshot = load_snapshot(&mut conn, &redis_prefix)?;
+    apply_snapshot(&snapshot, ewma_tracker);
+    sync_ewma_gauge(ewma_tracker);
+
+    let (tx, rx) = mpsc::channel();
+    spawn_redis_worker(client, redis_prefix, rx);
+
+    REDIS_RUNTIME
+        .set(RedisRuntime {
+            sender: tx,
+            histogram_offsets: snapshot.histogram_offsets.clone(),
+        })
+        .map_err(|_| anyhow!("Redis runtime is already initialized"))?;
+
+    info!("Redis metrics persistence initialized");
+    Ok(())
+}
+
+fn redis_runtime() -> Option<&'static RedisRuntime> {
+    REDIS_RUNTIME.get()
+}
+
+fn persist_counter_inc(metric: &'static str, labels: &[(&str, &str)], by: f64) {
+    if by <= 0.0 {
+        return;
+    }
+    if let Some(runtime) = redis_runtime() {
+        let _ = runtime.sender.send(PersistEvent::CounterInc {
+            metric,
+            labels: encode_labels(labels),
+            by,
+        });
+    }
+}
+
+fn persist_gauge_set(metric: &'static str, labels: &[(&str, &str)], value: f64) {
+    if let Some(runtime) = redis_runtime() {
+        let _ = runtime.sender.send(PersistEvent::GaugeSet {
+            metric,
+            labels: encode_labels(labels),
+            value,
+        });
+    }
+}
+
+fn persist_gauge_max(metric: &'static str, labels: &[(&str, &str)], value: f64) {
+    if let Some(runtime) = redis_runtime() {
+        let _ = runtime.sender.send(PersistEvent::GaugeMax {
+            metric,
+            labels: encode_labels(labels),
+            value,
+        });
+    }
+}
+
+fn persist_histogram_observe(metric: &'static str, labels: &[(&str, &str)], value: f64) {
+    if !value.is_finite() || value < 0.0 {
+        return;
+    }
+    if let Some(runtime) = redis_runtime() {
+        let _ = runtime.sender.send(PersistEvent::HistogramObserve {
+            metric,
+            labels: encode_labels(labels),
+            value,
+        });
+    }
+}
+
+fn persist_token_drift_state(tier: &str, entry: &TokenDriftEntry) {
+    if let Some(runtime) = redis_runtime() {
+        let _ = runtime.sender.send(PersistEvent::TokenDriftStateSet {
+            tier: tier.to_string(),
+            entry: entry.clone(),
+        });
+    }
+}
+
+fn persist_token_audit(entry: &PreRequestAuditEntry) {
+    if let Some(runtime) = redis_runtime() {
+        let _ = runtime.sender.send(PersistEvent::TokenAuditPush {
+            entry: entry.clone(),
+        });
+    }
+}
+
+fn persist_ewma_state(tier: &str, ewma: f64, samples: u64) {
+    if let Some(runtime) = redis_runtime() {
+        let _ = runtime.sender.send(PersistEvent::EwmaStateSet {
+            tier: tier.to_string(),
+            ewma,
+            samples,
+        });
+    }
+}
+
+fn get_hist_offset(
+    metric: &'static str,
+    labels: &[(&str, &str)],
+) -> Option<&'static HistogramOffset> {
+    let runtime = redis_runtime()?;
+    runtime
+        .histogram_offsets
+        .by_metric
+        .get(metric)
+        .and_then(|by_label| by_label.get(&encode_labels(labels)))
+}
+
+fn encode_labels(labels: &[(&str, &str)]) -> String {
+    let map: BTreeMap<&str, &str> = labels.iter().copied().collect();
+    serde_json::to_string(&map).unwrap_or_else(|_| "{}".to_string())
+}
+
+fn decode_labels(encoded: &str) -> Option<BTreeMap<String, String>> {
+    serde_json::from_str::<BTreeMap<String, String>>(encoded).ok()
+}
+
+fn get_label<'a>(labels: &'a BTreeMap<String, String>, key: &str) -> Option<&'a str> {
+    labels.get(key).map(|s| s.as_str())
+}
+
+fn snapshot_counter_sum(snapshot: &RedisSnapshot, metric: &'static str) -> u64 {
+    snapshot
+        .counters
+        .get(metric)
+        .map(|m| m.values().copied().sum::<f64>().max(0.0) as u64)
+        .unwrap_or(0)
+}
+
+fn load_snapshot(conn: &mut redis::Connection, prefix: &str) -> Result<RedisSnapshot> {
+    let counter_metrics = [
+        METRIC_REQUESTS_TOTAL,
+        METRIC_FRONTEND_REQUESTS_TOTAL,
+        METRIC_FAILURES_TOTAL,
+        METRIC_INPUT_TOKENS_TOTAL,
+        METRIC_OUTPUT_TOKENS_TOTAL,
+        METRIC_CACHE_READ_TOKENS_TOTAL,
+        METRIC_CACHE_CREATION_TOKENS_TOTAL,
+        METRIC_STREAM_BACKPRESSURE_TOTAL,
+        METRIC_REJECTED_STREAMS_TOTAL,
+        METRIC_PRE_REQUEST_TOKENS_TOTAL,
+        METRIC_RATE_LIMIT_HITS_TOTAL,
+        METRIC_RATE_LIMIT_BACKOFFS_TOTAL,
+        METRIC_TOKEN_DRIFT_ALERTS_TOTAL,
+    ];
+    let gauge_metrics = [
+        METRIC_PEAK_ACTIVE_STREAMS,
+        METRIC_TIER_EWMA_LATENCY_SECONDS,
+        METRIC_TOKEN_DRIFT_ABSOLUTE,
+        METRIC_TOKEN_DRIFT_PCT,
+    ];
+    let histogram_metrics = [
+        METRIC_REQUEST_DURATION_SECONDS,
+        METRIC_FRONTEND_REQUEST_DURATION_SECONDS,
+        METRIC_PRE_REQUEST_TOKENS,
+    ];
+
+    let mut snapshot = RedisSnapshot::default();
+
+    for metric in counter_metrics {
+        let key = redis_counter_key(prefix, metric);
+        let values: HashMap<String, f64> = conn.hgetall(&key).unwrap_or_default();
+        snapshot.counters.insert(metric, values);
+    }
+
+    for metric in gauge_metrics {
+        let key = redis_gauge_key(prefix, metric);
+        let values: HashMap<String, f64> = conn.hgetall(&key).unwrap_or_default();
+        snapshot.gauges.insert(metric, values);
+    }
+
+    for metric in histogram_metrics {
+        let sums: HashMap<String, f64> = conn
+            .hgetall(redis_hist_sum_key(prefix, metric))
+            .unwrap_or_default();
+        let counts: HashMap<String, u64> = conn
+            .hgetall(redis_hist_count_key(prefix, metric))
+            .unwrap_or_default();
+
+        let mut by_label: HashMap<String, HistogramOffset> = HashMap::new();
+        for (labels, sample_sum) in sums {
+            let entry = by_label.entry(labels).or_default();
+            entry.sample_sum = sample_sum;
+        }
+        for (labels, sample_count) in counts {
+            let entry = by_label.entry(labels).or_default();
+            entry.sample_count = sample_count;
+        }
+
+        if let Some(bounds) = histogram_bounds(metric) {
+            for bound in bounds {
+                let bound_key = format_bound(*bound);
+                let values: HashMap<String, u64> = conn
+                    .hgetall(redis_hist_bucket_key(prefix, metric, &bound_key))
+                    .unwrap_or_default();
+                for (labels, count) in values {
+                    let entry = by_label.entry(labels).or_default();
+                    entry.cumulative_buckets.insert(bound_key.clone(), count);
+                }
+            }
+        }
+
+        snapshot
+            .histogram_offsets
+            .by_metric
+            .insert(metric, by_label);
+    }
+
+    let drift_raw: HashMap<String, String> = conn
+        .hgetall(redis_token_drift_state_key(prefix))
+        .unwrap_or_default();
+    for (tier, raw) in drift_raw {
+        if let Ok(entry) = serde_json::from_str::<TokenDriftEntry>(&raw) {
+            snapshot.token_drift_state.insert(tier, entry);
+        }
+    }
+
+    let audit_raw: Vec<String> = conn
+        .lrange(
+            redis_token_audit_list_key(prefix),
+            0,
+            AUDIT_LOG_CAPACITY as isize - 1,
+        )
+        .unwrap_or_default();
+    for raw in audit_raw {
+        if let Ok(entry) = serde_json::from_str::<PreRequestAuditEntry>(&raw) {
+            snapshot.token_audit_log.push(entry);
+        }
+    }
+
+    let ewma_raw: HashMap<String, String> = conn
+        .hgetall(redis_ewma_state_key(prefix))
+        .unwrap_or_default();
+    for (tier, raw) in ewma_raw {
+        if let Ok(state) = serde_json::from_str::<PersistedEwmaState>(&raw) {
+            snapshot.ewma_state.insert(tier, state);
+        }
+    }
+
+    Ok(snapshot)
+}
+
+fn apply_snapshot(snapshot: &RedisSnapshot, ewma_tracker: &EwmaTracker) {
+    for (metric, values) in &snapshot.counters {
+        for (encoded_labels, value) in values {
+            apply_counter_restore(metric, encoded_labels, *value);
+        }
+    }
+
+    for (metric, values) in &snapshot.gauges {
+        for (encoded_labels, value) in values {
+            apply_gauge_restore(metric, encoded_labels, *value);
+        }
+    }
+
+    TOTAL_REQUESTS.store(
+        snapshot_counter_sum(snapshot, METRIC_REQUESTS_TOTAL),
+        Ordering::Relaxed,
+    );
+    TOTAL_FAILURES.store(
+        snapshot_counter_sum(snapshot, METRIC_FAILURES_TOTAL),
+        Ordering::Relaxed,
+    );
+    TOTAL_INPUT_TOKENS.store(
+        snapshot_counter_sum(snapshot, METRIC_INPUT_TOKENS_TOTAL),
+        Ordering::Relaxed,
+    );
+    TOTAL_OUTPUT_TOKENS.store(
+        snapshot_counter_sum(snapshot, METRIC_OUTPUT_TOKENS_TOTAL),
+        Ordering::Relaxed,
+    );
+
+    if snapshot.token_drift_state.is_empty() {
+        *TOKEN_DRIFT_STATE.write() = None;
+    } else {
+        *TOKEN_DRIFT_STATE.write() = Some(snapshot.token_drift_state.clone());
+    }
+
+    if snapshot.token_audit_log.is_empty() {
+        *AUDIT_LOG.write() = None;
+    } else {
+        let mut deque = VecDeque::with_capacity(AUDIT_LOG_CAPACITY);
+        for entry in snapshot
+            .token_audit_log
+            .iter()
+            .take(AUDIT_LOG_CAPACITY)
+            .cloned()
+        {
+            deque.push_back(entry);
+        }
+        *AUDIT_LOG.write() = Some(deque);
+    }
+
+    for (tier, state) in &snapshot.ewma_state {
+        ewma_tracker.restore_tier_state(tier, state.ewma, state.samples);
+    }
+}
+
+fn apply_counter_restore(metric: &'static str, encoded_labels: &str, value: f64) {
+    if value <= 0.0 {
+        return;
+    }
+    let labels = decode_labels(encoded_labels).unwrap_or_default();
+    match metric {
+        METRIC_REQUESTS_TOTAL => {
+            if let Some(tier) = get_label(&labels, "tier") {
+                REQUESTS_TOTAL.with_label_values(&[tier]).inc_by(value);
+            }
+        }
+        METRIC_FRONTEND_REQUESTS_TOTAL => {
+            if let Some(frontend) = get_label(&labels, "frontend") {
+                FRONTEND_REQUESTS_TOTAL
+                    .with_label_values(&[frontend])
+                    .inc_by(value);
+            }
+        }
+        METRIC_FAILURES_TOTAL => {
+            if let (Some(tier), Some(reason)) =
+                (get_label(&labels, "tier"), get_label(&labels, "reason"))
+            {
+                FAILURES_TOTAL
+                    .with_label_values(&[tier, reason])
+                    .inc_by(value);
+            }
+        }
+        METRIC_INPUT_TOKENS_TOTAL => {
+            if let Some(tier) = get_label(&labels, "tier") {
+                INPUT_TOKENS_TOTAL.with_label_values(&[tier]).inc_by(value);
+            }
+        }
+        METRIC_OUTPUT_TOKENS_TOTAL => {
+            if let Some(tier) = get_label(&labels, "tier") {
+                OUTPUT_TOKENS_TOTAL.with_label_values(&[tier]).inc_by(value);
+            }
+        }
+        METRIC_CACHE_READ_TOKENS_TOTAL => {
+            if let Some(tier) = get_label(&labels, "tier") {
+                CACHE_READ_TOKENS_TOTAL
+                    .with_label_values(&[tier])
+                    .inc_by(value);
+            }
+        }
+        METRIC_CACHE_CREATION_TOKENS_TOTAL => {
+            if let Some(tier) = get_label(&labels, "tier") {
+                CACHE_CREATION_TOKENS_TOTAL
+                    .with_label_values(&[tier])
+                    .inc_by(value);
+            }
+        }
+        METRIC_STREAM_BACKPRESSURE_TOTAL => {
+            STREAM_BACKPRESSURE.inc_by(value);
+        }
+        METRIC_REJECTED_STREAMS_TOTAL => {
+            REJECTED_STREAMS.inc_by(value);
+        }
+        METRIC_PRE_REQUEST_TOKENS_TOTAL => {
+            if let (Some(tier), Some(component)) =
+                (get_label(&labels, "tier"), get_label(&labels, "component"))
+            {
+                PRE_REQUEST_TOKENS
+                    .with_label_values(&[tier, component])
+                    .inc_by(value);
+            }
+        }
+        METRIC_RATE_LIMIT_HITS_TOTAL => {
+            if let Some(tier) = get_label(&labels, "tier") {
+                RATE_LIMIT_HITS.with_label_values(&[tier]).inc_by(value);
+            }
+        }
+        METRIC_RATE_LIMIT_BACKOFFS_TOTAL => {
+            if let Some(tier) = get_label(&labels, "tier") {
+                restore_rate_limit_backoff_counter(tier, value);
+            }
+        }
+        METRIC_TOKEN_DRIFT_ALERTS_TOTAL => {
+            if let (Some(tier), Some(severity)) =
+                (get_label(&labels, "tier"), get_label(&labels, "severity"))
+            {
+                TOKEN_DRIFT_ALERTS
+                    .with_label_values(&[tier, severity])
+                    .inc_by(value);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn apply_gauge_restore(metric: &'static str, encoded_labels: &str, value: f64) {
+    let labels = decode_labels(encoded_labels).unwrap_or_default();
+    match metric {
+        METRIC_PEAK_ACTIVE_STREAMS => {
+            if value > PEAK_ACTIVE_STREAMS.get() {
+                PEAK_ACTIVE_STREAMS.set(value);
+            }
+        }
+        METRIC_TIER_EWMA_LATENCY_SECONDS => {
+            if let Some(tier) = get_label(&labels, "tier") {
+                TIER_EWMA_LATENCY.with_label_values(&[tier]).set(value);
+            }
+        }
+        METRIC_TOKEN_DRIFT_ABSOLUTE => {
+            if let Some(tier) = get_label(&labels, "tier") {
+                TOKEN_DRIFT_ABS.with_label_values(&[tier]).set(value);
+            }
+        }
+        METRIC_TOKEN_DRIFT_PCT => {
+            if let Some(tier) = get_label(&labels, "tier") {
+                TOKEN_DRIFT_PCT.with_label_values(&[tier]).set(value);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn redis_counter_key(prefix: &str, metric: &str) -> String {
+    format!("{}:counter:{}", prefix, metric)
+}
+
+fn redis_gauge_key(prefix: &str, metric: &str) -> String {
+    format!("{}:gauge:{}", prefix, metric)
+}
+
+fn redis_hist_sum_key(prefix: &str, metric: &str) -> String {
+    format!("{}:hist:{}:sum", prefix, metric)
+}
+
+fn redis_hist_count_key(prefix: &str, metric: &str) -> String {
+    format!("{}:hist:{}:count", prefix, metric)
+}
+
+fn redis_hist_bucket_key(prefix: &str, metric: &str, bound: &str) -> String {
+    format!("{}:hist:{}:bucket:{}", prefix, metric, bound)
+}
+
+fn redis_token_drift_state_key(prefix: &str) -> String {
+    format!("{}:state:token-drift", prefix)
+}
+
+fn redis_token_audit_list_key(prefix: &str) -> String {
+    format!("{}:list:token-audit", prefix)
+}
+
+fn redis_ewma_state_key(prefix: &str) -> String {
+    format!("{}:state:ewma", prefix)
+}
+
+fn histogram_bounds(metric: &str) -> Option<&'static [f64]> {
+    match metric {
+        METRIC_REQUEST_DURATION_SECONDS | METRIC_FRONTEND_REQUEST_DURATION_SECONDS => {
+            Some(REQUEST_DURATION_BUCKETS)
+        }
+        METRIC_PRE_REQUEST_TOKENS => Some(PRE_REQUEST_TOKENS_BUCKETS),
+        _ => None,
+    }
+}
+
+fn format_bound(bound: f64) -> String {
+    format!("{:.6}", bound)
+}
+
+fn spawn_redis_worker(client: redis::Client, prefix: String, rx: Receiver<PersistEvent>) {
+    thread::spawn(move || {
+        let mut conn: Option<redis::Connection> = None;
+        while let Ok(event) = rx.recv() {
+            if conn.is_none() {
+                match client.get_connection() {
+                    Ok(c) => conn = Some(c),
+                    Err(err) => {
+                        warn!(error = %err, "Failed to connect to Redis persistence backend");
+                        continue;
+                    }
+                }
+            }
+
+            let Some(connection) = conn.as_mut() else {
+                continue;
+            };
+
+            if let Err(err) = persist_event(connection, &prefix, event) {
+                warn!(error = %err, "Redis persistence write failed");
+                conn = None;
+            }
+        }
+    });
+}
+
+fn persist_event(conn: &mut redis::Connection, prefix: &str, event: PersistEvent) -> Result<()> {
+    match event {
+        PersistEvent::CounterInc { metric, labels, by } => {
+            let _: f64 = redis::cmd("HINCRBYFLOAT")
+                .arg(redis_counter_key(prefix, metric))
+                .arg(labels)
+                .arg(by)
+                .query(conn)?;
+        }
+        PersistEvent::GaugeSet {
+            metric,
+            labels,
+            value,
+        } => {
+            let _: () = conn.hset(redis_gauge_key(prefix, metric), labels, value)?;
+        }
+        PersistEvent::GaugeMax {
+            metric,
+            labels,
+            value,
+        } => {
+            let key = redis_gauge_key(prefix, metric);
+            let current: Option<f64> = conn.hget(&key, &labels).ok();
+            if current.unwrap_or(f64::NEG_INFINITY) < value {
+                let _: () = conn.hset(key, labels, value)?;
+            }
+        }
+        PersistEvent::HistogramObserve {
+            metric,
+            labels,
+            value,
+        } => {
+            let mut pipe = redis::pipe();
+            pipe.cmd("HINCRBYFLOAT")
+                .arg(redis_hist_sum_key(prefix, metric))
+                .arg(&labels)
+                .arg(value)
+                .ignore()
+                .cmd("HINCRBY")
+                .arg(redis_hist_count_key(prefix, metric))
+                .arg(&labels)
+                .arg(1)
+                .ignore();
+
+            if let Some(bounds) = histogram_bounds(metric) {
+                for bound in bounds {
+                    if value <= *bound {
+                        pipe.cmd("HINCRBY")
+                            .arg(redis_hist_bucket_key(prefix, metric, &format_bound(*bound)))
+                            .arg(&labels)
+                            .arg(1)
+                            .ignore();
+                    }
+                }
+            }
+            let _: () = pipe.query(conn)?;
+        }
+        PersistEvent::TokenDriftStateSet { tier, entry } => {
+            let raw = serde_json::to_string(&entry)?;
+            let _: () = conn.hset(redis_token_drift_state_key(prefix), tier, raw)?;
+        }
+        PersistEvent::TokenAuditPush { entry } => {
+            let raw = serde_json::to_string(&entry)?;
+            let mut pipe = redis::pipe();
+            pipe.cmd("RPUSH")
+                .arg(redis_token_audit_list_key(prefix))
+                .arg(raw)
+                .ignore()
+                .cmd("LTRIM")
+                .arg(redis_token_audit_list_key(prefix))
+                .arg(-(AUDIT_LOG_CAPACITY as isize))
+                .arg(-1)
+                .ignore();
+            let _: () = pipe.query(conn)?;
+        }
+        PersistEvent::EwmaStateSet {
+            tier,
+            ewma,
+            samples,
+        } => {
+            let raw = serde_json::to_string(&PersistedEwmaState { ewma, samples })?;
+            let _: () = conn.hset(redis_ewma_state_key(prefix), tier, raw)?;
+        }
+    }
+    Ok(())
+}
+
+fn make_metric_with_labels(encoded_labels: &str) -> prometheus::proto::Metric {
+    let mut metric = prometheus::proto::Metric::new();
+    let labels = decode_labels(encoded_labels).unwrap_or_default();
+    for (name, value) in labels {
+        let mut pair = prometheus::proto::LabelPair::new();
+        pair.set_name(name);
+        pair.set_value(value);
+        metric.mut_label().push(pair);
+    }
+    metric
+}
+
+fn encode_metric_labels(metric: &prometheus::proto::Metric) -> String {
+    let mut labels = BTreeMap::new();
+    for label in metric.get_label() {
+        labels.insert(label.get_name().to_string(), label.get_value().to_string());
+    }
+    serde_json::to_string(&labels).unwrap_or_else(|_| "{}".to_string())
+}
+
+fn merge_histogram_offsets(metric_families: &mut Vec<prometheus::proto::MetricFamily>) {
+    let Some(runtime) = redis_runtime() else {
+        return;
+    };
+
+    for metric_name in [
+        METRIC_REQUEST_DURATION_SECONDS,
+        METRIC_FRONTEND_REQUEST_DURATION_SECONDS,
+        METRIC_PRE_REQUEST_TOKENS,
+    ] {
+        let Some(offsets) = runtime.histogram_offsets.by_metric.get(metric_name) else {
+            continue;
+        };
+        if offsets.is_empty() {
+            continue;
+        }
+
+        let family_idx = metric_families
+            .iter()
+            .position(|family| family.get_name() == metric_name);
+
+        if let Some(idx) = family_idx {
+            let family = &mut metric_families[idx];
+            let mut existing_indices: HashMap<String, usize> = HashMap::new();
+            for (i, metric) in family.get_metric().iter().enumerate() {
+                existing_indices.insert(encode_metric_labels(metric), i);
+            }
+
+            for (labels, offset) in offsets {
+                if let Some(&metric_idx) = existing_indices.get(labels) {
+                    let metric = &mut family.mut_metric()[metric_idx];
+                    let hist = metric.mut_histogram();
+                    hist.set_sample_sum(hist.get_sample_sum() + offset.sample_sum);
+                    hist.set_sample_count(hist.get_sample_count() + offset.sample_count);
+
+                    let mut current_buckets: HashMap<String, u64> = HashMap::new();
+                    for bucket in hist.get_bucket() {
+                        current_buckets.insert(
+                            format_bound(bucket.get_upper_bound()),
+                            bucket.get_cumulative_count(),
+                        );
+                    }
+                    for (bound, count) in &offset.cumulative_buckets {
+                        *current_buckets.entry(bound.clone()).or_insert(0) += count;
+                    }
+
+                    hist.clear_bucket();
+                    if let Some(bounds) = histogram_bounds(metric_name) {
+                        for bound in bounds {
+                            let key = format_bound(*bound);
+                            let mut bucket = prometheus::proto::Bucket::new();
+                            bucket.set_upper_bound(*bound);
+                            bucket.set_cumulative_count(
+                                current_buckets.get(&key).copied().unwrap_or(0),
+                            );
+                            hist.mut_bucket().push(bucket);
+                        }
+                    }
+                } else {
+                    let mut metric = make_metric_with_labels(labels);
+                    let mut hist = prometheus::proto::Histogram::new();
+                    hist.set_sample_sum(offset.sample_sum);
+                    hist.set_sample_count(offset.sample_count);
+                    if let Some(bounds) = histogram_bounds(metric_name) {
+                        for bound in bounds {
+                            let key = format_bound(*bound);
+                            let mut bucket = prometheus::proto::Bucket::new();
+                            bucket.set_upper_bound(*bound);
+                            bucket.set_cumulative_count(
+                                offset.cumulative_buckets.get(&key).copied().unwrap_or(0),
+                            );
+                            hist.mut_bucket().push(bucket);
+                        }
+                    }
+                    metric.set_histogram(hist);
+                    family.mut_metric().push(metric);
+                }
+            }
+        } else {
+            let mut family = prometheus::proto::MetricFamily::new();
+            family.set_name(metric_name.to_string());
+            family.set_help("restored histogram offsets".to_string());
+            family.set_field_type(prometheus::proto::MetricType::HISTOGRAM);
+
+            for (labels, offset) in offsets {
+                let mut metric = make_metric_with_labels(labels);
+                let mut hist = prometheus::proto::Histogram::new();
+                hist.set_sample_sum(offset.sample_sum);
+                hist.set_sample_count(offset.sample_count);
+                if let Some(bounds) = histogram_bounds(metric_name) {
+                    for bound in bounds {
+                        let key = format_bound(*bound);
+                        let mut bucket = prometheus::proto::Bucket::new();
+                        bucket.set_upper_bound(*bound);
+                        bucket.set_cumulative_count(
+                            offset.cumulative_buckets.get(&key).copied().unwrap_or(0),
+                        );
+                        hist.mut_bucket().push(bucket);
+                    }
+                }
+                metric.set_histogram(hist);
+                family.mut_metric().push(metric);
+            }
+            metric_families.push(family);
+        }
+    }
+}
 
 /// Get the current number of active streams.
 pub fn get_active_streams() -> f64 {
@@ -225,14 +1054,21 @@ fn frontend_label(frontend: FrontendType) -> &'static str {
 pub fn record_request(tier: &str) {
     REQUESTS_TOTAL.with_label_values(&[tier]).inc();
     TOTAL_REQUESTS.fetch_add(1, Ordering::Relaxed);
+    persist_counter_inc(METRIC_REQUESTS_TOTAL, &[("tier", tier)], 1.0);
 }
 
 pub fn record_request_with_frontend(tier: &str, frontend: FrontendType) {
     REQUESTS_TOTAL.with_label_values(&[tier]).inc();
     TOTAL_REQUESTS.fetch_add(1, Ordering::Relaxed);
+    persist_counter_inc(METRIC_REQUESTS_TOTAL, &[("tier", tier)], 1.0);
     FRONTEND_REQUESTS_TOTAL
         .with_label_values(&[frontend_label(frontend)])
         .inc();
+    persist_counter_inc(
+        METRIC_FRONTEND_REQUESTS_TOTAL,
+        &[("frontend", frontend_label(frontend))],
+        1.0,
+    );
 }
 
 /// Record request duration in the Prometheus histogram. EWMA tracking is handled
@@ -241,6 +1077,7 @@ pub fn record_request_duration(tier: &str, duration: f64) {
     REQUEST_DURATION
         .with_label_values(&[tier])
         .observe(duration);
+    persist_histogram_observe(METRIC_REQUEST_DURATION_SECONDS, &[("tier", tier)], duration);
 }
 
 /// Record request duration with frontend information.
@@ -248,22 +1085,35 @@ pub fn record_request_duration_with_frontend(tier: &str, duration: f64, frontend
     REQUEST_DURATION
         .with_label_values(&[tier])
         .observe(duration);
+    persist_histogram_observe(METRIC_REQUEST_DURATION_SECONDS, &[("tier", tier)], duration);
     FRONTEND_REQUEST_LATENCY
         .with_label_values(&[frontend_label(frontend)])
         .observe(duration);
+    persist_histogram_observe(
+        METRIC_FRONTEND_REQUEST_DURATION_SECONDS,
+        &[("frontend", frontend_label(frontend))],
+        duration,
+    );
 }
 
 /// Sync the Prometheus EWMA gauge from the routing tracker. Called after the
 /// tracker records a success or failure so the gauge stays in sync for scraping.
 pub fn sync_ewma_gauge(tracker: &EwmaTracker) {
-    for (tier, ewma, _count) in tracker.get_all_latencies() {
+    for (tier, ewma, count) in tracker.get_all_latencies() {
         TIER_EWMA_LATENCY.with_label_values(&[&tier]).set(ewma);
+        persist_gauge_set(METRIC_TIER_EWMA_LATENCY_SECONDS, &[("tier", &tier)], ewma);
+        persist_ewma_state(&tier, ewma, count);
     }
 }
 
 pub fn record_failure(tier: &str, reason: &str) {
     FAILURES_TOTAL.with_label_values(&[tier, reason]).inc();
     TOTAL_FAILURES.fetch_add(1, Ordering::Relaxed);
+    persist_counter_inc(
+        METRIC_FAILURES_TOTAL,
+        &[("tier", tier), ("reason", reason)],
+        1.0,
+    );
 }
 
 pub fn increment_active_streams(delta: i64) {
@@ -274,6 +1124,7 @@ pub fn increment_active_streams(delta: i64) {
         let peak = PEAK_ACTIVE_STREAMS.get();
         if current > peak {
             PEAK_ACTIVE_STREAMS.set(current);
+            persist_gauge_max(METRIC_PEAK_ACTIVE_STREAMS, &[], current);
         }
     } else {
         ACTIVE_STREAMS.sub((-delta) as f64);
@@ -283,17 +1134,25 @@ pub fn increment_active_streams(delta: i64) {
 /// Record that an SSE producer hit a full channel buffer (backpressure event).
 pub fn record_stream_backpressure() {
     STREAM_BACKPRESSURE.inc();
+    persist_counter_inc(METRIC_STREAM_BACKPRESSURE_TOTAL, &[], 1.0);
 }
 
 /// Record that a stream request was rejected due to concurrency limit.
 #[allow(dead_code)]
 pub fn record_rejected() {
     REJECTED_STREAMS.inc();
+    persist_counter_inc(METRIC_REJECTED_STREAMS_TOTAL, &[], 1.0);
 }
 
 /// Record a 429 rate limit response from a backend tier.
 pub fn record_rate_limit_hit(tier: &str) {
     RATE_LIMIT_HITS.with_label_values(&[tier]).inc();
+    persist_counter_inc(METRIC_RATE_LIMIT_HITS_TOTAL, &[("tier", tier)], 1.0);
+}
+
+/// Persist 429 backoff counter state managed by `ratelimit.rs`.
+pub fn record_rate_limit_backoff(tier: &str) {
+    persist_counter_inc(METRIC_RATE_LIMIT_BACKOFFS_TOTAL, &[("tier", tier)], 1.0);
 }
 
 /// Estimate token count for a JSON value by serializing it to a string and
@@ -328,6 +1187,11 @@ pub fn record_pre_request_tokens(
         PRE_REQUEST_TOKENS
             .with_label_values(&[tier, "messages"])
             .inc_by(msg_tokens as f64);
+        persist_counter_inc(
+            METRIC_PRE_REQUEST_TOKENS_TOTAL,
+            &[("tier", tier), ("component", "messages")],
+            msg_tokens as f64,
+        );
     }
     total += msg_tokens;
 
@@ -337,6 +1201,11 @@ pub fn record_pre_request_tokens(
         PRE_REQUEST_TOKENS
             .with_label_values(&[tier, "system"])
             .inc_by(sys_tokens as f64);
+        persist_counter_inc(
+            METRIC_PRE_REQUEST_TOKENS_TOTAL,
+            &[("tier", tier), ("component", "system")],
+            sys_tokens as f64,
+        );
     }
     total += sys_tokens;
 
@@ -348,12 +1217,18 @@ pub fn record_pre_request_tokens(
         PRE_REQUEST_TOKENS
             .with_label_values(&[tier, "tools"])
             .inc_by(tool_tokens as f64);
+        persist_counter_inc(
+            METRIC_PRE_REQUEST_TOKENS_TOTAL,
+            &[("tier", tier), ("component", "tools")],
+            tool_tokens as f64,
+        );
     }
     total += tool_tokens;
 
     PRE_REQUEST_TOKENS_HIST
         .with_label_values(&[tier])
         .observe(total as f64);
+    persist_histogram_observe(METRIC_PRE_REQUEST_TOKENS, &[("tier", tier)], total as f64);
 
     // Persist audit entry to the ring buffer for the /v1/token-audit endpoint.
     let entry = PreRequestAuditEntry {
@@ -370,8 +1245,10 @@ pub fn record_pre_request_tokens(
         if log.len() >= AUDIT_LOG_CAPACITY {
             log.pop_front();
         }
-        log.push_back(entry);
+        log.push_back(entry.clone());
     }
+
+    persist_token_audit(&entry);
 
     info!(
         tier = tier,
@@ -398,22 +1275,42 @@ pub fn record_usage(
             .with_label_values(&[tier])
             .inc_by(input_tokens as f64);
         TOTAL_INPUT_TOKENS.fetch_add(input_tokens, Ordering::Relaxed);
+        persist_counter_inc(
+            METRIC_INPUT_TOKENS_TOTAL,
+            &[("tier", tier)],
+            input_tokens as f64,
+        );
     }
     if output_tokens > 0 {
         OUTPUT_TOKENS_TOTAL
             .with_label_values(&[tier])
             .inc_by(output_tokens as f64);
         TOTAL_OUTPUT_TOKENS.fetch_add(output_tokens, Ordering::Relaxed);
+        persist_counter_inc(
+            METRIC_OUTPUT_TOKENS_TOTAL,
+            &[("tier", tier)],
+            output_tokens as f64,
+        );
     }
     if cache_read > 0 {
         CACHE_READ_TOKENS_TOTAL
             .with_label_values(&[tier])
             .inc_by(cache_read as f64);
+        persist_counter_inc(
+            METRIC_CACHE_READ_TOKENS_TOTAL,
+            &[("tier", tier)],
+            cache_read as f64,
+        );
     }
     if cache_creation > 0 {
         CACHE_CREATION_TOKENS_TOTAL
             .with_label_values(&[tier])
             .inc_by(cache_creation as f64);
+        persist_counter_inc(
+            METRIC_CACHE_CREATION_TOKENS_TOTAL,
+            &[("tier", tier)],
+            cache_creation as f64,
+        );
     }
 }
 
@@ -437,6 +1334,12 @@ pub fn verify_token_usage(tier: &str, local_estimate: u64, upstream_input: u64) 
         .with_label_values(&[tier])
         .set(drift_abs as f64);
     TOKEN_DRIFT_PCT.with_label_values(&[tier]).set(drift_pct);
+    persist_gauge_set(
+        METRIC_TOKEN_DRIFT_ABSOLUTE,
+        &[("tier", tier)],
+        drift_abs as f64,
+    );
+    persist_gauge_set(METRIC_TOKEN_DRIFT_PCT, &[("tier", tier)], drift_pct);
 
     // Classify severity and fire alert counters
     let abs_pct = drift_pct.abs();
@@ -444,6 +1347,11 @@ pub fn verify_token_usage(tier: &str, local_estimate: u64, upstream_input: u64) 
         TOKEN_DRIFT_ALERTS
             .with_label_values(&[tier, "critical"])
             .inc();
+        persist_counter_inc(
+            METRIC_TOKEN_DRIFT_ALERTS_TOTAL,
+            &[("tier", tier), ("severity", "critical")],
+            1.0,
+        );
         tracing::warn!(
             tier = tier,
             local = local_estimate,
@@ -456,6 +1364,11 @@ pub fn verify_token_usage(tier: &str, local_estimate: u64, upstream_input: u64) 
         TOKEN_DRIFT_ALERTS
             .with_label_values(&[tier, "warning"])
             .inc();
+        persist_counter_inc(
+            METRIC_TOKEN_DRIFT_ALERTS_TOTAL,
+            &[("tier", tier), ("severity", "warning")],
+            1.0,
+        );
         tracing::info!(
             tier = tier,
             local = local_estimate,
@@ -483,6 +1396,7 @@ pub fn verify_token_usage(tier: &str, local_estimate: u64, upstream_input: u64) 
     entry.last_drift_pct = drift_pct;
     entry.last_local = local_estimate;
     entry.last_upstream = upstream_input;
+    persist_token_drift_state(tier, entry);
 }
 
 /// Per-tier drift summary for the /v1/token-drift JSON endpoint.
@@ -686,7 +1600,8 @@ pub async fn usage_handler() -> impl IntoResponse {
         }
     }
 
-    // Collect avg durations
+    // Collect avg durations (live histogram + persisted offset histogram)
+    let mut duration_processed_tiers: HashSet<String> = HashSet::new();
     let dur_metrics: Vec<prometheus::proto::MetricFamily> = REQUEST_DURATION.collect();
     for mf in &dur_metrics {
         for m in mf.get_metric() {
@@ -695,12 +1610,34 @@ pub async fn usage_handler() -> impl IntoResponse {
                     let tier = label.get_value().to_string();
                     if let Some(entry) = tiers.get_mut(&tier) {
                         let h = m.get_histogram();
-                        let count = h.get_sample_count();
-                        if count > 0 {
-                            entry.avg_duration_seconds = h.get_sample_sum() / count as f64;
+                        let mut sample_sum = h.get_sample_sum();
+                        let mut count = h.get_sample_count();
+                        if let Some(offset) =
+                            get_hist_offset(METRIC_REQUEST_DURATION_SECONDS, &[("tier", &tier)])
+                        {
+                            sample_sum += offset.sample_sum;
+                            count += offset.sample_count;
                         }
+                        if count > 0 {
+                            entry.avg_duration_seconds = sample_sum / count as f64;
+                        }
+                        duration_processed_tiers.insert(tier);
                     }
                 }
+            }
+        }
+    }
+
+    // Fill duration averages for tiers that only exist in restored histogram offsets.
+    for entry in tiers.values_mut() {
+        if duration_processed_tiers.contains(&entry.tier) {
+            continue;
+        }
+        if let Some(offset) =
+            get_hist_offset(METRIC_REQUEST_DURATION_SECONDS, &[("tier", &entry.tier)])
+        {
+            if offset.sample_count > 0 {
+                entry.avg_duration_seconds = offset.sample_sum / offset.sample_count as f64;
             }
         }
     }
@@ -743,7 +1680,8 @@ pub async fn frontend_metrics_handler() -> impl IntoResponse {
         }
     }
 
-    // Collect latency info
+    // Collect latency info (live histogram + persisted offset histogram)
+    let mut frontend_latency_processed: HashSet<String> = HashSet::new();
     let lat_metrics = FRONTEND_REQUEST_LATENCY.collect();
     for mf in &lat_metrics {
         for m in mf.get_metric() {
@@ -752,12 +1690,35 @@ pub async fn frontend_metrics_handler() -> impl IntoResponse {
                     let frontend = label.get_value().to_string();
                     if let Some(entry) = frontend_metrics.get_mut(&frontend) {
                         let h = m.get_histogram();
-                        let count = h.get_sample_count();
-                        if count > 0 {
-                            entry.avg_latency_ms = (h.get_sample_sum() * 1000.0) / count as f64;
+                        let mut sample_sum = h.get_sample_sum();
+                        let mut count = h.get_sample_count();
+                        if let Some(offset) = get_hist_offset(
+                            METRIC_FRONTEND_REQUEST_DURATION_SECONDS,
+                            &[("frontend", &frontend)],
+                        ) {
+                            sample_sum += offset.sample_sum;
+                            count += offset.sample_count;
                         }
+                        if count > 0 {
+                            entry.avg_latency_ms = (sample_sum * 1000.0) / count as f64;
+                        }
+                        frontend_latency_processed.insert(frontend);
                     }
                 }
+            }
+        }
+    }
+
+    for entry in frontend_metrics.values_mut() {
+        if frontend_latency_processed.contains(&entry.frontend) {
+            continue;
+        }
+        if let Some(offset) = get_hist_offset(
+            METRIC_FRONTEND_REQUEST_DURATION_SECONDS,
+            &[("frontend", &entry.frontend)],
+        ) {
+            if offset.sample_count > 0 {
+                entry.avg_latency_ms = (offset.sample_sum * 1000.0) / offset.sample_count as f64;
             }
         }
     }
@@ -770,7 +1731,8 @@ pub async fn frontend_metrics_handler() -> impl IntoResponse {
 
 pub async fn metrics_handler() -> impl IntoResponse {
     let encoder = TextEncoder::new();
-    let metric_families = prometheus::gather();
+    let mut metric_families = prometheus::gather();
+    merge_histogram_offsets(&mut metric_families);
     let mut buffer = vec![];
     encoder.encode(&metric_families, &mut buffer).unwrap();
 

--- a/src/ratelimit.rs
+++ b/src/ratelimit.rs
@@ -111,3 +111,12 @@ impl RateLimitTracker {
         );
     }
 }
+
+/// Restore persisted backoff counters into Prometheus at startup.
+pub fn restore_rate_limit_backoff_counter(tier: &str, value: f64) {
+    if value > 0.0 {
+        RATE_LIMIT_BACKOFFS_TOTAL
+            .with_label_values(&[tier])
+            .inc_by(value);
+    }
+}

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -142,6 +142,15 @@ impl EwmaTracker {
             .collect()
     }
 
+    /// Restore a tier EWMA snapshot, used by persistence backends at startup.
+    pub fn restore_tier_state(&self, tier: &str, ewma: f64, samples: u64) {
+        let mut state = self.state.write();
+        let entry = state.entry(tier.to_string()).or_insert_with(TierState::new);
+        entry.ewma = ewma.max(0.0);
+        entry.samples = samples;
+        entry.consecutive_failures = 0;
+    }
+
     /// Reorder tiers by EWMA latency (lowest first). Tiers without enough
     /// samples keep their config-defined position.
     ///


### PR DESCRIPTION
## Summary
- add optional Redis-backed persistence for observability state so dashboard and metrics data survive CCR server restarts
- restore persisted state at startup for:
  - counters/gauges used by `/metrics`
  - histogram offsets (merged into `/metrics` and used by JSON averages)
  - `/v1/token-drift` aggregate state
  - `/v1/token-audit` ring buffer
  - EWMA tier latency state used by `/v1/latencies`
- add config surface:
  - `Persistence.mode` (`none` | `redis`)
  - `Persistence.redis_url` (or `CCR_REDIS_URL`)
  - `Persistence.redis_prefix`
- wire persistence init in server startup and rate-limit backoff persistence hooks
- document Redis setup and verification in README + observability + CLI docs

## Config Example
```json
"Persistence": {
  "mode": "redis",
  "redis_url": "redis://127.0.0.1:6379/0",
  "redis_prefix": "ccr-rust:persistence:v1"
}
```

## Validation
- `cargo check`
- `cargo test persistence_defaults_to_none -- --nocapture`
- `cargo test persistence_redis_parses -- --nocapture`
- `cargo test test_frontend_metrics_records_codex_requests -- --nocapture`

## Notes
- default behavior remains unchanged (`Persistence.mode = none`)
- CCR startup fails fast if `mode=redis` and Redis configuration/connection is invalid
