### PR TITLE
Make config.example.json valid JSON

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -68,9 +68,7 @@
                 ]
             },
             "tier_name": "ccr-qwen"
-        },
-
-        
+        }
     ],
     "Router": {
         "default": "wafer,Qwen3.5-397B-A17B",


### PR DESCRIPTION
## Summary

- Remove the trailing comma after the final provider entry in `config.example.json`.
- Make the starter config parse correctly when copied into `~/.claude-code-router/config.json`.
- Keep the documented setup flow consistent with `README.md` and `AGENTS.md`, both of which direct users to this example file.

## Testing

- `python3 -m json.tool config.example.json`
- Confirmed the committed `HEAD:config.example.json` is invalid JSON while the branch version parses cleanly.

## Risk

- Low.
- Limited to the example config file used for onboarding/setup.
- No routing logic, runtime behavior, dependencies, or Rust source files changed.
