### PR TITLE
feat: normalize provider transform routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **LongCat Thinking response normalization** — Added a `longcat-thinking`
+  transformer and changed native Anthropic response dispatch to apply response
+  transformers before strict deserialization. This lets CCR-Rust normalize
+  LongCat's unsigned `thinking` blocks before OpenAI-compatible clients require
+  a `choices[]` response shape.
+- **Anthropic Bearer auth provider option** — Added provider-level
+  `auth_header = "authorization"` support so Anthropic-compatible upstreams
+  that require `Authorization: Bearer` can route through the native Anthropic
+  dispatch path without a custom transformer.
 - **Centralized Pyright type-checking via MCP daemon** — New `type_check` native tool runs
   Pyright on the hub, eliminating per-worker Pyright/Pylance instances. Workers send file paths
   and optional content overlays; the hub creates ephemeral workspaces, runs `pyright --outputjson`,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -419,11 +419,13 @@ mod tests {
                 "api_key": "mk-xxx",
                 "models": ["model-v1"],
                 "protocol": "anthropic",
-                "anthropic_version": "2023-06-01"
+                "anthropic_version": "2023-06-01",
+                "auth_header": "authorization"
             }"#,
         );
         assert_eq!(p.protocol, ProviderProtocol::Anthropic);
         assert_eq!(p.anthropic_version.as_deref(), Some("2023-06-01"));
+        assert_eq!(p.auth_header.as_deref(), Some("authorization"));
     }
 
     #[test]

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -220,6 +220,13 @@ pub struct Provider {
     #[serde(default)]
     pub anthropic_version: Option<String>,
 
+    /// Authentication header style for `protocol=anthropic`.
+    ///
+    /// Defaults to `x-api-key`, matching Anthropic. Set to `authorization`
+    /// for Anthropic-compatible providers that require `Authorization: Bearer`.
+    #[serde(default)]
+    pub auth_header: Option<String>,
+
     #[serde(default)]
     pub transformer: Option<ProviderTransformer>,
 

--- a/src/router/dispatch.rs
+++ b/src/router/dispatch.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use tracing::{trace, warn};
 
 use super::streaming::{
-    stream_anthropic_response_with_tracking, stream_response_translated, BoxByteStream,
+    BoxByteStream, stream_anthropic_response_with_tracking, stream_response_translated,
 };
 use super::translate_request::translate_request_anthropic_to_openai;
 use super::translate_response::{build_transformer_chain, translate_response_openai_to_anthropic};
@@ -419,15 +419,42 @@ pub(super) fn build_anthropic_headers(
     provider: &crate::config::Provider,
 ) -> Result<reqwest::header::HeaderMap, TryRequestError> {
     let mut headers = reqwest::header::HeaderMap::new();
-    headers.insert(
-        "x-api-key",
-        provider
-            .api_key
-            .parse()
-            .map_err(|e: reqwest::header::InvalidHeaderValue| {
-                TryRequestError::Other(anyhow::anyhow!("{}", e))
-            })?,
-    );
+    match provider
+        .auth_header
+        .as_deref()
+        .unwrap_or("x-api-key")
+        .trim()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "x-api-key" => {
+            headers.insert(
+                "x-api-key",
+                provider
+                    .api_key
+                    .parse()
+                    .map_err(|e: reqwest::header::InvalidHeaderValue| {
+                        TryRequestError::Other(anyhow::anyhow!("{}", e))
+                    })?,
+            );
+        }
+        "authorization" | "bearer" | "authorization-bearer" => {
+            headers.insert(
+                "Authorization",
+                format!("Bearer {}", provider.api_key).parse().map_err(
+                    |e: reqwest::header::InvalidHeaderValue| {
+                        TryRequestError::Other(anyhow::anyhow!("{}", e))
+                    },
+                )?,
+            );
+        }
+        other => {
+            return Err(TryRequestError::Other(anyhow::anyhow!(
+                "Unsupported Anthropic auth_header '{}'",
+                other
+            )));
+        }
+    }
     headers.insert(
         "anthropic-version",
         provider
@@ -863,7 +890,25 @@ pub(super) async fn try_request_via_anthropic_protocol(
             }
         }
 
-        if let Ok(anthropic_resp) = serde_json::from_slice::<AnthropicResponse>(&body) {
+        let transformed_response_value = match serde_json::from_slice::<serde_json::Value>(&body) {
+            Ok(response_value) if !chain.is_empty() => Some(
+                chain
+                    .apply_response(response_value)
+                    .map_err(TryRequestError::Other)?,
+            ),
+            Ok(response_value) => Some(response_value),
+            Err(_) => None,
+        };
+
+        if let Some(response_value) = transformed_response_value {
+            let anthropic_resp = match serde_json::from_value::<AnthropicResponse>(response_value) {
+                Ok(response) => response,
+                Err(_) => {
+                    let mut response = (status, body).into_response();
+                    insert_ccr_tier_header(&mut response, tier_name);
+                    return Ok(response);
+                }
+            };
             // Estimate tokens when provider returns zeros (common for some Anthropic-compatible APIs)
             let mut input_tokens = anthropic_resp.usage.input_tokens;
             let mut output_tokens = anthropic_resp.usage.output_tokens;
@@ -903,19 +948,8 @@ pub(super) async fn try_request_via_anthropic_protocol(
             record_usage(tier_name, input_tokens, output_tokens, 0, 0);
             verify_token_usage(tier_name, local_estimate, input_tokens);
 
-            let final_resp = if chain.is_empty() {
-                anthropic_resp
-            } else {
-                let resp_value = serde_json::to_value(&anthropic_resp)
-                    .map_err(|e| TryRequestError::Other(e.into()))?;
-                let transformed = chain
-                    .apply_response(resp_value)
-                    .map_err(TryRequestError::Other)?;
-                serde_json::from_value::<AnthropicResponse>(transformed).unwrap_or(anthropic_resp)
-            };
-
-            let response_body =
-                serde_json::to_vec(&final_resp).map_err(|e| TryRequestError::Other(e.into()))?;
+            let response_body = serde_json::to_vec(&anthropic_resp)
+                .map_err(|e| TryRequestError::Other(e.into()))?;
             let mut response = (StatusCode::OK, response_body).into_response();
             insert_ccr_tier_header(&mut response, tier_name);
             return Ok(response);
@@ -924,5 +958,41 @@ pub(super) async fn try_request_via_anthropic_protocol(
         let mut response = (status, body).into_response();
         insert_ccr_tier_header(&mut response, tier_name);
         Ok(response)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Provider;
+
+    fn anthropic_provider(auth_header: Option<&str>) -> Provider {
+        let mut value = serde_json::json!({
+            "name": "test-anthropic",
+            "api_base_url": "https://api.example.test/anthropic/v1",
+            "api_key": "ak-test",
+            "models": ["model-v1"],
+            "protocol": "anthropic"
+        });
+        if let Some(header) = auth_header {
+            value["auth_header"] = serde_json::Value::String(header.to_string());
+        }
+        serde_json::from_value(value).expect("provider config should parse")
+    }
+
+    #[test]
+    fn anthropic_headers_default_to_x_api_key() {
+        let headers = build_anthropic_headers(&anthropic_provider(None)).unwrap();
+
+        assert_eq!(headers.get("x-api-key").unwrap(), "ak-test");
+        assert!(headers.get("authorization").is_none());
+    }
+
+    #[test]
+    fn anthropic_headers_can_use_bearer_authorization() {
+        let headers = build_anthropic_headers(&anthropic_provider(Some("authorization"))).unwrap();
+
+        assert_eq!(headers.get("authorization").unwrap(), "Bearer ak-test");
+        assert!(headers.get("x-api-key").is_none());
     }
 }

--- a/src/transform/registry.rs
+++ b/src/transform/registry.rs
@@ -10,7 +10,7 @@ use super::{
     OutputCompressTransformer, ThinkTagTransformer, ToolCompressTransformer,
 };
 use crate::config::TransformerEntry;
-use crate::transformer::{Transformer, TransformerChain};
+use crate::transformer::{LongCatThinkingTransformer, Transformer, TransformerChain};
 use std::collections::HashMap;
 use tracing::{debug, info, warn};
 
@@ -47,6 +47,10 @@ impl TransformerRegistry {
         }
         // Tier 7: DeepSeek Reasoner
         registry.register("deepseek", |_opts| Box::new(DeepSeekTransformer));
+        // LongCat thinking emits unsigned thinking blocks; normalize them.
+        registry.register("longcat-thinking", |_opts| {
+            Box::new(LongCatThinkingTransformer)
+        });
 
         // Format conversion transformers
         registry.register("anthropic", |_opts| Box::new(AnthropicToOpenaiTransformer));
@@ -110,7 +114,10 @@ impl TransformerRegistry {
             if let Some(transformer) = self.build(entry) {
                 chain = chain.with_transformer(std::sync::Arc::from(transformer));
             } else {
-                warn!(transformer = entry.name(), "skipping unregistered transformer");
+                warn!(
+                    transformer = entry.name(),
+                    "skipping unregistered transformer"
+                );
             }
         }
         info!(chain_len = chain.len(), "transformer chain built");
@@ -147,12 +154,13 @@ mod tests {
     fn registry_new_registers_provider_transformers() {
         let registry = TransformerRegistry::new();
         assert!(!registry.is_empty());
-        assert_eq!(registry.len(), 11);
+        assert_eq!(registry.len(), 12);
         assert!(registry.has("zai"));
         assert!(registry.has("minimax"));
         assert!(registry.has("moonshot"));
         assert!(registry.has("kimi"));
         assert!(registry.has("deepseek"));
+        assert!(registry.has("longcat-thinking"));
         assert!(registry.has("anthropic"));
         assert!(registry.has("openai-to-anthropic"));
         assert!(registry.has("maxtoken"));

--- a/src/transformer/builtin.rs
+++ b/src/transformer/builtin.rs
@@ -4,8 +4,8 @@
 //! These transformers handle format conversions between various LLM API formats
 //! (Anthropic ↔ OpenAI), token limits, reasoning tags, and tool metadata.
 
-use super::uuid_nopanic;
 use super::Transformer;
+use super::uuid_nopanic;
 use anyhow::Result;
 use regex::Regex;
 use serde_json::Value;
@@ -450,6 +450,63 @@ impl Transformer for ThinkTagTransformer {
                 }
             }
         }
+        Ok(response)
+    }
+}
+
+/// LongCat thinking response normalizer.
+///
+/// LongCat's thinking model returns Anthropic-style `thinking` content blocks
+/// without Anthropic's signed `signature` field. CCR-Rust cannot forward those
+/// as real thinking blocks to Anthropic clients, and the OpenAI compatibility
+/// layer cannot deserialize them before converting to `choices[]`. Preserve
+/// normal text/tool output and only turn thinking into text when it is the only
+/// useful content returned by the model.
+#[derive(Debug, Clone)]
+pub struct LongCatThinkingTransformer;
+
+impl Transformer for LongCatThinkingTransformer {
+    fn name(&self) -> &str {
+        "longcat-thinking"
+    }
+
+    fn transform_response(&self, mut response: Value) -> Result<Value> {
+        let Some(content_array) = response.get_mut("content").and_then(|c| c.as_array_mut()) else {
+            return Ok(response);
+        };
+
+        let has_non_thinking = content_array.iter().any(|block| {
+            block.get("type").and_then(|block_type| block_type.as_str()) != Some("thinking")
+        });
+        let original_blocks = std::mem::take(content_array);
+        let mut normalized_blocks = Vec::with_capacity(original_blocks.len());
+
+        for block in original_blocks {
+            let is_unsigned_thinking = block.get("type").and_then(|block_type| block_type.as_str())
+                == Some("thinking")
+                && block.get("signature").is_none();
+
+            if !is_unsigned_thinking {
+                normalized_blocks.push(block);
+                continue;
+            }
+
+            if has_non_thinking {
+                continue;
+            }
+
+            if let Some(thinking) = block.get("thinking").and_then(|value| value.as_str()) {
+                let text = thinking.trim();
+                if !text.is_empty() {
+                    normalized_blocks.push(serde_json::json!({
+                        "type": "text",
+                        "text": text
+                    }));
+                }
+            }
+        }
+
+        *content_array = normalized_blocks;
         Ok(response)
     }
 }

--- a/src/transformer/mod.rs
+++ b/src/transformer/mod.rs
@@ -253,6 +253,7 @@ impl TransformerRegistry {
         registry.register("reasoning", Arc::new(ReasoningTransformer));
         registry.register("enhancetool", Arc::new(EnhanceToolTransformer));
         registry.register("thinktag", Arc::new(ThinkTagTransformer));
+        registry.register("longcat-thinking", Arc::new(LongCatThinkingTransformer));
         registry.register("glm", Arc::new(GlmTransformer::default()));
         registry.register("kimi", Arc::new(KimiTransformer));
         registry.register("toolcompress", Arc::new(ToolCompressTransformer::default()));
@@ -509,6 +510,50 @@ mod tests {
             "Should strip think content"
         );
         assert!(text.contains("Before") && text.contains("After"));
+    }
+
+    #[test]
+    fn longcat_thinking_converts_thinking_only_response_to_text() {
+        let transformer = LongCatThinkingTransformer;
+        let response = serde_json::json!({
+            "id": "msg_1",
+            "type": "message",
+            "role": "assistant",
+            "model": "LongCat-Flash-Thinking-2601",
+            "content": [
+                {"type": "thinking", "thinking": "Need a final answer."}
+            ],
+            "stop_reason": "max_tokens",
+            "usage": {"input_tokens": 3, "output_tokens": 5}
+        });
+
+        let result = transformer.transform_response(response).unwrap();
+
+        assert_eq!(result["content"][0]["type"], "text");
+        assert_eq!(result["content"][0]["text"], "Need a final answer.");
+        assert!(result["content"][0].get("signature").is_none());
+    }
+
+    #[test]
+    fn longcat_thinking_drops_unsigned_thinking_when_tool_use_exists() {
+        let transformer = LongCatThinkingTransformer;
+        let response = serde_json::json!({
+            "content": [
+                {"type": "thinking", "thinking": "I should call a tool."},
+                {
+                    "type": "tool_use",
+                    "id": "call_1",
+                    "name": "Bash",
+                    "input": {"command": "pwd"}
+                }
+            ]
+        });
+
+        let result = transformer.transform_response(response).unwrap();
+        let blocks = result["content"].as_array().unwrap();
+
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0]["type"], "tool_use");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- normalize provider transform routing for the expanded CCR provider lanes
- support LongCat thinking response normalization and Wafer model lanes used by AlphaHENG

## Validation
- Covered by AlphaHENG root protocol/provider tests and local branch checks.