### PR TITLE
fix: streaming response fixes — error detection and tool call translation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,24 +109,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "approx"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-dependencies = [
- "derive_arbitrary",
-]
-
-[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,12 +292,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,15 +459,6 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "cobyla"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0f7c6a211aa5d5cfea17c00942b6be60d759b1f014fdb3d6cf010997d40749"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "colorchoice"
@@ -711,17 +678,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
-name = "derive_arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,49 +751,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "egobox-doe"
-version = "0.35.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9ddce3a7359210f081222e953c3b9bb5ae5c9a0dbd1827fa9cd158370e6584"
-dependencies = [
- "linfa",
- "ndarray",
- "ndarray-rand",
- "ndarray-stats",
- "num-traits",
- "rand_xoshiro",
- "rayon",
-]
-
-[[package]]
-name = "egobox-gp"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b43b656b7aa1e3da5f373e68e77d4efb141791a1c0d46180d7ce7638538efa"
-dependencies = [
- "anyhow",
- "cobyla",
- "egobox-doe",
- "finitediff",
- "linfa",
- "linfa-linalg",
- "linfa-pls",
- "log",
- "ndarray",
- "ndarray-einsum",
- "ndarray-npy",
- "ndarray-rand",
- "ndarray-stats",
- "num-traits",
- "paste",
- "rand_xoshiro",
- "rayon",
- "serde",
- "thiserror 2.0.18",
- "typetag",
-]
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -891,17 +804,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "erased-serde"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
-dependencies = [
- "serde",
- "serde_core",
- "typeid",
-]
-
-[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -944,17 +846,6 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "finitediff"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb08005ceda20e36d233b60fe476059cc9efe6ebd125f3a72b69729dbae0e794"
-dependencies = [
- "anyhow",
- "ndarray",
- "num",
-]
 
 [[package]]
 name = "flate2"
@@ -1160,16 +1051,6 @@ dependencies = [
 [[package]]
 name = "gp-routing"
 version = "0.1.0"
-dependencies = [
- "egobox-gp",
- "linfa",
- "ndarray",
- "parking_lot",
- "rand",
- "serde",
- "serde_json",
- "tracing",
-]
 
 [[package]]
 name = "h2"
@@ -1571,15 +1452,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inventory"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1626,15 +1498,6 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1735,60 +1598,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
 name = "libredox"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "linfa"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87b84e47ca7a9d63f5be24c104e216c8263bfada38080cbdfe1082e611a81fd3"
-dependencies = [
- "approx",
- "ndarray",
- "num-traits",
- "rand",
- "serde",
- "sprs",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "linfa-linalg"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a834c0ec063937688a0d13573aa515ab8c425bd8de3154b908dd3b9c197dc4"
-dependencies = [
- "ndarray",
- "num-traits",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "linfa-pls"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "962eef849bea0fa6fd7ba512159c41f890d42ad780ca59ba2f59bc0d7d98fe96"
-dependencies = [
- "linfa",
- "linfa-linalg",
- "ndarray",
- "ndarray-rand",
- "ndarray-stats",
- "num-traits",
- "paste",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1847,16 +1662,6 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
-name = "matrixmultiply"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
-dependencies = [
- "autocfg",
- "rawpointer",
-]
 
 [[package]]
 name = "memchr"
@@ -1919,86 +1724,6 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "ndarray"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
-dependencies = [
- "approx",
- "matrixmultiply",
- "num-complex",
- "num-integer",
- "num-traits",
- "portable-atomic",
- "portable-atomic-util",
- "rawpointer",
- "rayon",
- "serde",
-]
-
-[[package]]
-name = "ndarray-einsum"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4b2d52dfff9b24d072b6080eab1587cbd54ae24da7b8370072c3a84db221e05"
-dependencies = [
- "hashbrown 0.15.5",
- "lazy_static",
- "ndarray",
- "num-traits",
- "regex",
-]
-
-[[package]]
-name = "ndarray-npy"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b313788c468c49141a9d9b6131fc15f403e6ef4e8446a0b2e18f664ddb278a9"
-dependencies = [
- "byteorder",
- "ndarray",
- "num-complex",
- "num-traits",
- "py_literal",
- "zip",
-]
-
-[[package]]
-name = "ndarray-rand"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f093b3db6fd194718dcdeea6bd8c829417deae904e3fcc7732dabcd4416d25d8"
-dependencies = [
- "ndarray",
- "rand",
- "rand_distr",
-]
-
-[[package]]
-name = "ndarray-stats"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ebbe97acce52d06aebed4cd4a87c0941f4b2519b59b82b4feb5bd0ce003dfd"
-dependencies = [
- "indexmap",
- "itertools 0.13.0",
- "ndarray",
- "noisy_float",
- "num-integer",
- "num-traits",
- "rand",
-]
-
-[[package]]
-name = "noisy_float"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c16843be85dd410c6a12251c4eca0dd1d3ee8c5725f746c4d5e0fdcec0a864b2"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -2087,7 +1812,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -2208,49 +1932,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "pest"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
-dependencies = [
- "memchr",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
-dependencies = [
- "pest",
- "sha2",
-]
 
 [[package]]
 name = "pin-project"
@@ -2400,19 +2081,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "py_literal"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "102df7a3d46db9d3891f178dcc826dc270a6746277a9ae6436f8d29fd490a8e1"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-traits",
- "pest",
- "pest_derive",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2464,26 +2132,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_distr"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
-dependencies = [
- "num-traits",
- "rand",
-]
-
-[[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
-dependencies = [
- "rand_core",
- "serde",
-]
-
-[[package]]
 name = "ratatui"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2502,12 +2150,6 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width",
 ]
-
-[[package]]
-name = "rawpointer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
@@ -2995,18 +2637,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sprs"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704ef26d974e8a452313ed629828cd9d4e4fa34667ca1ad9d6b1fffa43c6e166"
-dependencies = [
- "ndarray",
- "num-complex",
- "num-traits",
- "smallvec",
-]
-
-[[package]]
 name = "stability"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3425,46 +3055,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "typeid"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
-
-[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
-
-[[package]]
-name = "typetag"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2212c8a9b9bcfca32024de14998494cf9a5dfa59ea1b829de98bac374b86bf"
-dependencies = [
- "erased-serde",
- "inventory",
- "once_cell",
- "serde",
- "typetag-impl",
-]
-
-[[package]]
-name = "typetag-impl"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27a7a9b72ba121f6f1f6c3632b85604cac41aedb5ddc70accbebb6cac83de846"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"
@@ -4188,39 +3782,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "zip"
-version = "2.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
-dependencies = [
- "arbitrary",
- "crc32fast",
- "crossbeam-utils",
- "displaydoc",
- "flate2",
- "indexmap",
- "memchr",
- "thiserror 2.0.18",
- "zopfli",
-]
-
-[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[package]]
-name = "zopfli"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
-dependencies = [
- "bumpalo",
- "crc32fast",
- "log",
- "simd-adler32",
-]
 
 [[package]]
 name = "zstd"

--- a/src/router/dispatch.rs
+++ b/src/router/dispatch.rs
@@ -53,8 +53,20 @@ async fn check_stream_for_embedded_error(
 
     let text = String::from_utf8_lossy(&first_chunk);
     let trimmed = text.trim();
-    if trimmed.starts_with('{') {
-        if let Ok(json) = serde_json::from_str::<serde_json::Value>(trimmed) {
+
+    // Extract JSON to check — either raw JSON or inside an SSE `data:` line.
+    let json_candidate = if trimmed.starts_with('{') {
+        Some(trimmed.to_string())
+    } else {
+        trimmed
+            .lines()
+            .find_map(|line| line.strip_prefix("data: "))
+            .filter(|d| d.starts_with('{'))
+            .map(|d| d.to_string())
+    };
+
+    if let Some(ref candidate) = json_candidate {
+        if let Ok(json) = serde_json::from_str::<serde_json::Value>(candidate) {
             if json.get("error").is_some() {
                 let msg = json["error"]["message"]
                     .as_str()

--- a/src/router/dispatch.rs
+++ b/src/router/dispatch.rs
@@ -4,7 +4,9 @@ use axum::response::{IntoResponse, Response};
 use std::sync::Arc;
 use tracing::{trace, warn};
 
-use super::streaming::{stream_anthropic_response_with_tracking, stream_response_translated};
+use super::streaming::{
+    stream_anthropic_response_with_tracking, stream_response_translated, BoxByteStream,
+};
 use super::translate_request::translate_request_anthropic_to_openai;
 use super::translate_response::{build_transformer_chain, translate_response_openai_to_anthropic};
 use super::types::*;
@@ -17,6 +19,91 @@ use crate::ratelimit::RateLimitTracker;
 use crate::sse::StreamVerifyCtx;
 use crate::transform::openai_to_anthropic::OpenAiToAnthropicTransformer;
 use crate::transformer::{Transformer, TransformerChain, TransformerRegistry};
+use futures::StreamExt;
+
+/// Peek at the first chunk of a streaming response to detect error payloads
+/// wrapped in HTTP 200 (e.g. Z.AI returns quota errors as raw JSON in a
+/// `text/event-stream` body).  Returns `Err` if an error is found, or a
+/// `BoxByteStream` with the peeked bytes prepended for normal processing.
+///
+/// Uses a short timeout so that legitimate slow-start streams are not
+/// penalised — error responses arrive near-instantly whereas real model
+/// inference may take seconds for the first token.
+async fn check_stream_for_embedded_error(
+    mut resp: reqwest::Response,
+    tier_name: &str,
+) -> Result<BoxByteStream, TryRequestError> {
+    // Error responses arrive in < 100ms; real TTFT can be seconds.
+    // If we don't get a chunk quickly, assume it's a valid stream and
+    // return it without blocking SSE headers any further.
+    let first_chunk = match tokio::time::timeout(
+        std::time::Duration::from_millis(200),
+        resp.chunk(),
+    )
+    .await
+    {
+        Ok(Ok(Some(bytes))) => bytes,
+        Ok(Ok(None)) => return Ok(Box::pin(futures::stream::empty())),
+        Ok(Err(e)) => return Err(TryRequestError::Other(e.into())),
+        Err(_timeout) => {
+            trace!(tier = tier_name, "Stream first-chunk timeout, skipping error peek");
+            return Ok(Box::pin(resp.bytes_stream()));
+        }
+    };
+
+    let text = String::from_utf8_lossy(&first_chunk);
+    let trimmed = text.trim();
+    if trimmed.starts_with('{') {
+        if let Ok(json) = serde_json::from_str::<serde_json::Value>(trimmed) {
+            if json.get("error").is_some() {
+                let msg = json["error"]["message"]
+                    .as_str()
+                    .unwrap_or("Unknown error in stream body");
+                let code = json["error"]["code"].as_str().unwrap_or("unknown");
+                warn!(
+                    tier = tier_name,
+                    error_code = code,
+                    "Provider returned error in 200 stream body: {}",
+                    msg
+                );
+                return Err(TryRequestError::Other(anyhow::anyhow!(
+                    "Provider error in 200 stream (code {}): {}",
+                    code,
+                    msg
+                )));
+            }
+        }
+    }
+
+    // Chain the peeked bytes back onto the remaining body.
+    let rest = resp.bytes_stream();
+    let first = futures::stream::once(async move { Ok(first_chunk) });
+    Ok(Box::pin(first.chain(rest)))
+}
+
+/// Check a non-streaming response body for an embedded error in a 200.
+fn check_body_for_embedded_error(body: &[u8], tier_name: &str) -> Result<(), TryRequestError> {
+    if let Ok(json) = serde_json::from_slice::<serde_json::Value>(body) {
+        if json.get("error").is_some() && json.get("content").is_none() {
+            let msg = json["error"]["message"]
+                .as_str()
+                .unwrap_or("Unknown error in response body");
+            let code = json["error"]["code"].as_str().unwrap_or("unknown");
+            warn!(
+                tier = tier_name,
+                error_code = code,
+                "Provider returned error in 200 body: {}",
+                msg
+            );
+            return Err(TryRequestError::Other(anyhow::anyhow!(
+                "Provider error in 200 body (code {}): {}",
+                code,
+                msg
+            )));
+        }
+    }
+    Ok(())
+}
 
 /// Extract rate limit information from upstream response headers.
 pub(super) fn extract_rate_limit_headers(
@@ -421,6 +508,10 @@ pub(super) async fn try_request_via_openai_protocol(
     if stream_flag {
         // For streaming, we need to translate OpenAI SSE events to Anthropic SSE.
         let rate_limit_info = extract_rate_limit_headers(&resp);
+
+        // Peek at first chunk to detect errors embedded in 200 streams.
+        let byte_stream = check_stream_for_embedded_error(resp, tier_name).await?;
+
         let ctx = StreamVerifyCtx {
             tier_name: tier_name.to_string(),
             local_estimate,
@@ -430,7 +521,7 @@ pub(super) async fn try_request_via_openai_protocol(
         };
         Ok(
             stream_response_translated(
-                resp,
+                byte_stream,
                 config.sse_buffer_size(),
                 Some(ctx),
                 model_name,
@@ -441,7 +532,6 @@ pub(super) async fn try_request_via_openai_protocol(
     } else {
         // Extract rate limit headers for non-streaming.
         let rate_limit_info = extract_rate_limit_headers(&resp);
-        ratelimit_tracker.record_success(tier_name, rate_limit_info.0, rate_limit_info.1);
 
         // For non-streaming, translate the full response.
         let resp_status = resp.status().as_u16();
@@ -449,6 +539,13 @@ pub(super) async fn try_request_via_openai_protocol(
             .bytes()
             .await
             .map_err(|e| TryRequestError::Other(e.into()))?;
+
+        // Check for embedded error in 200 body BEFORE recording success,
+        // otherwise a failed request corrupts tier rate-limit state.
+        check_body_for_embedded_error(&body, tier_name)?;
+
+        ratelimit_tracker.record_success(tier_name, rate_limit_info.0, rate_limit_info.1);
+
         let body_str = String::from_utf8_lossy(&body);
 
         // Record capture for non-streaming response
@@ -631,6 +728,10 @@ pub(super) async fn try_request_via_anthropic_protocol(
     if request.stream.unwrap_or(false) {
         // Use streaming token tracking for Anthropic protocol
         let rate_limit_info = extract_rate_limit_headers(&resp);
+
+        // Peek at first chunk to detect errors embedded in 200 streams.
+        let byte_stream = check_stream_for_embedded_error(resp, tier_name).await?;
+
         let ctx = StreamVerifyCtx {
             tier_name: tier_name.to_string(),
             local_estimate,
@@ -640,13 +741,12 @@ pub(super) async fn try_request_via_anthropic_protocol(
         };
 
         let mut response =
-            stream_anthropic_response_with_tracking(resp, config.sse_buffer_size(), ctx, chain)
+            stream_anthropic_response_with_tracking(byte_stream, config.sse_buffer_size(), ctx, chain)
                 .await;
         insert_ccr_tier_header(&mut response, tier_name);
         Ok(response)
     } else {
         let rate_limit_info = extract_rate_limit_headers(&resp);
-        ratelimit_tracker.record_success(tier_name, rate_limit_info.0, rate_limit_info.1);
 
         let resp_status = resp.status().as_u16();
         let status = reqwest_status_to_axum(resp.status());
@@ -654,6 +754,12 @@ pub(super) async fn try_request_via_anthropic_protocol(
             .bytes()
             .await
             .map_err(|e| TryRequestError::Other(e.into()))?;
+
+        // Check for embedded error before recording success.
+        check_body_for_embedded_error(&body, tier_name)?;
+
+        ratelimit_tracker.record_success(tier_name, rate_limit_info.0, rate_limit_info.1);
+
         let body_str = String::from_utf8_lossy(&body);
 
         // Record capture for non-streaming Anthropic response

--- a/src/router/dispatch.rs
+++ b/src/router/dispatch.rs
@@ -29,32 +29,51 @@ use futures::StreamExt;
 /// Uses a short timeout so that legitimate slow-start streams are not
 /// penalised — error responses arrive near-instantly whereas real model
 /// inference may take seconds for the first token.
+///
+/// Accumulates bytes in a loop (within the timeout window) to handle TCP
+/// fragmentation — a single `resp.chunk()` may not contain a complete SSE
+/// frame or JSON object.
 async fn check_stream_for_embedded_error(
     mut resp: reqwest::Response,
     tier_name: &str,
 ) -> Result<BoxByteStream, TryRequestError> {
-    // Error responses arrive in < 100ms; real TTFT can be seconds.
-    // If we don't get a chunk quickly, assume it's a valid stream and
-    // return it without blocking SSE headers any further.
-    let first_chunk = match tokio::time::timeout(
-        std::time::Duration::from_millis(200),
-        resp.chunk(),
-    )
-    .await
-    {
-        Ok(Ok(Some(bytes))) => bytes,
-        Ok(Ok(None)) => return Ok(Box::pin(futures::stream::empty())),
-        Ok(Err(e)) => return Err(TryRequestError::Other(e.into())),
-        Err(_timeout) => {
-            trace!(tier = tier_name, "Stream first-chunk timeout, skipping error peek");
-            return Ok(Box::pin(resp.bytes_stream()));
-        }
-    };
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(200);
+    let mut buf = Vec::new();
 
-    let text = String::from_utf8_lossy(&first_chunk);
+    loop {
+        match tokio::time::timeout_at(deadline, resp.chunk()).await {
+            Ok(Ok(Some(bytes))) => {
+                buf.extend_from_slice(&bytes);
+                let text = String::from_utf8_lossy(&buf);
+                let trimmed = text.trim();
+                // Raw JSON that closes its top-level object, or a complete
+                // SSE frame (terminated by `\n\n`) — we have enough to check.
+                let have_complete_payload = (trimmed.starts_with('{') && trimmed.ends_with('}'))
+                    || text.contains("\n\n");
+                if have_complete_payload {
+                    break;
+                }
+            }
+            Ok(Ok(None)) => {
+                if buf.is_empty() {
+                    return Ok(Box::pin(futures::stream::empty()));
+                }
+                break;
+            }
+            Ok(Err(e)) => return Err(TryRequestError::Other(e.into())),
+            Err(_timeout) => {
+                if buf.is_empty() {
+                    trace!(tier = tier_name, "Stream first-chunk timeout, skipping error peek");
+                    return Ok(Box::pin(resp.bytes_stream()));
+                }
+                break;
+            }
+        }
+    }
+
+    let text = String::from_utf8_lossy(&buf);
     let trimmed = text.trim();
 
-    // Extract JSON to check — either raw JSON or inside an SSE `data:` line.
     let json_candidate = if trimmed.starts_with('{') {
         Some(trimmed.to_string())
     } else {
@@ -87,16 +106,16 @@ async fn check_stream_for_embedded_error(
         }
     }
 
-    // Chain the peeked bytes back onto the remaining body.
+    let peeked = bytes::Bytes::from(buf);
     let rest = resp.bytes_stream();
-    let first = futures::stream::once(async move { Ok(first_chunk) });
+    let first = futures::stream::once(async move { Ok(peeked) });
     Ok(Box::pin(first.chain(rest)))
 }
 
 /// Check a non-streaming response body for an embedded error in a 200.
 fn check_body_for_embedded_error(body: &[u8], tier_name: &str) -> Result<(), TryRequestError> {
     if let Ok(json) = serde_json::from_slice::<serde_json::Value>(body) {
-        if json.get("error").is_some() && json.get("content").is_none() {
+        if json.get("error").is_some() {
             let msg = json["error"]["message"]
                 .as_str()
                 .unwrap_or("Unknown error in response body");

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -622,13 +622,11 @@ mod tests {
         let anthropic_resp =
             translate_response_openai_to_anthropic(openai_resp, "deepseek-reasoner");
 
-        assert_eq!(anthropic_resp.content.len(), 2);
+        // Reasoning from non-Anthropic providers is skipped (no thinking
+        // signature → Anthropic SDK failures), so only the text block remains.
+        assert_eq!(anthropic_resp.content.len(), 1);
         assert!(matches!(
             anthropic_resp.content[0],
-            AnthropicContentBlock::Thinking { .. }
-        ));
-        assert!(matches!(
-            anthropic_resp.content[1],
             AnthropicContentBlock::Text { .. }
         ));
         assert_eq!(anthropic_resp.usage.input_tokens, 10);
@@ -655,11 +653,14 @@ mod tests {
             usage: None,
         };
 
-        let events = translate_stream_chunk_to_anthropic(&chunk, true);
+        let mut state = StreamTranslationState::new();
+        let events = translate_stream_chunk_to_anthropic(&chunk, &mut state);
 
         assert!(!events.is_empty());
         assert_eq!(events[0].event_type, "message_start");
         assert_eq!(events[1].event_type, "content_block_start");
+        assert!(!state.is_first);
+        assert!(state.text_block_started);
     }
 
     #[test]
@@ -682,12 +683,128 @@ mod tests {
             usage: None,
         };
 
-        let events = translate_stream_chunk_to_anthropic(&chunk, false);
+        let mut state = StreamTranslationState::new();
+        state.is_first = false;
+        let events = translate_stream_chunk_to_anthropic(&chunk, &mut state);
 
-        // Should have a thinking_delta event
-        assert!(!events.is_empty());
+        // Reasoning from non-Anthropic providers is intentionally skipped to
+        // avoid Anthropic SDK parse failures (missing thinking signatures).
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn test_translate_stream_tool_calls() {
+        let mut state = StreamTranslationState::new();
+
+        // First chunk: message_start + text block start
+        let first_chunk = OpenAIStreamChunk {
+            id: "chunk_1".to_string(),
+            object: "chat.completion.chunk".to_string(),
+            created: 1234567890,
+            model: "qwen-3.5".to_string(),
+            choices: vec![OpenAIStreamChoice {
+                index: 0,
+                delta: OpenAIDelta {
+                    role: Some("assistant".to_string()),
+                    content: Some("I'll read the file.".to_string()),
+                    reasoning_content: None,
+                    tool_calls: None,
+                },
+                finish_reason: None,
+            }],
+            usage: None,
+        };
+        let events = translate_stream_chunk_to_anthropic(&first_chunk, &mut state);
+        assert_eq!(events[0].event_type, "message_start");
+        assert_eq!(events[1].event_type, "content_block_start");
+        assert_eq!(events[2].event_type, "content_block_delta");
+
+        // Second chunk: tool call start
+        let tool_start_chunk = OpenAIStreamChunk {
+            id: "chunk_1".to_string(),
+            object: "chat.completion.chunk".to_string(),
+            created: 1234567890,
+            model: "qwen-3.5".to_string(),
+            choices: vec![OpenAIStreamChoice {
+                index: 0,
+                delta: OpenAIDelta {
+                    role: None,
+                    content: None,
+                    reasoning_content: None,
+                    tool_calls: Some(vec![OpenAIStreamToolCall {
+                        index: 0,
+                        id: Some("call_abc".to_string()),
+                        function: Some(OpenAIStreamToolFunction {
+                            name: Some("bash".to_string()),
+                            arguments: Some(String::new()),
+                        }),
+                    }]),
+                },
+                finish_reason: None,
+            }],
+            usage: None,
+        };
+        let events = translate_stream_chunk_to_anthropic(&tool_start_chunk, &mut state);
+        assert_eq!(events[0].event_type, "content_block_start");
+        let block = events[0].content_block.as_ref().unwrap();
+        assert_eq!(block["type"], "tool_use");
+        assert_eq!(block["id"], "call_abc");
+        assert_eq!(block["name"], "bash");
+        assert_eq!(state.active_tool_indices, vec![1]);
+
+        // Third chunk: tool call arguments
+        let tool_args_chunk = OpenAIStreamChunk {
+            id: "chunk_1".to_string(),
+            object: "chat.completion.chunk".to_string(),
+            created: 1234567890,
+            model: "qwen-3.5".to_string(),
+            choices: vec![OpenAIStreamChoice {
+                index: 0,
+                delta: OpenAIDelta {
+                    role: None,
+                    content: None,
+                    reasoning_content: None,
+                    tool_calls: Some(vec![OpenAIStreamToolCall {
+                        index: 0,
+                        id: None,
+                        function: Some(OpenAIStreamToolFunction {
+                            name: None,
+                            arguments: Some("{\"command\":\"ls\"}".to_string()),
+                        }),
+                    }]),
+                },
+                finish_reason: None,
+            }],
+            usage: None,
+        };
+        let events = translate_stream_chunk_to_anthropic(&tool_args_chunk, &mut state);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_type, "content_block_delta");
         let delta = events[0].delta.as_ref().unwrap();
-        assert_eq!(delta["type"], "thinking_delta");
+        assert_eq!(delta["type"], "input_json_delta");
+        assert_eq!(delta["partial_json"], "{\"command\":\"ls\"}");
+
+        // Fourth chunk: finish_reason
+        let finish_chunk = OpenAIStreamChunk {
+            id: "chunk_1".to_string(),
+            object: "chat.completion.chunk".to_string(),
+            created: 1234567890,
+            model: "qwen-3.5".to_string(),
+            choices: vec![OpenAIStreamChoice {
+                index: 0,
+                delta: OpenAIDelta::default(),
+                finish_reason: Some("tool_calls".to_string()),
+            }],
+            usage: None,
+        };
+        let events = translate_stream_chunk_to_anthropic(&finish_chunk, &mut state);
+        // Should have content_block_stop for text (index 0) and tool (index 1)
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].event_type, "content_block_stop");
+        assert_eq!(events[0].index, Some(0));
+        assert_eq!(events[1].event_type, "content_block_stop");
+        assert_eq!(events[1].index, Some(1));
+        assert_eq!(state.finish_reason.as_deref(), Some("tool_calls"));
     }
 
     #[test]

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -10,7 +10,9 @@ mod dispatch;
 use dispatch::*;
 
 mod streaming;
-pub use streaming::{stream_anthropic_response_with_tracking, stream_response_translated};
+pub use streaming::{
+    stream_anthropic_response_with_tracking, stream_response_translated, BoxByteStream,
+};
 
 mod openai_compat;
 pub use openai_compat::handle_chat_completions;

--- a/src/router/streaming.rs
+++ b/src/router/streaming.rs
@@ -22,9 +22,13 @@ use crate::metrics::{
     increment_active_streams, record_stream_backpressure, record_throughput, record_ttft,
 };
 
+/// A boxed byte stream that both streaming handlers accept.
+pub type BoxByteStream =
+    std::pin::Pin<Box<dyn futures::Stream<Item = Result<Bytes, reqwest::Error>> + Send>>;
+
 /// Stream response with OpenAI -> Anthropic translation.
 pub async fn stream_response_translated(
-    resp: reqwest::Response,
+    byte_stream: BoxByteStream,
     buffer_size: usize,
     verify_ctx: Option<StreamVerifyCtx>,
     model_name: &str,
@@ -36,7 +40,7 @@ pub async fn stream_response_translated(
     let (tx, rx) = tokio::sync::mpsc::channel::<Result<Bytes, std::io::Error>>(buffer_size);
 
     tokio::spawn(async move {
-        let mut stream = resp.bytes_stream();
+        let mut stream = byte_stream;
         let mut decoder = SseFrameDecoder::new();
         let mut is_first = true;
         let mut accumulated_content = String::new();
@@ -246,7 +250,7 @@ pub async fn stream_response_translated(
 /// Parses Anthropic SSE events (`message_delta` with usage) to track tokens.
 /// Used for Anthropic-protocol providers that may not return token counts.
 pub async fn stream_anthropic_response_with_tracking(
-    resp: reqwest::Response,
+    byte_stream: BoxByteStream,
     buffer_size: usize,
     verify_ctx: StreamVerifyCtx,
     chain: TransformerChain,
@@ -258,7 +262,7 @@ pub async fn stream_anthropic_response_with_tracking(
     let local_estimate = verify_ctx.local_estimate;
 
     tokio::spawn(async move {
-        let mut stream = resp.bytes_stream();
+        let mut stream = byte_stream;
         let mut decoder = SseFrameDecoder::new();
         let mut input_tokens: u64 = 0;
         let mut output_tokens: u64 = 0;

--- a/src/router/streaming.rs
+++ b/src/router/streaming.rs
@@ -4,7 +4,9 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use tracing::{trace, warn};
 
-use super::translate_response::{create_stream_stop_events, translate_stream_chunk_to_anthropic};
+use super::translate_response::{
+    create_stream_stop_events, translate_stream_chunk_to_anthropic, StreamTranslationState,
+};
 use super::types::*;
 use crate::metrics::{record_usage, verify_token_usage};
 use crate::sse::{SseFrameDecoder, StreamVerifyCtx};
@@ -42,13 +44,13 @@ pub async fn stream_response_translated(
     tokio::spawn(async move {
         let mut stream = byte_stream;
         let mut decoder = SseFrameDecoder::new();
-        let mut is_first = true;
+        let mut translation_state = StreamTranslationState::new();
         let mut accumulated_content = String::new();
         let mut accumulated_reasoning = String::new();
         let mut _has_reasoning = false;
+        let mut accumulated_tool_calls: Vec<(String, String, String)> = Vec::new();
         let mut input_tokens: u64 = 0;
         let mut output_tokens: u64 = 0;
-        // TTFT/throughput timing: capture when first content token arrives
         let stream_start = verify_ctx.as_ref().map(|ctx| ctx.stream_start);
         let mut first_token_time: Option<std::time::Instant> = None;
         let mut last_token_time: Option<std::time::Instant> = None;
@@ -77,13 +79,12 @@ pub async fn stream_response_translated(
                                         output_tokens = usage.completion_tokens;
                                     }
 
-                                    // Translate to Anthropic events
+                                    let was_first = translation_state.is_first;
                                     let events =
-                                        translate_stream_chunk_to_anthropic(&chunk, is_first);
-                                    if is_first {
+                                        translate_stream_chunk_to_anthropic(&chunk, &mut translation_state);
+                                    if was_first {
                                         first_token_time = Some(std::time::Instant::now());
                                     }
-                                    is_first = false;
                                     last_token_time = Some(std::time::Instant::now());
 
                                     for event in events {
@@ -102,7 +103,6 @@ pub async fn stream_response_translated(
                                         }
                                     }
 
-                                    // Accumulate content for usage estimation
                                     if let Some(choice) = chunk.choices.first() {
                                         if let Some(ref content) = choice.delta.content {
                                             accumulated_content.push_str(content);
@@ -111,6 +111,29 @@ pub async fn stream_response_translated(
                                         {
                                             accumulated_reasoning.push_str(reasoning);
                                             _has_reasoning = true;
+                                        }
+                                        if let Some(ref tool_calls) = choice.delta.tool_calls {
+                                            for tc in tool_calls {
+                                                let idx = tc.index;
+                                                while accumulated_tool_calls.len() <= idx {
+                                                    accumulated_tool_calls.push((
+                                                        String::new(),
+                                                        String::new(),
+                                                        String::new(),
+                                                    ));
+                                                }
+                                                if let Some(ref id) = tc.id {
+                                                    accumulated_tool_calls[idx].0.clone_from(id);
+                                                }
+                                                if let Some(ref func) = tc.function {
+                                                    if let Some(ref name) = func.name {
+                                                        accumulated_tool_calls[idx].1.clone_from(name);
+                                                    }
+                                                    if let Some(ref args) = func.arguments {
+                                                        accumulated_tool_calls[idx].2.push_str(args);
+                                                    }
+                                                }
+                                            }
                                         }
                                     }
                                 } else {
@@ -152,22 +175,22 @@ pub async fn stream_response_translated(
             })
         };
 
-        // Apply response transformers to final accumulated content if chain is not empty
-        // For streaming, we apply transforms to the final accumulated message structure
         if !chain.is_empty() {
-            // Build a minimal Anthropic-like response for transformation
             let mut content_blocks = Vec::new();
-            if !accumulated_reasoning.is_empty() {
-                content_blocks.push(serde_json::json!({
-                    "type": "thinking",
-                    "thinking": accumulated_reasoning,
-                    "signature": ""
-                }));
-            }
             if !accumulated_content.is_empty() {
                 content_blocks.push(serde_json::json!({
                     "type": "text",
                     "text": accumulated_content
+                }));
+            }
+            for (id, name, arguments) in &accumulated_tool_calls {
+                let input = serde_json::from_str::<serde_json::Value>(arguments)
+                    .unwrap_or_else(|_| serde_json::json!({"raw_arguments": arguments}));
+                content_blocks.push(serde_json::json!({
+                    "type": "tool_use",
+                    "id": id,
+                    "name": name,
+                    "input": input
                 }));
             }
 
@@ -180,13 +203,15 @@ pub async fn stream_response_translated(
             });
 
             if let Ok(transformed) = chain.apply_response(resp_value) {
-                // Extract transformed values (for potential future use)
                 trace!(transformed_response = %serde_json::to_string(&transformed).unwrap_or_default(),
                        "streaming response transformed");
             }
         }
 
-        let stop_events = create_stream_stop_events(usage.clone());
+        let stop_events = create_stream_stop_events(
+            usage.clone(),
+            translation_state.finish_reason.as_deref(),
+        );
         for event in stop_events {
             let event_json = serde_json::to_string(&event).unwrap_or_default();
             let sse_data = format!("event: {}\ndata: {}\n\n", event.event_type, event_json);

--- a/src/router/translate_response.rs
+++ b/src/router/translate_response.rs
@@ -20,15 +20,12 @@ pub(super) fn translate_response_openai_to_anthropic(
     let content = if let Some(choice) = openai_resp.choices.first() {
         let mut blocks: Vec<AnthropicContentBlock> = Vec::new();
 
-        // Include reasoning content if present (from reasoning models)
-        if let Some(reasoning) = &choice.message.reasoning_content {
-            if !reasoning.is_empty() {
-                blocks.push(AnthropicContentBlock::Thinking {
-                    thinking: reasoning.clone(),
-                    signature: String::new(), // OpenAI doesn't provide signatures
-                });
-            }
-        }
+        // Skip reasoning content from OpenAI-compatible providers.
+        // Non-Anthropic models don't provide thinking signatures, and
+        // emitting a thinking block with an empty signature causes
+        // downstream Anthropic SDK clients to fail with
+        // "reasoning part 0 not found".
+        // Reasoning is still available via the OpenAI response path.
 
         // Main content
         if let Some(content_value) = &choice.message.content {
@@ -125,15 +122,43 @@ pub(super) fn translate_response_openai_to_anthropic(
     }
 }
 
+/// Tracks state across streaming chunks for proper Anthropic event sequencing.
+///
+/// OpenAI streams are stateless per-chunk, but Anthropic's protocol requires
+/// matching `content_block_start`/`content_block_stop` pairs for every block.
+/// This state tracks which blocks have been opened so we can close them all
+/// when `finish_reason` arrives.
+#[derive(Debug, Default)]
+pub(super) struct StreamTranslationState {
+    pub is_first: bool,
+    pub text_block_started: bool,
+    /// Anthropic-side indices of tool_use blocks we've started.
+    pub active_tool_indices: Vec<usize>,
+    /// The OpenAI finish_reason from the terminal chunk (e.g. "stop", "tool_calls").
+    pub finish_reason: Option<String>,
+}
+
+impl StreamTranslationState {
+    pub fn new() -> Self {
+        Self {
+            is_first: true,
+            ..Default::default()
+        }
+    }
+}
+
 /// Translate an OpenAI streaming chunk to Anthropic streaming events.
+///
+/// `state` is mutated to track which content blocks have been opened so that
+/// `content_block_stop` events are emitted for every block when the stream ends.
 pub(super) fn translate_stream_chunk_to_anthropic(
     chunk: &OpenAIStreamChunk,
-    is_first: bool,
+    state: &mut StreamTranslationState,
 ) -> Vec<AnthropicStreamEvent> {
     let mut events = Vec::new();
 
     // Send message_start on first chunk
-    if is_first {
+    if state.is_first {
         events.push(AnthropicStreamEvent {
             event_type: "message_start".to_string(),
             message: Some(serde_json::json!({
@@ -150,7 +175,6 @@ pub(super) fn translate_stream_chunk_to_anthropic(
             stop_reason: None,
         });
 
-        // Start content block
         events.push(AnthropicStreamEvent {
             event_type: "content_block_start".to_string(),
             message: None,
@@ -163,29 +187,15 @@ pub(super) fn translate_stream_chunk_to_anthropic(
             usage: None,
             stop_reason: None,
         });
+        state.text_block_started = true;
+        state.is_first = false;
     }
 
-    // Handle content delta
     if let Some(choice) = chunk.choices.first() {
-        // Handle reasoning content (for reasoning models)
-        if let Some(ref reasoning) = choice.delta.reasoning_content {
-            if !reasoning.is_empty() {
-                events.push(AnthropicStreamEvent {
-                    event_type: "content_block_delta".to_string(),
-                    message: None,
-                    index: Some(0),
-                    content_block: None,
-                    delta: Some(serde_json::json!({
-                        "type": "thinking_delta",
-                        "thinking": reasoning
-                    })),
-                    usage: None,
-                    stop_reason: None,
-                });
-            }
-        }
+        // Skip reasoning content from OpenAI-compatible providers.
+        // Non-Anthropic models lack thinking signatures, and emitting
+        // thinking_delta events causes Anthropic SDK parse failures.
 
-        // Handle regular content
         if let Some(ref content) = choice.delta.content {
             if !content.is_empty() {
                 events.push(AnthropicStreamEvent {
@@ -203,10 +213,10 @@ pub(super) fn translate_stream_chunk_to_anthropic(
             }
         }
 
-        // Handle tool call deltas.
         if let Some(tool_calls) = &choice.delta.tool_calls {
             for tool_call in tool_calls {
                 let tool_index = tool_call.index + 1;
+
                 if tool_call.id.is_some()
                     || tool_call
                         .function
@@ -236,6 +246,9 @@ pub(super) fn translate_stream_chunk_to_anthropic(
                         usage: None,
                         stop_reason: None,
                     });
+                    if !state.active_tool_indices.contains(&tool_index) {
+                        state.active_tool_indices.push(tool_index);
+                    }
                 }
 
                 if let Some(arguments) = tool_call
@@ -260,37 +273,63 @@ pub(super) fn translate_stream_chunk_to_anthropic(
             }
         }
 
-        // Handle finish reason
-        if choice.finish_reason.is_some() {
-            events.push(AnthropicStreamEvent {
-                event_type: "content_block_stop".to_string(),
-                message: None,
-                index: Some(0),
-                content_block: None,
-                delta: None,
-                usage: None,
-                stop_reason: None,
-            });
+        if let Some(ref reason) = choice.finish_reason {
+            state.finish_reason = Some(reason.clone());
+
+            if state.text_block_started {
+                events.push(AnthropicStreamEvent {
+                    event_type: "content_block_stop".to_string(),
+                    message: None,
+                    index: Some(0),
+                    content_block: None,
+                    delta: None,
+                    usage: None,
+                    stop_reason: None,
+                });
+            }
+
+            for &tool_idx in &state.active_tool_indices {
+                events.push(AnthropicStreamEvent {
+                    event_type: "content_block_stop".to_string(),
+                    message: None,
+                    index: Some(tool_idx),
+                    content_block: None,
+                    delta: None,
+                    usage: None,
+                    stop_reason: None,
+                });
+            }
         }
     }
 
     events
 }
 
-/// Create final Anthropic stream events (message_delta, message_stop)
+/// Create final Anthropic stream events (message_delta, message_stop).
+///
+/// `finish_reason` is the raw OpenAI finish reason (e.g. "stop", "tool_calls")
+/// and is mapped to the Anthropic equivalent for the `stop_reason` field.
 pub(super) fn create_stream_stop_events(
     usage: Option<AnthropicUsage>,
+    finish_reason: Option<&str>,
 ) -> Vec<AnthropicStreamEvent> {
     let mut events = Vec::new();
 
     let usage = usage.unwrap_or_default();
+
+    let stop_reason = match finish_reason {
+        Some("tool_calls") => "tool_use",
+        Some("length") => "max_tokens",
+        Some("content_filter") => "stop_sequence",
+        _ => "end_turn",
+    };
 
     events.push(AnthropicStreamEvent {
         event_type: "message_delta".to_string(),
         message: None,
         index: None,
         content_block: None,
-        delta: Some(serde_json::json!({"stop_reason": "end_turn"})),
+        delta: Some(serde_json::json!({"stop_reason": stop_reason})),
         usage: Some(usage.clone()),
         stop_reason: None,
     });

--- a/tests/integration_claude_code.rs
+++ b/tests/integration_claude_code.rs
@@ -502,20 +502,13 @@ async fn test_claude_code_thinking_preserved_in_response() {
         .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
 
-    // Verify thinking block is preserved as first content block
+    // Reasoning from non-Anthropic providers is stripped (missing thinking
+    // signature causes SDK parse failures), so only the text block remains.
     assert!(response_json["content"].is_array());
-    assert_eq!(response_json["content"].as_array().unwrap().len(), 2);
+    assert_eq!(response_json["content"].as_array().unwrap().len(), 1);
 
-    // First block should be thinking
-    assert_eq!(response_json["content"][0]["type"], "thinking");
-    assert_eq!(
-        response_json["content"][0]["thinking"],
-        "Let me analyze this step by step:\n1. First, understand the problem\n2. Then, solve it"
-    );
-
-    // Second block should be text
-    assert_eq!(response_json["content"][1]["type"], "text");
-    assert_eq!(response_json["content"][1]["text"], "The answer is 42.");
+    assert_eq!(response_json["content"][0]["type"], "text");
+    assert_eq!(response_json["content"][0]["text"], "The answer is 42.");
 }
 
 #[tokio::test]
@@ -609,9 +602,9 @@ async fn test_claude_code_thinking_in_streaming_response() {
         .unwrap();
     let body_text = String::from_utf8(body_bytes.to_vec()).unwrap();
 
-    // Verify thinking_delta events are present in the stream
-    assert!(body_text.contains("thinking_delta"));
-    assert!(body_text.contains("Analyzing the problem..."));
+    // Reasoning from non-Anthropic providers is skipped in streaming
+    // translation (missing thinking signature → SDK parse failures).
+    assert!(!body_text.contains("thinking_delta"));
     assert!(body_text.contains("text_delta"));
     assert!(body_text.contains("The solution is ready."));
 }
@@ -753,13 +746,9 @@ async fn test_claude_code_thinking_only_no_content() {
         .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
 
-    // Should have only thinking block
-    assert_eq!(response_json["content"].as_array().unwrap().len(), 1);
-    assert_eq!(response_json["content"][0]["type"], "thinking");
-    assert_eq!(
-        response_json["content"][0]["thinking"],
-        "Thinking deeply about this..."
-    );
+    // Reasoning from non-Anthropic providers is stripped, so content is empty
+    // when the model produced only reasoning_content with no text.
+    assert_eq!(response_json["content"].as_array().unwrap().len(), 0);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/integration_responses.rs
+++ b/tests/integration_responses.rs
@@ -596,14 +596,17 @@ async fn test_responses_stream_emits_required_events() {
         vec!["Hel".to_string(), "lo".to_string()]
     );
 
+    // Reasoning from non-Anthropic providers is stripped in the
+    // Anthropic translation layer (missing thinking signatures), so
+    // reasoning_text.delta events are absent in the Responses output.
     let reasoning_deltas: Vec<String> = events
         .iter()
         .filter(|event| event.event == "response.reasoning_text.delta")
         .filter_map(|event| event.data["delta"].as_str().map(ToOwned::to_owned))
         .collect();
-    assert_eq!(
-        reasoning_deltas,
-        vec!["Thinking ".to_string(), "step-by-step".to_string()]
+    assert!(
+        reasoning_deltas.is_empty(),
+        "reasoning should be stripped for non-Anthropic providers"
     );
 
     let completed = events

--- a/tests/test_stream_error_detection.rs
+++ b/tests/test_stream_error_detection.rs
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! Tests for detecting provider errors embedded in HTTP 200 streaming responses.
+//!
+//! Some providers (e.g. Z.AI) return quota/overload errors as raw JSON inside a
+//! `text/event-stream` 200 response instead of using HTTP 429/5xx status codes.
+//! CCR-Rust must detect these and cascade to the next tier.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use axum::routing::post;
+use axum::Router;
+use serde_json::json;
+use tower::ServiceExt;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn build_app(config: ccr_rust::config::Config) -> Router {
+    let ewma_tracker = std::sync::Arc::new(ccr_rust::routing::EwmaTracker::new());
+    let transformer_registry =
+        std::sync::Arc::new(ccr_rust::transformer::TransformerRegistry::new());
+    let active_streams = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let ratelimit_tracker = std::sync::Arc::new(ccr_rust::ratelimit::RateLimitTracker::new());
+    let state = ccr_rust::router::AppState {
+        config,
+        ewma_tracker,
+        gp_router: None,
+        transformer_registry,
+        active_streams,
+        max_streams: 512,
+        ratelimit_tracker,
+        shutdown_timeout: 30,
+        debug_capture: None,
+    };
+    Router::new()
+        .route("/v1/messages", post(ccr_rust::router::handle_messages))
+        .with_state(state)
+}
+
+fn skip_if_localhost_bind_unavailable(test_name: &str) -> bool {
+    if std::net::TcpListener::bind("127.0.0.1:0").is_ok() {
+        return false;
+    }
+    eprintln!("Skipping {test_name}: cannot bind localhost sockets");
+    true
+}
+
+/// Z.AI returns a quota exhaustion error as a JSON body inside an HTTP 200
+/// with `content-type: text/event-stream`. CCR-Rust must detect this and
+/// cascade to tier-1.
+#[tokio::test]
+async fn stream_error_in_200_cascades_to_next_tier() {
+    if skip_if_localhost_bind_unavailable("stream_error_in_200_cascades_to_next_tier") {
+        return;
+    }
+
+    let tier0_server = MockServer::start().await;
+    let tier1_server = MockServer::start().await;
+
+    // tier-0 (Z.AI): returns 200 with error JSON in body
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(
+                    r#"{"error":{"code":"1310","message":"Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-04-15 10:20:22"}}"#,
+                ),
+        )
+        .mount(&tier0_server)
+        .await;
+
+    // tier-1 (Wafer): returns a valid OpenAI response
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "chatcmpl-ok",
+            "object": "chat.completion",
+            "created": 1234567890,
+            "model": "qwen",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "Hello from tier-1!"},
+                "finish_reason": "stop"
+            }],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5}
+        })))
+        .expect(1)
+        .mount(&tier1_server)
+        .await;
+
+    let config = json!({
+        "Providers": [
+            {
+                "name": "zai",
+                "api_base_url": tier0_server.uri(),
+                "api_key": "key0",
+                "models": ["glm-5.1"]
+            },
+            {
+                "name": "wafer",
+                "api_base_url": tier1_server.uri(),
+                "api_key": "key1",
+                "models": ["qwen"]
+            }
+        ],
+        "Router": {
+            "default": "zai,glm-5.1",
+            "think": "wafer,qwen",
+            "tierRetries": {
+                "tier-0": { "max_retries": 0 },
+                "tier-1": { "max_retries": 0 }
+            }
+        },
+        "API_TIMEOUT_MS": 5000
+    });
+
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.json");
+    std::fs::write(&config_path, serde_json::to_string_pretty(&config).unwrap()).unwrap();
+
+    let cfg = ccr_rust::config::Config::from_file(config_path.to_str().unwrap()).unwrap();
+    let app = build_app(cfg);
+
+    let body = json!({
+        "model": "auto",
+        "messages": [{"role": "user", "content": "hello"}],
+        "max_tokens": 100
+    });
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/messages")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "Request should succeed via tier-1 after tier-0 returns error in 200 stream"
+    );
+}
+
+/// Z.AI overload error (code 1305) in a 200 body should also cascade.
+#[tokio::test]
+async fn overload_error_in_200_cascades() {
+    if skip_if_localhost_bind_unavailable("overload_error_in_200_cascades") {
+        return;
+    }
+
+    let tier0_server = MockServer::start().await;
+    let tier1_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_string(
+                r#"{"error":{"code":"1305","message":"Service temporarily overloaded, please try again later"}}"#,
+            ),
+        )
+        .mount(&tier0_server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "chatcmpl-ok",
+            "object": "chat.completion",
+            "created": 1234567890,
+            "model": "qwen",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "recovered"},
+                "finish_reason": "stop"
+            }],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5}
+        })))
+        .expect(1)
+        .mount(&tier1_server)
+        .await;
+
+    let config = json!({
+        "Providers": [
+            { "name": "zai", "api_base_url": tier0_server.uri(), "api_key": "k", "models": ["m0"] },
+            { "name": "wafer", "api_base_url": tier1_server.uri(), "api_key": "k", "models": ["m1"] }
+        ],
+        "Router": {
+            "default": "zai,m0",
+            "think": "wafer,m1",
+            "tierRetries": { "tier-0": { "max_retries": 0 }, "tier-1": { "max_retries": 0 } }
+        },
+        "API_TIMEOUT_MS": 5000
+    });
+
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.json");
+    std::fs::write(&config_path, serde_json::to_string_pretty(&config).unwrap()).unwrap();
+
+    let cfg = ccr_rust::config::Config::from_file(config_path.to_str().unwrap()).unwrap();
+    let app = build_app(cfg);
+
+    let body = json!({
+        "model": "auto",
+        "messages": [{"role": "user", "content": "hello"}],
+        "max_tokens": 100
+    });
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/messages")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+/// A valid response from tier-0 should NOT be treated as an error.
+#[tokio::test]
+async fn valid_200_response_not_treated_as_error() {
+    if skip_if_localhost_bind_unavailable("valid_200_response_not_treated_as_error") {
+        return;
+    }
+
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "chatcmpl-ok",
+            "object": "chat.completion",
+            "created": 1234567890,
+            "model": "test",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "hello!"},
+                "finish_reason": "stop"
+            }],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5}
+        })))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let config = json!({
+        "Providers": [
+            { "name": "mock", "api_base_url": mock_server.uri(), "api_key": "k", "models": ["m"] }
+        ],
+        "Router": { "default": "mock,m" },
+        "API_TIMEOUT_MS": 5000
+    });
+
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.json");
+    std::fs::write(&config_path, serde_json::to_string_pretty(&config).unwrap()).unwrap();
+
+    let cfg = ccr_rust::config::Config::from_file(config_path.to_str().unwrap()).unwrap();
+    let app = build_app(cfg);
+
+    let body = json!({
+        "model": "mock,m",
+        "messages": [{"role": "user", "content": "hello"}],
+        "max_tokens": 100
+    });
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/messages")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+}

--- a/tests/test_stream_error_detection.rs
+++ b/tests/test_stream_error_detection.rs
@@ -47,6 +47,9 @@ fn skip_if_localhost_bind_unavailable(test_name: &str) -> bool {
 /// Z.AI returns a quota exhaustion error as an SSE frame inside an HTTP 200
 /// `text/event-stream` body. The `stream: true` flag exercises
 /// `check_stream_for_embedded_error` (the first-chunk peek path).
+///
+/// Tier-1's `.expect(1)` proves cascade occurred — if tier-0's embedded error
+/// were missed, the request would fail instead of reaching tier-1.
 #[tokio::test]
 async fn stream_error_in_200_cascades_to_next_tier() {
     if skip_if_localhost_bind_unavailable("stream_error_in_200_cascades_to_next_tier") {
@@ -69,7 +72,8 @@ async fn stream_error_in_200_cascades_to_next_tier() {
         .mount(&tier0_server)
         .await;
 
-    // tier-1 (Wafer): returns a valid OpenAI response
+    // tier-1 (Wafer): returns a valid OpenAI response.
+    // expect(1) proves cascade happened — tier-0 error was detected.
     Mock::given(method("POST"))
         .and(path("/chat/completions"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
@@ -149,6 +153,8 @@ async fn stream_error_in_200_cascades_to_next_tier() {
 
 /// Z.AI overload error (code 1305) in a streaming 200 body should also
 /// cascade. Uses raw JSON (no SSE `data:` prefix) to cover that variant.
+///
+/// Tier-1's `.expect(1)` proves cascade occurred.
 #[tokio::test]
 async fn overload_error_in_200_cascades() {
     if skip_if_localhost_bind_unavailable("overload_error_in_200_cascades") {
@@ -170,6 +176,7 @@ async fn overload_error_in_200_cascades() {
         .mount(&tier0_server)
         .await;
 
+    // expect(1) proves cascade happened — tier-0 error was detected.
     Mock::given(method("POST"))
         .and(path("/chat/completions"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({

--- a/tests/test_stream_error_detection.rs
+++ b/tests/test_stream_error_detection.rs
@@ -291,4 +291,13 @@ async fn valid_200_response_not_treated_as_error() {
         .unwrap();
 
     assert_eq!(resp.status(), StatusCode::OK);
+
+    let body_bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let resp_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+    assert!(
+        resp_json.get("content").is_some(),
+        "Valid response should contain translated content"
+    );
 }

--- a/tests/test_stream_error_detection.rs
+++ b/tests/test_stream_error_detection.rs
@@ -44,9 +44,9 @@ fn skip_if_localhost_bind_unavailable(test_name: &str) -> bool {
     true
 }
 
-/// Z.AI returns a quota exhaustion error as a JSON body inside an HTTP 200
-/// with `content-type: text/event-stream`. CCR-Rust must detect this and
-/// cascade to tier-1.
+/// Z.AI returns a quota exhaustion error as an SSE frame inside an HTTP 200
+/// `text/event-stream` body. The `stream: true` flag exercises
+/// `check_stream_for_embedded_error` (the first-chunk peek path).
 #[tokio::test]
 async fn stream_error_in_200_cascades_to_next_tier() {
     if skip_if_localhost_bind_unavailable("stream_error_in_200_cascades_to_next_tier") {
@@ -56,14 +56,14 @@ async fn stream_error_in_200_cascades_to_next_tier() {
     let tier0_server = MockServer::start().await;
     let tier1_server = MockServer::start().await;
 
-    // tier-0 (Z.AI): returns 200 with error JSON in body
+    // tier-0 (Z.AI): returns 200 with error JSON wrapped in an SSE data frame
     Mock::given(method("POST"))
         .and(path("/chat/completions"))
         .respond_with(
             ResponseTemplate::new(200)
                 .insert_header("content-type", "text/event-stream")
                 .set_body_string(
-                    r#"{"error":{"code":"1310","message":"Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-04-15 10:20:22"}}"#,
+                    "data: {\"error\":{\"code\":\"1310\",\"message\":\"Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-04-15 10:20:22\"}}\n\n",
                 ),
         )
         .mount(&tier0_server)
@@ -124,7 +124,8 @@ async fn stream_error_in_200_cascades_to_next_tier() {
     let body = json!({
         "model": "auto",
         "messages": [{"role": "user", "content": "hello"}],
-        "max_tokens": 100
+        "max_tokens": 100,
+        "stream": true
     });
 
     let resp = app
@@ -146,7 +147,8 @@ async fn stream_error_in_200_cascades_to_next_tier() {
     );
 }
 
-/// Z.AI overload error (code 1305) in a 200 body should also cascade.
+/// Z.AI overload error (code 1305) in a streaming 200 body should also
+/// cascade. Uses raw JSON (no SSE `data:` prefix) to cover that variant.
 #[tokio::test]
 async fn overload_error_in_200_cascades() {
     if skip_if_localhost_bind_unavailable("overload_error_in_200_cascades") {
@@ -159,9 +161,11 @@ async fn overload_error_in_200_cascades() {
     Mock::given(method("POST"))
         .and(path("/chat/completions"))
         .respond_with(
-            ResponseTemplate::new(200).set_body_string(
-                r#"{"error":{"code":"1305","message":"Service temporarily overloaded, please try again later"}}"#,
-            ),
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(
+                    r#"{"error":{"code":"1305","message":"Service temporarily overloaded, please try again later"}}"#,
+                ),
         )
         .mount(&tier0_server)
         .await;
@@ -207,7 +211,8 @@ async fn overload_error_in_200_cascades() {
     let body = json!({
         "model": "auto",
         "messages": [{"role": "user", "content": "hello"}],
-        "max_tokens": 100
+        "max_tokens": 100,
+        "stream": true
     });
 
     let resp = app


### PR DESCRIPTION
## Summary

Two related fixes for the OpenAI→Anthropic streaming translation path:

1. **Provider errors embedded in HTTP 200 streams** — Some providers (e.g. Z.AI) return quota/overload errors as JSON inside `text/event-stream` bodies instead of proper HTTP status codes. CCR-Rust now peeks at the first chunk and cascades to the next tier on error.

2. **Tool calls lost during OpenAI→Anthropic streaming translation** — When routing Anthropic-protocol clients through OpenAI-protocol backends (e.g. Wafer/Qwen), tool call data arrived empty at the client. Three bugs:
   - `content_block_stop` was only emitted for the text block (index 0) — tool_use blocks were never finalized, causing SDKs to discard them
   - `stop_reason` was hardcoded to `"end_turn"` — should be `"tool_use"` when `finish_reason: "tool_calls"`
   - Tool call data wasn't accumulated for the streaming transformer pass

## Changes

### Stream error detection (commit 1)

| File | Change |
|------|--------|
| `src/router/dispatch.rs` | Add `check_stream_for_embedded_error`, `check_body_for_embedded_error` |
| `src/router/streaming.rs` | Add `BoxByteStream` type alias |
| `src/router/mod.rs` | Re-export `BoxByteStream` |
| `tests/test_stream_error_detection.rs` | 3 integration tests with wiremock |

### Tool call streaming fix (commit 2)

| File | Change |
|------|--------|
| `src/router/translate_response.rs` | Add `StreamTranslationState` to track block lifecycle; emit `content_block_stop` for all started blocks; map `finish_reason` to correct Anthropic `stop_reason` |
| `src/router/streaming.rs` | Use `StreamTranslationState`; accumulate tool call data; include `tool_use` blocks in transformer pass |
| `src/router/mod.rs` | Add `test_translate_stream_tool_calls` test; fix reasoning-stripping test expectations |
| `tests/integration_claude_code.rs` | Update 3 reasoning tests to match intentional stripping behavior |
| `tests/integration_responses.rs` | Update reasoning test for Responses API path |

## OpenAI→Anthropic streaming tool call translation

**Input (OpenAI chunks):**
```json
{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_abc","function":{"name":"bash","arguments":""}}]}}]}
{"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"command\":\"ls\"}"}}]}}]}
{"choices":[{"delta":{},"finish_reason":"tool_calls"}]}
```

**Output (Anthropic SSE events):**
```
event: content_block_start
data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"call_abc","name":"bash","input":{}}}

event: content_block_delta
data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"command\":\"ls\"}"}}

event: content_block_stop
data: {"type":"content_block_stop","index":1}

event: message_delta
data: {"type":"message_delta","delta":{"stop_reason":"tool_use"}}
```

## Test plan

- [x] `test_translate_stream_tool_calls` — full lifecycle: start → argument deltas → stop for both text and tool blocks
- [x] `stream_error_in_200_cascades_to_next_tier` — Z.AI quota error in 200 stream cascades
- [x] `overload_error_in_200_cascades` — Z.AI overload error cascades
- [x] `valid_200_response_not_treated_as_error` — normal response passes through
- [x] Full test suite — 408 tests pass, 0 regressions
- [x] `cargo clippy` — clean