### PR TITLE
fix: don't block tiers on informational rate-limit headers from 200 responses

### DIFF
--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -234,6 +234,17 @@ pub struct Provider {
     /// for Kimi's coding agent identity check).
     #[serde(default)]
     pub extra_headers: Option<std::collections::HashMap<String, String>>,
+
+    /// When true (default), proactively skip this tier if upstream reports
+    /// `X-RateLimit-Remaining: 0` on a successful response.  Set to false
+    /// for providers like Z.AI that include rate-limit headers on every 200
+    /// as informational warnings without actually rejecting at quota zero.
+    #[serde(default = "default_honor_ratelimit_headers")]
+    pub honor_ratelimit_headers: bool,
+}
+
+fn default_honor_ratelimit_headers() -> bool {
+    true
 }
 
 impl Provider {

--- a/src/ratelimit.rs
+++ b/src/ratelimit.rs
@@ -32,12 +32,18 @@ impl RateLimitTracker {
         Self::default()
     }
 
-    pub fn should_skip_tier(&self, tier: &str) -> bool {
+    /// Check whether a tier should be skipped before dispatching.
+    ///
+    /// `honor_remaining` controls whether `X-RateLimit-Remaining: 0` from a
+    /// successful response causes proactive skipping.  Set to `false` for
+    /// providers that include rate-limit headers on every 200 as informational
+    /// warnings (e.g. Z.AI).
+    pub fn should_skip_tier(&self, tier: &str, honor_remaining: bool) -> bool {
         let tiers = self.tiers.read();
         if let Some(state) = tiers.get(tier) {
             let now = Instant::now();
 
-            // Check if we're in exponential backoff due to previous 429s
+            // Always skip when in exponential backoff from a real 429.
             if let Some(until) = state.backoff_until {
                 if now < until {
                     tracing::debug!(
@@ -49,21 +55,38 @@ impl RateLimitTracker {
                 }
             }
 
-            // Check if remaining quota is exhausted and we haven't reset yet
+            // Proactive skip when remaining quota is exhausted — only when
+            // the provider's headers are trusted (honor_ratelimit_headers).
             if let Some(0) = state.remaining {
                 if let Some(reset) = state.reset_at {
                     if now < reset {
+                        if honor_remaining {
+                            tracing::debug!(
+                                tier = %tier,
+                                reset_remaining_secs = %reset.saturating_duration_since(now).as_secs(),
+                                "Skipping tier: quota exhausted"
+                            );
+                            return true;
+                        }
                         tracing::debug!(
                             tier = %tier,
                             reset_remaining_secs = %reset.saturating_duration_since(now).as_secs(),
-                            "Skipping tier: quota exhausted"
+                            "Informational: quota appears exhausted (not blocking)"
                         );
-                        return true;
                     }
                 }
             }
         }
         false
+    }
+
+    /// Returns true if the tier is in exponential backoff from a real 429.
+    pub fn has_backoff(&self, tier: &str) -> bool {
+        let tiers = self.tiers.read();
+        tiers
+            .get(tier)
+            .and_then(|state| state.backoff_until)
+            .is_some_and(|until| Instant::now() < until)
     }
 
     pub fn record_429(&self, tier: &str, retry_after: Option<Duration>) {

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -160,7 +160,14 @@ pub async fn handle_messages(
 
     // Try each tier with retries
     for (tier, tier_name) in ordered.iter() {
-        if state.ratelimit_tracker.should_skip_tier(tier_name) {
+        let honor_remaining = config
+            .resolve_provider(tier)
+            .map(|p| p.honor_ratelimit_headers)
+            .unwrap_or(true);
+        if state
+            .ratelimit_tracker
+            .should_skip_tier(tier_name, honor_remaining)
+        {
             tracing::debug!(tier = %tier_name, "Skipping rate-limited tier");
             continue;
         }

--- a/tests/test_ratelimit_phantom.rs
+++ b/tests/test_ratelimit_phantom.rs
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! Tests for phantom rate-limiting when upstream returns 200 with rate-limit headers.
+//!
+//! Z.AI (and other Anthropic-compatible providers) include `x-ratelimit-remaining`
+//! and `x-ratelimit-reset` headers on every successful response as informational
+//! warnings.  When `honor_ratelimit_headers` is false for a provider, CCR-Rust
+//! must not treat these as blocking signals.
+
+use std::time::{Duration, Instant};
+
+use ccr_rust::ratelimit::RateLimitTracker;
+
+// ---------------------------------------------------------------------------
+// honor_ratelimit_headers = false  (Z.AI-style providers)
+// ---------------------------------------------------------------------------
+
+/// With honor_remaining=false, 200 responses with rate-limit headers should
+/// never trigger tier skipping, even when remaining reaches 0.
+#[test]
+fn test_200_with_ratelimit_headers_not_treated_as_429() {
+    let tracker = RateLimitTracker::new();
+    let tier = "zai-tier";
+
+    for remaining in (0..=9).rev() {
+        let reset_at = Some(Instant::now() + Duration::from_secs(60));
+        tracker.record_success(tier, Some(remaining), reset_at);
+
+        assert!(
+            !tracker.has_backoff(tier),
+            "Tier should not have exponential backoff after {} successful requests \
+             (remaining={})",
+            10 - remaining,
+            remaining,
+        );
+    }
+
+    assert!(
+        !tracker.should_skip_tier(tier, false),
+        "Tier must not be skipped (honor_remaining=false) after 10 successful \
+         200 responses, even when x-ratelimit-remaining reached 0"
+    );
+}
+
+/// Actual 429 should still trigger backoff regardless of honor_remaining.
+#[test]
+fn test_actual_429_triggers_backoff() {
+    let tracker = RateLimitTracker::new();
+    let tier = "zai-tier";
+
+    tracker.record_429(tier, Some(Duration::from_secs(5)));
+
+    assert!(
+        tracker.should_skip_tier(tier, false),
+        "Tier must be skipped after a real 429, even with honor_remaining=false"
+    );
+    assert!(
+        tracker.has_backoff(tier),
+        "Tier must have exponential backoff after a real 429"
+    );
+}
+
+/// record_success after a 429 should clear the backoff.
+#[test]
+fn test_success_clears_429_backoff() {
+    let tracker = RateLimitTracker::new();
+    let tier = "zai-tier";
+
+    tracker.record_429(tier, Some(Duration::from_secs(1)));
+    assert!(tracker.should_skip_tier(tier, false));
+
+    tracker.record_success(tier, Some(5), None);
+
+    assert!(
+        !tracker.should_skip_tier(tier, false),
+        "Tier must not be skipped after a successful request clears the 429 backoff"
+    );
+}
+
+/// Full lifecycle: 10 successes → 429 → backoff → success → clear.
+#[test]
+fn test_full_lifecycle_200_then_429_then_recovery() {
+    let tracker = RateLimitTracker::new();
+    let tier = "zai-tier";
+
+    // Phase 1: 10 requests return 200 with rate-limit headers → all succeed
+    for i in (0..=9).rev() {
+        let reset_at = Some(Instant::now() + Duration::from_secs(60));
+        tracker.record_success(tier, Some(i), reset_at);
+        assert!(
+            !tracker.should_skip_tier(tier, false),
+            "should_skip_tier(honor=false) must be false after success #{} (remaining={})",
+            10 - i,
+            i,
+        );
+    }
+
+    // Phase 2: 1 request returns actual 429 → backoff triggers
+    tracker.record_429(tier, Some(Duration::from_secs(2)));
+    assert!(
+        tracker.should_skip_tier(tier, false),
+        "Tier must be skipped after a real 429"
+    );
+
+    // Phase 3: Next request succeeds → backoff clears
+    tracker.record_success(tier, Some(10), None);
+    assert!(
+        !tracker.should_skip_tier(tier, false),
+        "Tier must not be skipped after recovery"
+    );
+    assert!(
+        !tracker.has_backoff(tier),
+        "Backoff must be cleared after recovery"
+    );
+}
+
+/// Remaining=0 with honor_remaining=false is informational — does NOT block.
+#[test]
+fn test_remaining_zero_informational_when_not_honored() {
+    let tracker = RateLimitTracker::new();
+    let tier = "zai-tier";
+
+    let reset_at = Some(Instant::now() + Duration::from_secs(60));
+    tracker.record_success(tier, Some(0), reset_at);
+
+    assert!(
+        !tracker.should_skip_tier(tier, false),
+        "remaining=0 must not block when honor_remaining=false"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// honor_ratelimit_headers = true  (default — providers with accurate headers)
+// ---------------------------------------------------------------------------
+
+/// With honor_remaining=true, remaining=0 SHOULD block the tier.
+#[test]
+fn test_remaining_zero_blocks_when_honored() {
+    let tracker = RateLimitTracker::new();
+    let tier = "anthropic-tier";
+
+    let reset_at = Some(Instant::now() + Duration::from_secs(60));
+    tracker.record_success(tier, Some(0), reset_at);
+
+    assert!(
+        tracker.should_skip_tier(tier, true),
+        "remaining=0 must block when honor_remaining=true (provider headers are trusted)"
+    );
+}
+
+/// With honor_remaining=true, remaining > 0 should NOT block.
+#[test]
+fn test_remaining_nonzero_does_not_block_when_honored() {
+    let tracker = RateLimitTracker::new();
+    let tier = "anthropic-tier";
+
+    let reset_at = Some(Instant::now() + Duration::from_secs(60));
+    tracker.record_success(tier, Some(5), reset_at);
+
+    assert!(
+        !tracker.should_skip_tier(tier, true),
+        "remaining=5 must not block even with honor_remaining=true"
+    );
+}


### PR DESCRIPTION
## Summary

- **Fix phantom rate-limiting** when providers (e.g. Z.AI) include `X-RateLimit-Remaining` / `X-RateLimit-Reset` headers on successful 200 responses as informational warnings.
- Previously, `should_skip_tier()` treated `remaining=0` from a 200 as a hard block, skipping the tier for the entire reset window (~60s). After ~5-6 successful requests, the remaining counter would reach 0 and all traffic would be blocked — despite no actual 429 from the provider.
- The fix adds a per-provider `honor_ratelimit_headers` config flag (**default: `true`**) so existing providers with accurate quota headers keep proactive skipping. Setting it to `false` (e.g. for Z.AI) makes `remaining=0` informational-only — tier skipping then relies solely on actual HTTP 429 responses via the existing exponential backoff path.

## Changes

| File | Change |
|------|--------|
| `src/config/types.rs` | Add `honor_ratelimit_headers: bool` to `Provider` (default `true`) |
| `src/ratelimit.rs` | `should_skip_tier()` accepts `honor_remaining` flag; add `has_backoff()` helper |
| `src/router/mod.rs` | Resolve provider config and pass `honor_ratelimit_headers` to `should_skip_tier` |
| `tests/test_ratelimit_phantom.rs` | 7 tests: both `honor=true` and `honor=false` paths, 429 lifecycle |

## Config example

```json
{
  "name": "zai",
  "api_base_url": "https://api.z.ai/api/anthropic/v1",
  "api_key": "${ZAI_API_KEY}",
  "protocol": "anthropic",
  "honor_ratelimit_headers": false,
  "models": ["glm-5.1"]
}
```

## Verification

- Confirmed the bug: `should_skip_tier(tier, true)` returns `true` after `record_success(tier, Some(0), ...)` — matching the old behavior
- With `honor_remaining=false`: `should_skip_tier` returns `false` after the same call — fix confirmed
- Full test suite (97 tests) passes with 0 regressions
- Live-tested against Z.AI: 20 consecutive requests, 0 failures, 0 rate-limit triggers

## Test plan

- [x] `cargo test --test test_ratelimit_phantom` — 7 tests (both honor=true and honor=false)
- [x] `cargo test` — full suite, all passed, 0 failed
- [x] `cargo clippy` — clean
- [x] Live test: 20 requests through CCR-Rust → Z.AI, all 200, no backoffs