### PR TITLE
Fix ccr-rust openssl Dependabot alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,10 +36,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Security dependency refresh** — Pinned `openssl` to `0.10.79`, `rand`
+- **Security dependency refresh** — Pinned `openssl` to `0.10.80`, `rand`
   to `0.8.6`, and upgraded `ratatui` to `0.30.0` so the router lockfile can
   resolve away from the current Dependabot advisories affecting `openssl`,
-  `rand`, and transitive `lru` usage.
+  `rand`, and transitive `lru` usage, including the follow-up AES-KW-PAD
+  `CipherCtxRef::cipher_update_inplace` advisory.
 
 - **Codex Responses token limit routing** — `/v1/responses` requests now map
   `max_output_tokens` to OpenAI chat-compatible `max_completion_tokens` instead

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,7 +554,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2354,9 +2354,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
-version = "0.10.79"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
@@ -4903,7 +4903,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ lazy_static = "1.4"
 log = "0.4"
 num_cpus = "1.16"
 once_cell = "1.19"
-openssl = "=0.10.79"                                                # CVE-2026-42327, CVE-2026-44662, CVE-2026-41676, CVE-2026-41677, CVE-2026-41678, CVE-2026-41898, CVE-2026-41681
+openssl = "=0.10.80"                                                # CVE-2026-42327, CVE-2026-44662, CVE-2026-45784, CVE-2026-41676, CVE-2026-41677, CVE-2026-41678, CVE-2026-41898, CVE-2026-41681
 parking_lot = "0.12"
 prometheus = "0.14"                                                 # CVE-2025-53605: requires protobuf >=3.7.2
 rand = "=0.8.6"                                                     # GHSA-cq8v-f236-94qc


### PR DESCRIPTION
## Summary
- pin `openssl` to `0.10.80` for the new follow-up security advisory
- refresh `Cargo.lock` to the patched openssl release
- update the changelog to record the added advisory coverage

## Validation
- `cargo update -p openssl --precise 0.10.80`
- `cargo check`
- `cargo test`
- `cargo install --path . --force`