### PR TITLE
feat!: pass through 429 responses instead of internal cascade (v1.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-04-09
+
+### Changed
+
+- **BREAKING: 429 pass-through instead of internal tier cascade** — When a provider returns
+  HTTP 429 (rate limited), ccr-rust now passes the response through to the client with
+  normalized error body (`type: "rate_limit_error"`, `code: "rate_limited"`) and upstream
+  headers intact, plus an `x-ccr-tier` header identifying which tier was rate-limited.
+  Previously, ccr-rust silently cascaded to the next tier internally. This change enables
+  external orchestrators (like AlphaHENG's AdaptiveRouter) to make informed routing decisions
+  with accurate rate-limit signal. OSS users relying on the internal cascade should implement
+  client-side retry logic or configure their proxy to retry on 429.
+
+- **`honor_ratelimit_headers` default changed to `true`** — Per-provider setting now defaults
+  to `true`, meaning ccr-rust proactively skips tiers that report `X-RateLimit-Remaining: 0`
+  on successful responses. Set to `false` for providers (like Z.AI) that send informational
+  rate-limit headers without actually enforcing them.
+
+- **All-tiers-exhausted response simplified to 503** — Since 429s are now passed through at
+  the dispatch layer, the "all tiers exhausted" path only fires for non-rate-limit failures
+  (5xx, timeouts) and consistently returns HTTP 503 with `server_error` type.
+
 ## [1.2.0] - 2026-04-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "ccr-rust"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccr-rust"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 authors = ["RESMP-DEV"]
 license = "AGPL-3.0-or-later"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Your Claude Code instance hits daily usage limits and you're blocked. CCR-Rust a
 
 ## Features
 
-- **Automatic failover** — tiered provider cascade on 429/5xx/timeouts
+- **Automatic failover** — tiered provider cascade on 5xx/timeouts; 429s pass through to client
 - **Multi-protocol** — Anthropic and OpenAI APIs behind one endpoint
 - **Cost routing** — send traffic classes (default/think/background) to different models
 - **Observability** — Prometheus metrics, live TUI dashboard, token/latency tracking
@@ -93,12 +93,13 @@ For common presets (Claude-only, multi-tier, cost-optimized), see [Presets](docs
 
 ### Rate Limiting
 
-Rate limiting is handled transparently:
+Rate limiting is handled with transparency for orchestrators and clients:
 
-- **429 responses** cascade to the next tier automatically. The client only sees an error if all tiers are exhausted.
-- **Informational headers** (`X-RateLimit-Remaining: 0` on 200 responses) are ignored by default. Most providers send these as warnings, not actual quota limits. To opt in per provider, set `"honor_ratelimit_headers": true`.
+- **429 responses are passed through** with a normalized error body (`type: "rate_limit_error"`, `code: "rate_limited"`) and an `x-ccr-tier` header identifying which provider was rate-limited. The rate limit is still tracked internally for future tier-skipping decisions.
+- **5xx/timeout errors** cascade to the next tier automatically. The client only sees an error if all tiers are exhausted.
+- **Informational headers** (`X-RateLimit-Remaining: 0` on 200 responses) trigger proactive tier-skipping by default. Set `"honor_ratelimit_headers": false` per provider for those (like Z.AI) that send these as informational warnings without actual enforcement.
 
-No special client configuration is needed — CCR exhausts all tiers before returning an error.
+This design works well with external orchestrators (e.g., AlphaHENG's AdaptiveRouter) that need accurate rate-limit signal for intelligent routing. Standalone users should implement client-side retry logic for 429s.
 
 ## Observability
 

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -235,15 +235,16 @@ pub struct Provider {
     #[serde(default)]
     pub extra_headers: Option<std::collections::HashMap<String, String>>,
 
-    /// When true, proactively skip this tier if upstream reports
-    /// `X-RateLimit-Remaining: 0` on a successful response.
-    ///
-    /// **Default: `false`** — most providers either don't send rate-limit
-    /// headers on 200 responses, or send them as informational warnings
-    /// that don't reflect actual quota enforcement.  Only set to `true`
-    /// for providers where you've verified the headers are accurate.
-    #[serde(default)]
+    /// When true (default), proactively skip this tier if upstream reports
+    /// `X-RateLimit-Remaining: 0` on a successful response.  Set to `false`
+    /// for providers like Z.AI that include rate-limit headers on every 200
+    /// as informational warnings without actually rejecting at quota zero.
+    #[serde(default = "default_honor_ratelimit_headers")]
     pub honor_ratelimit_headers: bool,
+}
+
+fn default_honor_ratelimit_headers() -> bool {
+    true
 }
 
 impl Provider {

--- a/src/router/dispatch.rs
+++ b/src/router/dispatch.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+use axum::body::Body;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use std::sync::Arc;
@@ -390,6 +391,7 @@ pub(super) async fn try_request_via_openai_protocol(
         let status = resp.status();
 
         if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            // Parse Retry-After header if present
             let retry_after = resp
                 .headers()
                 .get("retry-after")
@@ -397,11 +399,62 @@ pub(super) async fn try_request_via_openai_protocol(
                 .and_then(|s| s.parse::<u64>().ok())
                 .map(std::time::Duration::from_secs);
 
+            // Record the rate limit hit for tracking
             record_rate_limit_hit(tier_name);
             ratelimit_tracker.record_429(tier_name, retry_after);
             record_rate_limit_backoff(tier_name);
 
-            return Err(TryRequestError::RateLimited(retry_after));
+            // Pass through the 429 response as-is so the coordinator/client
+            // can make informed routing decisions instead of ccr-rust silently
+            // cascading internally.
+            let mut builder =
+                axum::response::Response::builder().status(reqwest_status_to_axum(status));
+
+            // Copy upstream headers
+            for (key, value) in resp.headers() {
+                if let Ok(name) = axum::http::HeaderName::from_bytes(key.as_str().as_bytes()) {
+                    if let Ok(val) = axum::http::HeaderValue::from_bytes(value.as_bytes()) {
+                        builder = builder.header(name, val);
+                    }
+                }
+            }
+
+            builder = builder.header("x-ccr-tier", tier_name);
+
+            let body_bytes = resp
+                .bytes()
+                .await
+                .map_err(|e| TryRequestError::Other(e.into()))?;
+
+            // Normalize error body to include required fields for downstream clients
+            let normalized_body = if let Ok(mut error_json) =
+                serde_json::from_slice::<serde_json::Value>(&body_bytes)
+            {
+                if let Some(error_obj) = error_json.get_mut("error").and_then(|e| e.as_object_mut())
+                {
+                    error_obj.insert(
+                        "type".to_string(),
+                        serde_json::Value::String("rate_limit_error".to_string()),
+                    );
+                    error_obj.insert(
+                        "code".to_string(),
+                        serde_json::Value::String("rate_limited".to_string()),
+                    );
+                    if let Some(retry_after_secs) = retry_after {
+                        error_obj.insert(
+                            "retry_after".to_string(),
+                            serde_json::json!(retry_after_secs.as_secs()),
+                        );
+                    }
+                }
+                serde_json::to_vec(&error_json).unwrap_or(body_bytes.to_vec())
+            } else {
+                body_bytes.to_vec()
+            };
+
+            return builder.body(Body::from(normalized_body)).map_err(|e| {
+                TryRequestError::Other(anyhow::anyhow!("Failed to build response: {}", e))
+            });
         }
 
         let body = resp
@@ -598,7 +651,7 @@ pub(super) async fn try_request_via_anthropic_protocol(
     if !resp.status().is_success() {
         let status = resp.status();
 
-        // For 429 rate limit, propagate as error to enable tier cascade
+        // For 429 rate limit, pass through to let coordinator/client handle routing
         if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
             let retry_after = resp
                 .headers()
@@ -611,7 +664,53 @@ pub(super) async fn try_request_via_anthropic_protocol(
             ratelimit_tracker.record_429(tier_name, retry_after);
             record_rate_limit_backoff(tier_name);
 
-            return Err(TryRequestError::RateLimited(retry_after));
+            // Pass through the 429 response as-is
+            let mut builder =
+                axum::response::Response::builder().status(reqwest_status_to_axum(status));
+
+            for (key, value) in resp.headers() {
+                if let Ok(name) = axum::http::HeaderName::from_bytes(key.as_str().as_bytes()) {
+                    if let Ok(val) = axum::http::HeaderValue::from_bytes(value.as_bytes()) {
+                        builder = builder.header(name, val);
+                    }
+                }
+            }
+
+            builder = builder.header("x-ccr-tier", tier_name);
+
+            let body_bytes = resp
+                .bytes()
+                .await
+                .map_err(|e| TryRequestError::Other(e.into()))?;
+
+            let normalized_body = if let Ok(mut error_json) =
+                serde_json::from_slice::<serde_json::Value>(&body_bytes)
+            {
+                if let Some(error_obj) = error_json.get_mut("error").and_then(|e| e.as_object_mut())
+                {
+                    error_obj.insert(
+                        "type".to_string(),
+                        serde_json::Value::String("rate_limit_error".to_string()),
+                    );
+                    error_obj.insert(
+                        "code".to_string(),
+                        serde_json::Value::String("rate_limited".to_string()),
+                    );
+                    if let Some(retry_after_secs) = retry_after {
+                        error_obj.insert(
+                            "retry_after".to_string(),
+                            serde_json::json!(retry_after_secs.as_secs()),
+                        );
+                    }
+                }
+                serde_json::to_vec(&error_json).unwrap_or(body_bytes.to_vec())
+            } else {
+                body_bytes.to_vec()
+            };
+
+            return builder.body(Body::from(normalized_body)).map_err(|e| {
+                TryRequestError::Other(anyhow::anyhow!("Failed to build response: {}", e))
+            });
         }
 
         let body = resp

--- a/src/router/dispatch.rs
+++ b/src/router/dispatch.rs
@@ -186,6 +186,81 @@ pub(super) fn insert_ccr_tier_header(response: &mut Response, tier_name: &str) {
     );
 }
 
+fn should_forward_429_header(name: &axum::http::HeaderName) -> bool {
+    !matches!(
+        name.as_str(),
+        // Hop-by-hop headers (RFC 7230 §6.1)
+        "connection"
+            | "keep-alive"
+            | "proxy-authenticate"
+            | "proxy-authorization"
+            | "te"
+            | "trailer"
+            | "transfer-encoding"
+            | "upgrade"
+            // Representation headers that become stale when body is normalized
+            | "content-length"
+            | "content-encoding"
+            // Always set by CCR to prevent upstream spoofing/duplication
+            | "x-ccr-tier"
+    )
+}
+
+fn normalize_429_error_body(
+    body_bytes: &[u8],
+    retry_after: Option<std::time::Duration>,
+) -> Vec<u8> {
+    if let Ok(mut error_json) = serde_json::from_slice::<serde_json::Value>(body_bytes) {
+        if let Some(error_obj) = error_json.get_mut("error").and_then(|e| e.as_object_mut()) {
+            error_obj.insert(
+                "type".to_string(),
+                serde_json::Value::String("rate_limit_error".to_string()),
+            );
+            error_obj.insert(
+                "code".to_string(),
+                serde_json::Value::String("rate_limited".to_string()),
+            );
+            if let Some(retry_after_secs) = retry_after {
+                error_obj.insert(
+                    "retry_after".to_string(),
+                    serde_json::json!(retry_after_secs.as_secs()),
+                );
+            }
+        }
+        serde_json::to_vec(&error_json).unwrap_or_else(|_| body_bytes.to_vec())
+    } else {
+        body_bytes.to_vec()
+    }
+}
+
+fn build_429_passthrough_response(
+    status: reqwest::StatusCode,
+    upstream_headers: &reqwest::header::HeaderMap,
+    body_bytes: Vec<u8>,
+    tier_name: &str,
+    retry_after: Option<std::time::Duration>,
+) -> Result<Response, TryRequestError> {
+    let mut builder = axum::response::Response::builder().status(reqwest_status_to_axum(status));
+
+    for (key, value) in upstream_headers {
+        if let Ok(name) = axum::http::HeaderName::from_bytes(key.as_str().as_bytes()) {
+            if !should_forward_429_header(&name) {
+                continue;
+            }
+            if let Ok(val) = axum::http::HeaderValue::from_bytes(value.as_bytes()) {
+                builder = builder.header(name, val);
+            }
+        }
+    }
+
+    builder = builder.header("x-ccr-tier", tier_name);
+
+    let normalized_body = normalize_429_error_body(&body_bytes, retry_after);
+    builder
+        .body(Body::from(normalized_body))
+        .map_err(|e| TryRequestError::Other(anyhow::anyhow!("Failed to build response: {}", e)))
+}
+
 pub(super) fn build_openai_headers(
     provider: &crate::config::Provider,
 ) -> Result<reqwest::header::HeaderMap, TryRequestError> {
@@ -404,57 +479,21 @@ pub(super) async fn try_request_via_openai_protocol(
             ratelimit_tracker.record_429(tier_name, retry_after);
             record_rate_limit_backoff(tier_name);
 
-            // Pass through the 429 response as-is so the coordinator/client
-            // can make informed routing decisions instead of ccr-rust silently
-            // cascading internally.
-            let mut builder =
-                axum::response::Response::builder().status(reqwest_status_to_axum(status));
-
-            // Copy upstream headers
-            for (key, value) in resp.headers() {
-                if let Ok(name) = axum::http::HeaderName::from_bytes(key.as_str().as_bytes()) {
-                    if let Ok(val) = axum::http::HeaderValue::from_bytes(value.as_bytes()) {
-                        builder = builder.header(name, val);
-                    }
-                }
-            }
-
-            builder = builder.header("x-ccr-tier", tier_name);
-
+            // Preserve headers/body contract while returning 429 directly.
+            let upstream_headers = resp.headers().clone();
             let body_bytes = resp
                 .bytes()
                 .await
-                .map_err(|e| TryRequestError::Other(e.into()))?;
+                .map_err(|e| TryRequestError::Other(e.into()))?
+                .to_vec();
 
-            // Normalize error body to include required fields for downstream clients
-            let normalized_body = if let Ok(mut error_json) =
-                serde_json::from_slice::<serde_json::Value>(&body_bytes)
-            {
-                if let Some(error_obj) = error_json.get_mut("error").and_then(|e| e.as_object_mut())
-                {
-                    error_obj.insert(
-                        "type".to_string(),
-                        serde_json::Value::String("rate_limit_error".to_string()),
-                    );
-                    error_obj.insert(
-                        "code".to_string(),
-                        serde_json::Value::String("rate_limited".to_string()),
-                    );
-                    if let Some(retry_after_secs) = retry_after {
-                        error_obj.insert(
-                            "retry_after".to_string(),
-                            serde_json::json!(retry_after_secs.as_secs()),
-                        );
-                    }
-                }
-                serde_json::to_vec(&error_json).unwrap_or(body_bytes.to_vec())
-            } else {
-                body_bytes.to_vec()
-            };
-
-            return builder.body(Body::from(normalized_body)).map_err(|e| {
-                TryRequestError::Other(anyhow::anyhow!("Failed to build response: {}", e))
-            });
+            return build_429_passthrough_response(
+                status,
+                &upstream_headers,
+                body_bytes,
+                tier_name,
+                retry_after,
+            );
         }
 
         let body = resp
@@ -573,6 +612,7 @@ pub(super) async fn try_request_via_anthropic_protocol(
 
     let url = provider_anthropic_messages_url(provider);
     let headers = build_anthropic_headers(provider)?;
+
     trace!(tier = tier_name, model = model_name, url = %url, "dispatching Anthropic-compatible upstream request");
 
     let request: AnthropicRequest = serde_json::from_value(transformed_request.clone())
@@ -664,53 +704,20 @@ pub(super) async fn try_request_via_anthropic_protocol(
             ratelimit_tracker.record_429(tier_name, retry_after);
             record_rate_limit_backoff(tier_name);
 
-            // Pass through the 429 response as-is
-            let mut builder =
-                axum::response::Response::builder().status(reqwest_status_to_axum(status));
-
-            for (key, value) in resp.headers() {
-                if let Ok(name) = axum::http::HeaderName::from_bytes(key.as_str().as_bytes()) {
-                    if let Ok(val) = axum::http::HeaderValue::from_bytes(value.as_bytes()) {
-                        builder = builder.header(name, val);
-                    }
-                }
-            }
-
-            builder = builder.header("x-ccr-tier", tier_name);
-
+            let upstream_headers = resp.headers().clone();
             let body_bytes = resp
                 .bytes()
                 .await
-                .map_err(|e| TryRequestError::Other(e.into()))?;
+                .map_err(|e| TryRequestError::Other(e.into()))?
+                .to_vec();
 
-            let normalized_body = if let Ok(mut error_json) =
-                serde_json::from_slice::<serde_json::Value>(&body_bytes)
-            {
-                if let Some(error_obj) = error_json.get_mut("error").and_then(|e| e.as_object_mut())
-                {
-                    error_obj.insert(
-                        "type".to_string(),
-                        serde_json::Value::String("rate_limit_error".to_string()),
-                    );
-                    error_obj.insert(
-                        "code".to_string(),
-                        serde_json::Value::String("rate_limited".to_string()),
-                    );
-                    if let Some(retry_after_secs) = retry_after {
-                        error_obj.insert(
-                            "retry_after".to_string(),
-                            serde_json::json!(retry_after_secs.as_secs()),
-                        );
-                    }
-                }
-                serde_json::to_vec(&error_json).unwrap_or(body_bytes.to_vec())
-            } else {
-                body_bytes.to_vec()
-            };
-
-            return builder.body(Body::from(normalized_body)).map_err(|e| {
-                TryRequestError::Other(anyhow::anyhow!("Failed to build response: {}", e))
-            });
+            return build_429_passthrough_response(
+                status,
+                &upstream_headers,
+                body_bytes,
+                tier_name,
+                retry_after,
+            );
         }
 
         let body = resp

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -211,6 +211,19 @@ pub async fn handle_messages(
             .await
             {
                 Ok(response) => {
+                    if response.status() == StatusCode::TOO_MANY_REQUESTS {
+                        // 429 passthrough is an intentional non-cascading return path,
+                        // but it must be tracked as a failed attempt for EWMA scoring.
+                        timer.finish_failure();
+                        let total_duration = start.elapsed().as_secs_f64();
+                        sync_ewma_gauge(&state.ewma_tracker);
+                        info!(
+                            "Rate-limit passthrough on {} after {:.2}s",
+                            tier_name, total_duration
+                        );
+                        return response;
+                    }
+
                     let attempt_duration = timer.finish_success();
                     let total_duration = start.elapsed().as_secs_f64();
                     record_request_with_frontend(tier_name, frontend);

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -159,12 +159,11 @@ pub async fn handle_messages(
     let tool_values: Option<Vec<serde_json::Value>> = request.tools.clone();
 
     // Try each tier with retries
-    let mut any_rate_limited = false;
     for (tier, tier_name) in ordered.iter() {
         let honor_remaining = config
             .resolve_provider(tier)
             .map(|p| p.honor_ratelimit_headers)
-            .unwrap_or(false);
+            .unwrap_or(true);
         if state
             .ratelimit_tracker
             .should_skip_tier(tier_name, honor_remaining)
@@ -231,9 +230,10 @@ pub async fn handle_messages(
                     return response;
                 }
                 Err(TryRequestError::RateLimited(retry_after)) => {
+                    // Note: With 429 pass-through in dispatch, this arm fires
+                    // only for edge cases where dispatch still returns RateLimited.
                     timer.finish_failure();
                     sync_ewma_gauge(&state.ewma_tracker);
-                    any_rate_limited = true;
                     warn!(
                         "Rate limited on {} attempt {} (retry-after: {:?})",
                         tier_name,
@@ -242,7 +242,6 @@ pub async fn handle_messages(
                     );
                     record_failure(tier_name, "rate_limited");
                     record_rate_limit_hit(tier_name);
-                    // Record 429 for backoff tracking
                     state.ratelimit_tracker.record_429(tier_name, retry_after);
                     record_rate_limit_backoff(tier_name);
                     // Skip remaining retries for this tier - move to next
@@ -274,43 +273,26 @@ pub async fn handle_messages(
         }
     }
 
-    // All tiers exhausted
+    // All tiers exhausted — 429s are passed through at the dispatch layer,
+    // so reaching this point means only non-rate-limit failures (5xx, timeouts).
     let total_attempts: usize = ordered
         .iter()
         .map(|(_, tier_name)| config.get_tier_retry(tier_name).max_retries + 1)
         .sum();
     error!("All tiers exhausted after {} tier(s)", ordered.len());
 
-    if any_rate_limited {
-        // At least one tier was rate-limited: return 429 so downstream
-        // clients (OpenCode, Codex CLI) use their standard retry logic.
-        let error_resp = serde_json::json!({
-            "error": {
-                "type": "rate_limit_error",
-                "message": format!(
-                    "All {} backend tier(s) exhausted after {} total attempt(s)",
-                    ordered.len(),
-                    total_attempts
-                ),
-                "code": "rate_limited"
-            }
-        });
-        (StatusCode::TOO_MANY_REQUESTS, Json(error_resp)).into_response()
-    } else {
-        // Pure backend failures (5xx, timeouts) — return 503.
-        let error_resp = serde_json::json!({
-            "error": {
-                "type": "server_error",
-                "message": format!(
-                    "All {} backend tier(s) failed after {} total attempt(s)",
-                    ordered.len(),
-                    total_attempts
-                ),
-                "code": "service_unavailable"
-            }
-        });
-        (StatusCode::SERVICE_UNAVAILABLE, Json(error_resp)).into_response()
-    }
+    let error_resp = serde_json::json!({
+        "error": {
+            "type": "server_error",
+            "message": format!(
+                "All {} backend tier(s) failed after {} total attempt(s)",
+                ordered.len(),
+                total_attempts
+            ),
+            "code": "service_unavailable"
+        }
+    });
+    (StatusCode::SERVICE_UNAVAILABLE, Json(error_resp)).into_response()
 }
 
 // ============================================================================

--- a/tests/test_routing.rs
+++ b/tests/test_routing.rs
@@ -541,6 +541,18 @@ async fn upstream_429_returns_structured_rate_limit_payload() {
         .unwrap();
 
     assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+    assert_eq!(
+        resp.headers()
+            .get("retry-after")
+            .and_then(|v| v.to_str().ok()),
+        Some("17")
+    );
+    assert_eq!(
+        resp.headers()
+            .get("x-ccr-tier")
+            .and_then(|v| v.to_str().ok()),
+        Some("mock")
+    );
 
     let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
         .await


### PR DESCRIPTION
## Summary

**BREAKING:** 429 rate-limit responses are now passed through to the client instead of silently cascading to the next tier internally. This gives external orchestrators (AlphaHENG's AdaptiveRouter, client retry logic) accurate rate-limit signal for intelligent routing decisions.

Reconciles PR #7 branch (`pr7/fix-phantom-ratelimit`) with main by applying the 429 pass-through behavioral change on top of main's features (throughput/TTFT metrics, dashboard env vars).

## Changes

### Behavioral (BREAKING)
- **429 pass-through**: When a provider returns 429, ccr-rust now records the rate limit, copies upstream headers, normalizes the error body (`type: "rate_limit_error"`, `code: "rate_limited"`), adds `x-ccr-tier` header, and returns it to the client. Previously, it cascaded to the next internal tier.
- **`honor_ratelimit_headers` default: `false` → `true`**: Proactive tier-skipping on `X-RateLimit-Remaining: 0` is now opt-out per provider. Set `"honor_ratelimit_headers": false` for providers like Z.AI that send informational rate-limit headers.
- **All-tiers-exhausted always returns 503**: Since 429s are handled at dispatch, the "all tiers exhausted" path only fires for 5xx/timeout failures.

### Kept from main
- Throughput/TTFT metrics (`/v1/throughput` endpoint, `record_ttft`, `record_throughput`)
- Dashboard env vars (`CCR_DASHBOARD_HOST`, `CCR_DASHBOARD_PORT`)
- Full observability stack

### Why this is better for the coordinator
- AlphaHENG's Thompson Sampling router gets real 429 signal → accurate Beta posterior updates
- Circuit breaker operates on actual rate-limit data, not masked/hidden retries
- No double-cascade confusion (ccr-rust internal + coordinator external)
- 5xx/timeouts still cascade within ccr-rust — only 429 behavior changed

### For OSS users
- 429 goes directly to your client — implement retry logic or use a retry-capable proxy
- `honor_ratelimit_headers: true` by default means ccr-rust proactively skips rate-limited tiers on subsequent requests
- 5xx/timeout cascade behavior unchanged

## Verification
- `cargo check` ✅
- `cargo clippy` ✅  
- `cargo test` — 32 passed, 0 failed ✅
- CHANGELOG.md updated
- README rate-limiting section updated
- AGENTS.md fallback_behavior section updated