### PR TITLE
feat: make AUTO routing cost-aware and standalone

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,13 +30,15 @@ For a clean local setup:
 Important files and areas:
 
 - `src/main.rs` — CLI entry point.
-- `src/config.rs` — configuration parsing and provider protocol definitions.
+- `src/config/` — configuration parsing, pricing, and provider protocol definitions.
 - `src/router/` — HTTP handlers, dispatch, request translation, response translation, and streaming.
+- `src/gp_router.rs` — request-aware GP reranking and credible-set cost ordering.
 - `src/frontend/` — client-format normalization.
 - `src/transform/` and `src/transformer.rs` — transformer implementations and registry plumbing.
 - `src/metrics/` — Prometheus metrics and persistence.
 - `src/mcp/` — MCP server and tool-catalog handling.
 - `src/ratelimit.rs` — provider backoff logic.
+- `vendor/gp-routing/` — pinned Apache-2.0 GP surrogate source used by standard builds.
 - `tests/` — integration coverage.
 
 ## Working Rules
@@ -48,6 +50,12 @@ Keep these invariants intact:
 - Keep frontend detection and serialization aligned when adding client-specific behavior.
 - Use environment-backed config placeholders instead of embedding secrets.
 - Preserve the existing rate-limit and retry model unless the change is explicitly about routing semantics.
+- Treat 429s as tracked failures: stop retries for that tier, continue to later eligible tiers, and synthesize a 429 only when every candidate is rate-limited.
+- When direct or search routing pins entries at the front, update `pinned_prefix_len`; GP reranking must never move the pinned prefix.
+- When `AppState` gains a field, update every integration-test helper that constructs it directly.
+- Keep `vendor/gp-routing/NOTICE` accurate when modifying the vendored encoder or surrogate boundary.
+- Keep the optional sindexer Git revision pinned to a reviewed public commit;
+  standalone CCR-Rust clones must not require an adjacent repository.
 
 ## Common Change Patterns
 
@@ -65,7 +73,7 @@ For new CLI commands:
 
 ## Validation Expectations
 
-Run at least the relevant unit or integration tests for the area you changed. For routing, translation, or config work, `cargo test` is usually the minimum acceptable validation path.
+Run at least the relevant unit or integration tests for the area you changed. For routing, translation, or config work, `cargo test --all-features` is usually the minimum acceptable validation path. Changes under `vendor/gp-routing/` also run that package's own tests.
 
 Integration tests use mocked upstreams, so prefer updating those over inventing ad hoc manual checks.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **GP configuration validation** — Reject invalid KPLS dimensions during
+  startup validation and before fitting so bad configuration cannot trigger
+  repeated failed refits.
+
 - **MiniMax structured reasoning handling** — The `minimax` transformer now correctly extracts
   and normalizes reasoning content from MiniMax-M3's structured `reasoning_content` array
   format (returned by the OpenAI-compatible endpoint) into plain text for consistent handling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Self-contained GP routing** — Vendored the Apache-2.0 `gp-routing` crate at
+  its pinned upstream commit so public builds no longer require access to a
+  private repository.
+- **Standalone sindexer dependency** — Pin the optional MIT-licensed sindexer
+  integration to its public Git commit so CCR-Rust builds no longer require a
+  sibling checkout.
+- **Provider and model pricing** — Added optional USD-per-million input/output
+  pricing with model-specific overrides and continuous per-request cost
+  features for GP routing.
+
 - **Z.AI GLM-5.2 with reasoning_effort** — Added GLM-5.2 model with configurable
   `reasoning_effort` parameter (`low`, `medium`, `high`). The `glm` transformer now
   injects `reasoning_effort=medium` by default for GLM-5.2/5.1/5-turbo models, enabling
@@ -34,6 +44,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `anthropic-beta`, `anthropic-version`) to ensure clean upstream requests.
 
 ### Changed
+
+- **GP routing enabled in standard builds** — Added `gp` to the default feature
+  set, expanded the encoder and default candidate limit from 8 to 32 routes,
+  and reject GP-enabled configuration when using an explicitly GP-free build.
+- **Uncertainty-respecting cost ordering** — Cheaper routes are promoted only
+  inside the GP posterior quality credible set, avoiding an arbitrary scalar
+  exchange rate between predicted quality and dollars.
 
 - **Default coding model** — Changed default routing from `glm-5.1` to `glm-5.2` for improved
   reasoning and coding performance with configurable reasoning effort.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **GP configuration validation** — Reject invalid KPLS dimensions during
   startup validation and before fitting so bad configuration cannot trigger
-  repeated failed refits.
+  repeated failed refits, and cap public backend-ranking inputs to the fixed
+  32-slot feature capacity.
 
 - **MiniMax structured reasoning handling** — The `minimax` transformer now correctly extracts
   and normalizes reasoning content from MiniMax-M3's structured `reasoning_content` array

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,6 +424,7 @@ dependencies = [
  "env_logger",
  "flate2",
  "futures",
+ "gp-routing",
  "hex",
  "http-body-util",
  "humantime",
@@ -540,6 +559,12 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cobyla"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d7c3233e5d400a8fd61b50b79797d28a0657e4c0abeb41469b69d2d9d60ef3e"
 
 [[package]]
 name = "colorchoice"
@@ -865,6 +890,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,6 +984,49 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "egobox-doe"
+version = "0.35.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9ddce3a7359210f081222e953c3b9bb5ae5c9a0dbd1827fa9cd158370e6584"
+dependencies = [
+ "linfa",
+ "ndarray",
+ "ndarray-rand",
+ "ndarray-stats",
+ "num-traits",
+ "rand_xoshiro",
+ "rayon",
+]
+
+[[package]]
+name = "egobox-gp"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2b43b656b7aa1e3da5f373e68e77d4efb141791a1c0d46180d7ce7638538efa"
+dependencies = [
+ "anyhow",
+ "cobyla",
+ "egobox-doe",
+ "finitediff",
+ "linfa",
+ "linfa-linalg",
+ "linfa-pls",
+ "log",
+ "ndarray",
+ "ndarray-einsum",
+ "ndarray-npy",
+ "ndarray-rand",
+ "ndarray-stats",
+ "num-traits",
+ "paste",
+ "rand_xoshiro",
+ "rayon",
+ "serde",
+ "thiserror 2.0.18",
+ "typetag",
+]
 
 [[package]]
 name = "either"
@@ -1092,6 +1171,17 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "finitediff"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb08005ceda20e36d233b60fe476059cc9efe6ebd125f3a72b69729dbae0e794"
+dependencies = [
+ "anyhow",
+ "ndarray",
+ "num",
+]
 
 [[package]]
 name = "finl_unicode"
@@ -1340,6 +1430,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "gp-routing"
+version = "0.1.0"
+dependencies = [
+ "egobox-gp",
+ "linfa",
+ "ndarray",
+ "parking_lot",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1400,6 +1504,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -1851,6 +1957,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1977,6 +2092,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1992,6 +2113,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "linfa"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87b84e47ca7a9d63f5be24c104e216c8263bfada38080cbdfe1082e611a81fd3"
+dependencies = [
+ "approx",
+ "ndarray",
+ "num-traits",
+ "rand 0.8.6",
+ "serde",
+ "sprs",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "linfa-linalg"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02a834c0ec063937688a0d13573aa515ab8c425bd8de3154b908dd3b9c197dc4"
+dependencies = [
+ "ndarray",
+ "num-traits",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "linfa-pls"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "962eef849bea0fa6fd7ba512159c41f890d42ad780ca59ba2f59bc0d7d98fe96"
+dependencies = [
+ "linfa",
+ "linfa-linalg",
+ "ndarray",
+ "ndarray-rand",
+ "ndarray-stats",
+ "num-traits",
+ "paste",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2078,6 +2241,16 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
 
 [[package]]
 name = "measure_time"
@@ -2176,6 +2349,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndarray"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+ "rayon",
+ "serde",
+]
+
+[[package]]
+name = "ndarray-einsum"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4b2d52dfff9b24d072b6080eab1587cbd54ae24da7b8370072c3a84db221e05"
+dependencies = [
+ "hashbrown 0.15.5",
+ "lazy_static",
+ "ndarray",
+ "num-traits",
+ "regex",
+]
+
+[[package]]
+name = "ndarray-npy"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b313788c468c49141a9d9b6131fc15f403e6ef4e8446a0b2e18f664ddb278a9"
+dependencies = [
+ "byteorder",
+ "ndarray",
+ "num-complex",
+ "num-traits",
+ "py_literal",
+ "zip",
+]
+
+[[package]]
+name = "ndarray-rand"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f093b3db6fd194718dcdeea6bd8c829417deae904e3fcc7732dabcd4416d25d8"
+dependencies = [
+ "ndarray",
+ "rand 0.8.6",
+ "rand_distr",
+]
+
+[[package]]
+name = "ndarray-stats"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ebbe97acce52d06aebed4cd4a87c0941f4b2519b59b82b4feb5bd0ce003dfd"
+dependencies = [
+ "indexmap",
+ "itertools 0.13.0",
+ "ndarray",
+ "noisy_float",
+ "num-integer",
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2186,6 +2430,15 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "noisy_float"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c16843be85dd410c6a12251c4eca0dd1d3ee8c5725f746c4d5e0fdcec0a864b2"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2301,6 +2554,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2456,6 +2710,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -2712,6 +2972,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "py_literal"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "102df7a3d46db9d3891f178dcc826dc270a6746277a9ae6436f8d29fd490a8e1"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-traits",
+ "pest",
+ "pest_derive",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2847,6 +3120,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core 0.6.4",
+ "serde",
+]
+
+[[package]]
 name = "ratatui"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2946,6 +3239,12 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width",
 ]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
@@ -3513,6 +3812,7 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 [[package]]
 name = "sindexer"
 version = "0.1.0"
+source = "git+https://github.com/RESMP-DEV/rust_sindexer.git?rev=b7c8d998732b8325b59aa2ca9fbde643c898da78#b7c8d998732b8325b59aa2ca9fbde643c898da78"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -3605,6 +3905,18 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "sprs"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704ef26d974e8a452313ed629828cd9d4e4fa34667ca1ad9d6b1fffa43c6e166"
+dependencies = [
+ "ndarray",
+ "num-complex",
+ "num-traits",
+ "smallvec",
 ]
 
 [[package]]
@@ -5359,10 +5671,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,8 @@ dirs = "6"
 env_logger = "0.11"
 flate2 = "1.0"
 futures = "0.3"
-sindexer = { path = "../rust_sindexer", default-features = false, optional = true }
+gp-routing = { path = "vendor/gp-routing", optional = true }
+sindexer = { git = "https://github.com/RESMP-DEV/rust_sindexer.git", rev = "b7c8d998732b8325b59aa2ca9fbde643c898da78", default-features = false, optional = true }
 hex = "0.4"
 humantime = "2"
 jsonschema = "0.29"
@@ -66,9 +67,9 @@ name = "concurrent_streams"
 harness = false
 
 [features]
-default = ["dashboard", "sindexer"]
+default = ["dashboard", "gp", "sindexer"]
 dashboard = ["reqwest/blocking"]
-gp = []
+gp = ["dep:gp-routing"]
 sindexer = ["dep:sindexer"]
 
 [profile.release]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,6 +59,16 @@ See [Gemini Integration](gemini-integration.md) for detailed security guidance.
       "api_base_url": "https://api.example.com/v1/chat/completions",
       "api_key": "sk-...",
       "models": ["model-a", "model-b"],
+      "pricing": {
+        "input_per_million_tokens": 1.0,
+        "output_per_million_tokens": 4.0
+      },
+      "model_pricing": {
+        "model-b": {
+          "input_per_million_tokens": 3.0,
+          "output_per_million_tokens": 12.0
+        }
+      },
       "transformer": {
         "use": ["transformer-name"],
         "model-specific": { "use": ["override-transformer"] }
@@ -69,6 +79,11 @@ See [Gemini Integration](gemini-integration.md) for detailed security guidance.
     "default": "provider,model",
     "background": "provider,model",
     "think": "provider,model",
+    "gpRouting": {
+      "enabled": true,
+      "maxCandidates": 32,
+      "acquisition": "ucb"
+    },
     "webSearch": "provider,model",
     "tierRetries": {
       "tier-0": {
@@ -99,7 +114,35 @@ Each provider entry configures an upstream API endpoint.
 | `api_base_url` | string | Yes | - | Full URL to the API endpoint. |
 | `api_key` | string | Yes | - | API key for authentication. |
 | `models` | array | Yes | - | List of model names available from this provider. |
+| `pricing` | object | No | - | Provider-default input/output prices in USD per million tokens. |
+| `model_pricing` | object | No | - | Model-keyed price overrides using the same two rate fields. |
 | `transformer` | object | No | - | Request/response transformation configuration. |
+
+### Provider and Model Pricing
+
+Pricing is optional. When configured, both `input_per_million_tokens` and
+`output_per_million_tokens` are required. A `model_pricing` entry overrides the
+provider default for that model:
+
+```json
+{
+  "pricing": {
+    "input_per_million_tokens": 1.0,
+    "output_per_million_tokens": 4.0
+  },
+  "model_pricing": {
+    "premium-model": {
+      "input_per_million_tokens": 3.0,
+      "output_per_million_tokens": 12.0
+    }
+  }
+}
+```
+
+CCR-Rust estimates pre-dispatch cost from the request input estimate and the
+configured output-token budget. The continuous feature is normalized relative
+to the priced candidates in that request. Missing pricing remains explicitly
+unknown; it is never treated as free.
 
 ### Provider Transformer Configuration
 
@@ -163,6 +206,20 @@ The `Router` section configures how incoming requests are routed to providers.
 | `tierRetries` | object | No | - | Per-tier retry configuration. |
 | `forceNonStreaming` | boolean | No | false | Disable streaming for agent workloads. |
 | `ignoreDirect` | boolean | No | false | Ignore client model targeting, enforce tier order. |
+| `gpRouting` | object | No | disabled | GP-backed request-aware tier reranking. |
+
+### Cost-Aware GP Routing
+
+The standard CCR-Rust build includes GP support. Set `gpRouting.enabled` to
+activate it. The encoder supports up to 32 configured provider/model routes;
+routes beyond that bound remain available in their configured fallback order.
+
+Cost does not use a fixed scalar penalty. CCR-Rust first forms a posterior
+quality credible set: a candidate remains eligible when its upper confidence
+bound overlaps the best candidate's lower confidence bound. It then prefers
+lower estimated cost only within that statistically indistinguishable set. If
+any credible candidate lacks pricing, acquisition order is retained for the
+whole set so incomplete metadata cannot bias routing.
 
 ### Route Format
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -382,8 +382,40 @@ mod tests {
         assert_eq!(p.protocol, ProviderProtocol::Openai);
         assert!(p.anthropic_version.is_none());
         assert!(p.transformer.is_none());
+        assert!(p.pricing.is_none());
+        assert!(p.model_pricing.is_empty());
         assert!(p.provider_transformers().is_empty());
         assert!(p.model_transformers("qwen2.5-coder:latest").is_none());
+    }
+
+    #[test]
+    fn provider_pricing_parses_with_model_override() {
+        let p = parse_provider(
+            r#"{
+                "name": "priced",
+                "api_base_url": "https://example.test/v1",
+                "api_key": "x",
+                "models": ["economy", "premium"],
+                "pricing": {
+                    "input_per_million_tokens": 1.25,
+                    "output_per_million_tokens": 5.0
+                },
+                "model_pricing": {
+                    "premium": {
+                        "input_per_million_tokens": 3.0,
+                        "output_per_million_tokens": 15.0
+                    }
+                }
+            }"#,
+        );
+
+        let economy = p.pricing_for_model("economy").expect("provider pricing");
+        assert_eq!(economy.input_per_million_tokens, 1.25);
+        assert_eq!(economy.output_per_million_tokens, 5.0);
+
+        let premium = p.pricing_for_model("premium").expect("model pricing");
+        assert_eq!(premium.input_per_million_tokens, 3.0);
+        assert_eq!(premium.output_per_million_tokens, 15.0);
     }
 
     #[test]

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -200,12 +200,53 @@ impl<'de> Deserialize<'de> for ProviderTransformer {
     }
 }
 
+/// Token pricing for a provider or model override, in USD per million tokens.
+///
+/// Pricing is optional at the provider level. When supplied, both rates are
+/// explicit so cost comparisons never silently treat a missing component as
+/// free. A model-specific entry takes precedence over the provider default.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+pub struct ModelPricing {
+    #[serde(alias = "inputPerMillionTokens")]
+    pub input_per_million_tokens: f64,
+
+    #[serde(alias = "outputPerMillionTokens")]
+    pub output_per_million_tokens: f64,
+}
+
+impl ModelPricing {
+    /// Estimate the request cost for the supplied token counts.
+    /// Invalid negative or non-finite rates are treated as unpriced.
+    pub fn estimate_request_cost_usd(&self, input_tokens: u64, output_tokens: u64) -> Option<f64> {
+        if !self.input_per_million_tokens.is_finite()
+            || !self.output_per_million_tokens.is_finite()
+            || self.input_per_million_tokens < 0.0
+            || self.output_per_million_tokens < 0.0
+        {
+            return None;
+        }
+
+        let estimated = (input_tokens as f64 * self.input_per_million_tokens
+            + output_tokens as f64 * self.output_per_million_tokens)
+            / 1_000_000.0;
+        estimated.is_finite().then_some(estimated)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Provider {
     pub name: String,
     pub api_base_url: String,
     pub api_key: String,
     pub models: Vec<String>,
+
+    /// Default token pricing for this provider.
+    #[serde(default)]
+    pub pricing: Option<ModelPricing>,
+
+    /// Optional model-specific token pricing overrides.
+    #[serde(default, alias = "modelPricing")]
+    pub model_pricing: HashMap<String, ModelPricing>,
 
     /// Upstream API protocol for this provider.
     ///
@@ -261,6 +302,11 @@ fn default_honor_ratelimit_headers() -> bool {
 }
 
 impl Provider {
+    /// Resolve model-specific pricing, falling back to the provider default.
+    pub fn pricing_for_model(&self, model: &str) -> Option<&ModelPricing> {
+        self.model_pricing.get(model).or(self.pricing.as_ref())
+    }
+
     /// Get the provider-level transformer chain, or an empty slice if none.
     pub fn provider_transformers(&self) -> &[TransformerEntry] {
         self.transformer
@@ -651,7 +697,9 @@ fn default_redis_prefix() -> String {
 }
 
 fn default_gp_max_candidates() -> usize {
-    8
+    // Matches the vendored GP encoder's bounded backend capacity. Keeping this
+    // literal here avoids making config parsing depend on the optional crate.
+    32
 }
 
 fn default_gp_buffer_capacity() -> usize {
@@ -793,7 +841,7 @@ mod backoff_tests {
         .expect("parse RouterConfig");
 
         assert!(!router.gp_routing.enabled);
-        assert_eq!(router.gp_routing.max_candidates, 8);
+        assert_eq!(router.gp_routing.max_candidates, 32);
         assert_eq!(router.gp_routing.acquisition, GpAcquisitionStrategy::Ucb);
     }
 

--- a/src/debug_capture.rs
+++ b/src/debug_capture.rs
@@ -306,7 +306,7 @@ impl DebugCapture {
             })
             .collect();
 
-        files_with_time.sort_by(|a, b| a.1.cmp(&b.1));
+        files_with_time.sort_by_key(|entry| entry.1);
 
         // Delete oldest files
         let to_delete = files_with_time.len() - self.config.max_files;

--- a/src/gp_router.rs
+++ b/src/gp_router.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 use chrono::Timelike;
 use gp_routing::features::BACKEND_SLOTS;
-use gp_routing::{thompson_sample, ucb_score, FeatureVector, GpRoutingConfig, GpSurrogate, ObservationBuffer};
+use gp_routing::{
+    thompson_sample, ucb_score, FeatureVector, GpRoutingConfig, GpSurrogate, ObservationBuffer,
+};
 use parking_lot::Mutex;
 use rand::Rng;
 use std::cmp::Ordering as CmpOrdering;
@@ -24,11 +26,20 @@ pub struct GpRequestRouter {
 pub struct GpRoutingPlan {
     pub ordered: Vec<(String, String)>,
     request_features: RequestFeatureContext,
+    tier_costs: HashMap<String, TierCostEstimate>,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct TierCostEstimate {
+    usd: Option<f64>,
+    relative: Option<f32>,
 }
 
 #[derive(Clone, Debug)]
 struct RequestFeatureContext {
     prompt_chars: usize,
+    estimated_input_tokens: u64,
+    max_output_tokens: u64,
     request_class: u8,
     has_system_prompt: bool,
     message_count: usize,
@@ -40,8 +51,11 @@ struct RequestFeatureContext {
 
 impl RequestFeatureContext {
     fn from_request(request: &AnthropicRequest, active_streams: usize, max_streams: usize) -> Self {
+        let prompt_chars = prompt_chars(request);
         Self {
-            prompt_chars: prompt_chars(request),
+            prompt_chars,
+            estimated_input_tokens: estimate_input_tokens(prompt_chars),
+            max_output_tokens: request.max_tokens.map_or(0, u64::from),
             request_class: classify_request(request),
             has_system_prompt: request.system.is_some(),
             message_count: request.messages.len(),
@@ -51,6 +65,17 @@ impl RequestFeatureContext {
             hour_of_day: chrono::Local::now().hour(),
         }
     }
+}
+
+#[derive(Clone, Debug)]
+struct ScoredCandidate {
+    canonical_index: usize,
+    entry: (String, String),
+    acquisition_score: f32,
+    mean: f32,
+    variance: f32,
+    estimated_cost_usd: Option<f64>,
+    credible: bool,
 }
 
 impl GpRequestRouter {
@@ -75,10 +100,10 @@ impl GpRequestRouter {
             .build();
 
         if canonical_tiers.len() > BACKEND_SLOTS {
-            info!(
+            warn!(
                 configured_tiers = canonical_tiers.len(),
                 gp_slots = BACKEND_SLOTS,
-                "gp-routing will learn only the first configured backend slots"
+                "configured tiers exceed the bounded GP feature capacity; tail tiers remain in fallback order"
             );
         }
 
@@ -100,11 +125,14 @@ impl GpRequestRouter {
         max_streams: usize,
         pinned_prefix_len: usize,
     ) -> GpRoutingPlan {
-        let request_features = RequestFeatureContext::from_request(request, active_streams, max_streams);
+        let request_features =
+            RequestFeatureContext::from_request(request, active_streams, max_streams);
+        let tier_costs = estimate_tier_costs(ordered, &request_features, config);
         if !self.surrogate.is_fitted() {
             return GpRoutingPlan {
                 ordered: ordered.to_vec(),
                 request_features,
+                tier_costs,
             };
         }
 
@@ -122,6 +150,7 @@ impl GpRequestRouter {
             return GpRoutingPlan {
                 ordered: ordered.to_vec(),
                 request_features,
+                tier_costs,
             };
         }
 
@@ -142,33 +171,42 @@ impl GpRequestRouter {
             .enumerate()
             .filter_map(|(candidate_idx, pos)| {
                 let entry = ordered.get(*pos)?.clone();
-                let features = self.build_features(&request_features, &entry.0, 0, config)?;
+                let tier_cost = tier_costs.get(&entry.0).copied().unwrap_or_default();
+                let features =
+                    self.build_features(&request_features, &entry.0, 0, tier_cost.relative)?;
                 let (mean, variance) = self.surrogate.predict(&features);
                 let score = self.score_candidate(mean, variance, candidate_idx, epsilon_pick);
-                Some((candidate_idx, entry, score, mean, variance))
+                Some(ScoredCandidate {
+                    canonical_index: candidate_idx,
+                    entry,
+                    acquisition_score: score,
+                    mean,
+                    variance,
+                    estimated_cost_usd: tier_cost.usd,
+                    credible: false,
+                })
             })
             .collect::<Vec<_>>();
 
-        scored.sort_by(|left, right| {
-            right
-                .2
-                .partial_cmp(&left.2)
-                .unwrap_or(CmpOrdering::Equal)
-                .then_with(|| left.0.cmp(&right.0))
-        });
+        credible_set_cost_order(&mut scored, self.runtime_config.ucb_kappa);
 
         let mut reranked = ordered.to_vec();
-        for (pos, (_, entry, _, _, _)) in candidate_positions.iter().zip(scored.iter()) {
-            reranked[*pos] = entry.clone();
+        for (pos, candidate) in candidate_positions.iter().zip(scored.iter()) {
+            reranked[*pos] = candidate.entry.clone();
         }
 
         if reranked != ordered {
             let scored_log = scored
                 .iter()
-                .map(|(_, (_, tier_name), score, mean, variance)| {
+                .map(|candidate| {
                     format!(
-                        "{}(score={:.3}, mean={:.3}, var={:.3})",
-                        tier_name, score, mean, variance
+                        "{}(score={:.3}, mean={:.3}, var={:.3}, cost={:?}, credible={})",
+                        candidate.entry.1,
+                        candidate.acquisition_score,
+                        candidate.mean,
+                        candidate.variance,
+                        candidate.estimated_cost_usd,
+                        candidate.credible,
                     )
                 })
                 .collect::<Vec<_>>();
@@ -184,6 +222,7 @@ impl GpRequestRouter {
         GpRoutingPlan {
             ordered: reranked,
             request_features,
+            tier_costs,
         }
     }
 
@@ -193,9 +232,12 @@ impl GpRequestRouter {
         tier: &str,
         attempt: usize,
         duration_secs: Option<f64>,
-        config: &Config,
+        _config: &Config,
     ) {
-        let Some(features) = self.build_features(&plan.request_features, tier, attempt, config) else {
+        let relative_cost = plan.tier_costs.get(tier).and_then(|cost| cost.relative);
+        let Some(features) =
+            self.build_features(&plan.request_features, tier, attempt, relative_cost)
+        else {
             return;
         };
 
@@ -231,13 +273,15 @@ impl GpRequestRouter {
         request_features: &RequestFeatureContext,
         tier: &str,
         attempt: usize,
-        config: &Config,
+        relative_cost: Option<f32>,
     ) -> Option<FeatureVector> {
         let backend_index = *self.backend_indices.get(tier)?;
-        let total_capacity = normalize_capacity(request_features.max_streams, request_features.active_streams);
+        let total_capacity = normalize_capacity(
+            request_features.max_streams,
+            request_features.active_streams,
+        );
         let clamped_active = request_features.active_streams.min(total_capacity);
         let idle_capacity = total_capacity.saturating_sub(clamped_active);
-        let cost_tier = is_paid_tier(config, tier);
 
         Some(
             FeatureVector::builder()
@@ -254,7 +298,7 @@ impl GpRequestRouter {
                 .in_flight_ratio(clamped_active, total_capacity)
                 .hour_of_day(request_features.hour_of_day)
                 .loop_count(request_features.tool_count)
-                .cost_tier(cost_tier)
+                .relative_cost(relative_cost)
                 .build(),
         )
     }
@@ -299,8 +343,14 @@ fn prompt_chars(request: &AnthropicRequest) -> usize {
 
 fn classify_request(request: &AnthropicRequest) -> u8 {
     let streaming = request.stream.unwrap_or(false);
-    let tool_heavy = request.tools.as_ref().is_some_and(|tools| !tools.is_empty())
-        || request.messages.iter().any(|message| message.role == "tool");
+    let tool_heavy = request
+        .tools
+        .as_ref()
+        .is_some_and(|tools| !tools.is_empty())
+        || request
+            .messages
+            .iter()
+            .any(|message| message.role == "tool");
 
     match (streaming, tool_heavy) {
         (false, false) => 0,
@@ -318,15 +368,121 @@ fn normalize_capacity(max_streams: usize, active_streams: usize) -> usize {
     }
 }
 
-fn is_paid_tier(config: &Config, tier: &str) -> bool {
-    config.resolve_provider(tier).is_none_or(|provider| {
-        let name = provider.name.to_ascii_lowercase();
-        let url = provider.api_base_url.to_ascii_lowercase();
-        !(name.contains("ollama")
-            || name.contains("local")
-            || url.contains("localhost")
-            || url.contains("127.0.0.1"))
-    })
+/// Approximate input tokens before dispatch. This matches the existing CCR
+/// fallback convention of four UTF-8 bytes per token and is used only for
+/// relative cost ranking; authoritative usage still comes from the provider.
+fn estimate_input_tokens(prompt_chars: usize) -> u64 {
+    (prompt_chars.saturating_add(3) / 4) as u64
+}
+
+fn estimate_tier_costs(
+    ordered: &[(String, String)],
+    request: &RequestFeatureContext,
+    config: &Config,
+) -> HashMap<String, TierCostEstimate> {
+    let absolute = ordered
+        .iter()
+        .map(|(tier, _)| {
+            let usd = tier
+                .split_once(',')
+                .and_then(|(_, model)| {
+                    config
+                        .resolve_provider(tier)
+                        .and_then(|provider| provider.pricing_for_model(model))
+                })
+                .and_then(|pricing| {
+                    pricing.estimate_request_cost_usd(
+                        request.estimated_input_tokens,
+                        request.max_output_tokens,
+                    )
+                });
+            (tier.clone(), usd)
+        })
+        .collect::<Vec<_>>();
+
+    let max_cost = absolute
+        .iter()
+        .filter_map(|(_, cost)| *cost)
+        .fold(0.0_f64, f64::max);
+
+    absolute
+        .into_iter()
+        .map(|(tier, usd)| {
+            let relative = usd.map(|cost| {
+                if max_cost > 0.0 {
+                    (cost / max_cost).clamp(0.0, 1.0) as f32
+                } else {
+                    0.0
+                }
+            });
+            (tier, TierCostEstimate { usd, relative })
+        })
+        .collect()
+}
+
+/// Apply a quality-credible-set then cost-lexicographic ordering.
+///
+/// The best posterior lower confidence bound defines the quality bar. Any
+/// candidate whose upper confidence bound overlaps that bar remains credible;
+/// only within that statistically indistinguishable set do we prefer lower
+/// estimated cost. This avoids an arbitrary scalar exchange rate between model
+/// quality and dollars. If any credible candidate is unpriced, the entire set
+/// retains acquisition ordering so missing metadata never masquerades as free.
+fn credible_set_cost_order(candidates: &mut [ScoredCandidate], kappa: f32) {
+    if candidates.is_empty() {
+        return;
+    }
+
+    let confidence = kappa.max(0.0);
+    let best_lower_bound = candidates
+        .iter()
+        .map(|candidate| candidate.mean - confidence * candidate.variance.max(0.0).sqrt())
+        .fold(f32::NEG_INFINITY, f32::max);
+
+    for candidate in candidates.iter_mut() {
+        let upper_bound = candidate.mean + confidence * candidate.variance.max(0.0).sqrt();
+        candidate.credible = upper_bound >= best_lower_bound;
+    }
+
+    let credible_count = candidates
+        .iter()
+        .filter(|candidate| candidate.credible)
+        .count();
+    let cost_comparable = credible_count > 1
+        && candidates
+            .iter()
+            .filter(|candidate| candidate.credible)
+            .all(|candidate| candidate.estimated_cost_usd.is_some());
+
+    candidates.sort_by(|left, right| {
+        right
+            .credible
+            .cmp(&left.credible)
+            .then_with(|| {
+                if left.credible && right.credible && cost_comparable {
+                    left.estimated_cost_usd
+                        .expect("cost-comparable candidates are priced")
+                        .partial_cmp(
+                            &right
+                                .estimated_cost_usd
+                                .expect("cost-comparable candidates are priced"),
+                        )
+                        .unwrap_or(CmpOrdering::Equal)
+                } else {
+                    right
+                        .acquisition_score
+                        .partial_cmp(&left.acquisition_score)
+                        .unwrap_or(CmpOrdering::Equal)
+                }
+            })
+            .then_with(|| {
+                right
+                    .acquisition_score
+                    .partial_cmp(&left.acquisition_score)
+                    .unwrap_or(CmpOrdering::Equal)
+            })
+            .then_with(|| left.canonical_index.cmp(&right.canonical_index))
+    });
 }
 
 fn outcome_score(duration_secs: Option<f64>) -> f32 {
@@ -358,8 +514,11 @@ mod tests {
             }
         });
         let temp = tempfile::NamedTempFile::new().expect("temp config file");
-        fs::write(temp.path(), serde_json::to_vec(&raw).expect("serialize config"))
-            .expect("write config file");
+        fs::write(
+            temp.path(),
+            serde_json::to_vec(&raw).expect("serialize config"),
+        )
+        .expect("write config file");
         Config::from_file(temp.path().to_str().expect("config path"))
             .expect("load Config from file")
     }
@@ -401,5 +560,146 @@ mod tests {
         assert_eq!(outcome_score(None), 0.0);
         assert_eq!(outcome_score(Some(-1.0)), 0.0);
         assert!(outcome_score(Some(0.5)) > outcome_score(Some(3.0)));
+    }
+
+    #[test]
+    fn pricing_math_uses_input_and_output_rates() {
+        let pricing = crate::config::ModelPricing {
+            input_per_million_tokens: 1.5,
+            output_per_million_tokens: 6.0,
+        };
+
+        let cost = pricing
+            .estimate_request_cost_usd(2_000, 500)
+            .expect("valid pricing");
+        assert!((cost - 0.006).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn gp_encoder_covers_thirty_two_candidates_and_leaves_tail_in_fallback() {
+        let tiers = (0..33)
+            .map(|idx| format!("mock,m{idx}"))
+            .collect::<Vec<_>>();
+        let router = GpRequestRouter::new(GpRoutingRuntimeConfig::default(), &tiers);
+
+        assert_eq!(router.backend_indices.len(), 32);
+        assert_eq!(router.model_config.n_backends, 32);
+        let request_features = RequestFeatureContext::from_request(&sample_request(), 0, 16);
+        let features = router
+            .build_features(&request_features, "mock,m31", 0, Some(0.5))
+            .expect("last bounded backend has a feature slot");
+        let tail_index = gp_routing::features::BACKEND_START + 31;
+        assert_eq!(features.as_array()[tail_index], 1.0);
+        assert!(router
+            .build_features(&request_features, "mock,m32", 0, Some(0.5))
+            .is_none());
+    }
+
+    #[test]
+    fn relative_costs_are_continuous_per_request() {
+        let raw = json!({
+            "Providers": [{
+                "name": "mock",
+                "api_base_url": "https://example.test/v1",
+                "api_key": "x",
+                "models": ["cheap", "expensive"],
+                "pricing": {
+                    "input_per_million_tokens": 1.0,
+                    "output_per_million_tokens": 2.0
+                },
+                "model_pricing": {
+                    "expensive": {
+                        "input_per_million_tokens": 10.0,
+                        "output_per_million_tokens": 20.0
+                    }
+                }
+            }],
+            "Router": {
+                "default": "mock,cheap",
+                "tiers": ["mock,cheap", "mock,expensive"]
+            }
+        });
+        let temp = tempfile::NamedTempFile::new().expect("temp config file");
+        fs::write(
+            temp.path(),
+            serde_json::to_vec(&raw).expect("serialize config"),
+        )
+        .expect("write config file");
+        let config =
+            Config::from_file(temp.path().to_str().expect("config path")).expect("load config");
+        let ordered = vec![
+            ("mock,cheap".to_string(), "cheap".to_string()),
+            ("mock,expensive".to_string(), "expensive".to_string()),
+        ];
+        let request = RequestFeatureContext::from_request(&sample_request(), 0, 16);
+        let costs = estimate_tier_costs(&ordered, &request, &config);
+
+        assert!((costs["mock,cheap"].relative.expect("priced") - 0.1).abs() < 1e-6);
+        assert_eq!(costs["mock,expensive"].relative, Some(1.0));
+        assert!(costs["mock,cheap"].usd < costs["mock,expensive"].usd);
+    }
+
+    #[test]
+    fn cost_orders_candidates_only_inside_quality_credible_set() {
+        let mut candidates = vec![
+            ScoredCandidate {
+                canonical_index: 0,
+                entry: ("mock,expensive".to_string(), "expensive".to_string()),
+                acquisition_score: 0.81,
+                mean: 0.70,
+                variance: 0.04,
+                estimated_cost_usd: Some(0.10),
+                credible: false,
+            },
+            ScoredCandidate {
+                canonical_index: 1,
+                entry: ("mock,cheap".to_string(), "cheap".to_string()),
+                acquisition_score: 0.79,
+                mean: 0.69,
+                variance: 0.04,
+                estimated_cost_usd: Some(0.001),
+                credible: false,
+            },
+        ];
+
+        credible_set_cost_order(&mut candidates, 2.0);
+        assert_eq!(candidates[0].entry.1, "cheap");
+
+        candidates[0].mean = 0.20;
+        candidates[0].variance = 0.0001;
+        candidates[0].acquisition_score = 0.22;
+        candidates[1].mean = 0.90;
+        candidates[1].variance = 0.0001;
+        candidates[1].acquisition_score = 0.92;
+        credible_set_cost_order(&mut candidates, 2.0);
+        assert_eq!(candidates[0].entry.1, "expensive");
+    }
+
+    #[test]
+    fn mixed_pricing_preserves_acquisition_order_inside_credible_set() {
+        let mut candidates = vec![
+            ScoredCandidate {
+                canonical_index: 0,
+                entry: ("mock,priced".to_string(), "priced".to_string()),
+                acquisition_score: 0.81,
+                mean: 0.70,
+                variance: 0.04,
+                estimated_cost_usd: Some(0.10),
+                credible: false,
+            },
+            ScoredCandidate {
+                canonical_index: 1,
+                entry: ("mock,unknown".to_string(), "unknown".to_string()),
+                acquisition_score: 0.79,
+                mean: 0.69,
+                variance: 0.04,
+                estimated_cost_usd: None,
+                credible: false,
+            },
+        ];
+
+        credible_set_cost_order(&mut candidates, 2.0);
+        assert_eq!(candidates[0].entry.1, "priced");
+        assert!(candidates.iter().all(|candidate| candidate.credible));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -351,6 +351,7 @@ async fn run_server(
     shutdown_timeout: u64,
 ) -> anyhow::Result<()> {
     let config = Config::from_file(config_path)?;
+    ensure_gp_build_support(&config)?;
     tracing::info!("Loaded config from {}", config_path);
     tracing::info!("Tier order: {:?}", config.backend_tiers());
     tracing::info!("Max concurrent streams: {}", max_streams);
@@ -444,6 +445,7 @@ fn validate_config(config_path: &str) -> anyhow::Result<()> {
     println!("Validating: {}", config_path);
 
     let config = Config::from_file(config_path)?;
+    ensure_gp_build_support(&config)?;
 
     let providers = config.providers();
     println!("✓ {} provider(s)", providers.len());
@@ -458,6 +460,18 @@ fn validate_config(config_path: &str) -> anyhow::Result<()> {
     }
 
     println!("\n✓ Configuration valid");
+    Ok(())
+}
+
+fn ensure_gp_build_support(config: &Config) -> anyhow::Result<()> {
+    #[cfg(not(feature = "gp"))]
+    if config.router().gp_routing.enabled {
+        anyhow::bail!(
+            "Router.gpRouting.enabled=true requires a CCR-Rust build with the `gp` feature"
+        );
+    }
+
+    let _ = config;
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -471,7 +471,25 @@ fn ensure_gp_build_support(config: &Config) -> anyhow::Result<()> {
         );
     }
 
+    #[cfg(feature = "gp")]
+    if config.router().gp_routing.enabled {
+        validate_gp_runtime_config(&config.router().gp_routing)?;
+    }
+
     let _ = config;
+    Ok(())
+}
+
+#[cfg(feature = "gp")]
+fn validate_gp_runtime_config(config: &config::GpRoutingRuntimeConfig) -> anyhow::Result<()> {
+    if let Some(kpls_dim) = config.kpls_dim {
+        let feature_dim = gp_routing::features::FEATURE_DIM;
+        if kpls_dim == 0 || kpls_dim > feature_dim {
+            anyhow::bail!(
+                "Router.gpRouting.kplsDim must be between 1 and {feature_dim}; got {kpls_dim}"
+            );
+        }
+    }
     Ok(())
 }
 
@@ -683,5 +701,27 @@ async fn debug_capture_stats(State(state): State<AppState>) -> impl axum::respon
         None => axum::Json(serde_json::json!({
             "error": "Debug capture not enabled"
         })),
+    }
+}
+
+#[cfg(all(test, feature = "gp"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gp_runtime_validation_rejects_invalid_kpls_dimensions() {
+        for kpls_dim in [0, gp_routing::features::FEATURE_DIM + 1] {
+            let config = config::GpRoutingRuntimeConfig {
+                kpls_dim: Some(kpls_dim),
+                ..Default::default()
+            };
+            assert!(validate_gp_runtime_config(&config).is_err());
+        }
+
+        let config = config::GpRoutingRuntimeConfig {
+            kpls_dim: Some(gp_routing::features::FEATURE_DIM),
+            ..Default::default()
+        };
+        assert!(validate_gp_runtime_config(&config).is_ok());
     }
 }

--- a/vendor/gp-routing/.gitignore
+++ b/vendor/gp-routing/.gitignore
@@ -1,0 +1,2 @@
+/target/
+/Cargo.lock

--- a/vendor/gp-routing/Cargo.toml
+++ b/vendor/gp-routing/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "gp-routing"
+version = "0.1.0"
+edition = "2021"
+authors = ["RESMP-DEV"]
+license = "Apache-2.0"
+description = "Gaussian Process surrogate for LLM backend routing and load balancing"
+repository = "https://github.com/RESMP-DEV/gp-routing"
+readme = "README.md"
+keywords = ["gaussian-process", "routing", "load-balancing", "bayesian", "llm"]
+categories = ["algorithms", "science"]
+
+[dependencies]
+egobox-gp = { version = "0.36", features = ["serializable"] }
+linfa = "0.8"
+ndarray = { version = "0.16", features = ["serde"] }
+parking_lot = "0.12"
+rand = "0.8"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tracing = "0.1"
+
+[dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
+approx = "0.5"
+
+[[bench]]
+name = "fit_predict"
+harness = false

--- a/vendor/gp-routing/LICENSE
+++ b/vendor/gp-routing/LICENSE
@@ -1,0 +1,53 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work.
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+(a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work; and
+
+(d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+8. Limitation of Liability. In no event and under no legal theory shall any Contributor be liable to You for damages arising in any way out of the use of the Work.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer support, warranty, indemnity, or other liability obligations, but only on Your own behalf and on Your sole responsibility.
+
+END OF TERMS AND CONDITIONS

--- a/vendor/gp-routing/NOTICE
+++ b/vendor/gp-routing/NOTICE
@@ -1,0 +1,16 @@
+gp-routing
+Copyright RESMP-DEV
+
+This product includes software developed in the RESMP-DEV/gp-routing project:
+https://github.com/RESMP-DEV/gp-routing
+
+Vendored from commit e471cba9816fe44b2d17a8136f124a8acb41e4b2.
+
+Modified by CCR-Rust:
+- increased the one-hot backend capacity from 8 to 32;
+- updated the fixed feature dimension and downstream indices accordingly;
+- changed the binary paid/free feature into a continuous relative request-cost
+  feature in the inclusive range 0.0 through 1.0, accompanied by an explicit
+  pricing-known bit so missing prices are not learned as free;
+- normalized formatting in `src/acquisition.rs` and `src/ring_buffer.rs`
+  without changing their behavior.

--- a/vendor/gp-routing/README.md
+++ b/vendor/gp-routing/README.md
@@ -1,0 +1,13 @@
+# Vendored gp-routing
+
+This directory contains a source snapshot of
+[RESMP-DEV/gp-routing](https://github.com/RESMP-DEV/gp-routing) at commit
+`e471cba9816fe44b2d17a8136f124a8acb41e4b2`.
+
+The upstream crate is licensed under Apache-2.0. CCR-Rust vendors it so public
+downstream builds do not depend on a private Git repository.
+
+CCR-Rust modifies the upstream feature encoder to support 32 backend slots and
+a continuous relative request-cost feature. See `NOTICE` for the exact local
+changes. The vendored crate remains a separate package and retains its upstream
+name, authorship, repository metadata, and license.

--- a/vendor/gp-routing/benches/fit_predict.rs
+++ b/vendor/gp-routing/benches/fit_predict.rs
@@ -1,0 +1,116 @@
+// Modified for CCR-Rust: benchmark the continuous relative-cost feature.
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use gp_routing::{FeatureVector, GpRoutingConfig, GpSurrogate, ObservationBuffer};
+use rand::Rng;
+
+fn random_feature(rng: &mut impl Rng, backend_idx: usize, n_backends: usize) -> FeatureVector {
+    FeatureVector::builder()
+        .prompt_length(rng.gen_range(32..16_384))
+        .priority(rng.gen_range(0..4) as u8)
+        .has_verify(rng.gen_bool(0.5))
+        .dependency_count(rng.gen_range(0..12))
+        .retry_count(rng.gen_range(0..20))
+        .backend_index(backend_idx, n_backends)
+        .idle_ratio(rng.gen_range(0..8), 8)
+        .in_flight_ratio(rng.gen_range(0..8), 8)
+        .hour_of_day(rng.gen_range(0..24) as u32)
+        .loop_count(rng.gen_range(0..4))
+        .relative_cost(Some(rng.gen_range(0.0..=1.0)))
+        .build()
+}
+
+fn build_buffer(n: usize, n_backends: usize) -> ObservationBuffer {
+    let mut rng = rand::thread_rng();
+    let mut buffer = ObservationBuffer::new(n.max(1));
+    for sample in 0..n {
+        let backend = sample % n_backends.max(1);
+        let feature = random_feature(&mut rng, backend, n_backends);
+        let outcome = rng.gen::<f32>();
+        buffer.push(feature, outcome);
+    }
+    buffer
+}
+
+fn fit_surrogate(n: usize) -> GpSurrogate {
+    let config = GpRoutingConfig::builder()
+        .buffer_capacity(n.max(32))
+        .min_observations(10)
+        .n_backends(4)
+        .build();
+    let surrogate = GpSurrogate::new(config);
+    let buffer = build_buffer(n, 4);
+    surrogate.fit(&buffer).expect("benchmark surrogate fit");
+    surrogate
+}
+
+fn bench_predict_single(c: &mut Criterion) {
+    let surrogate = fit_surrogate(200);
+    let mut rng = rand::thread_rng();
+    let feature = random_feature(&mut rng, 1, 4);
+
+    c.bench_function("bench_predict_single", |b| {
+        b.iter(|| surrogate.predict(black_box(&feature)))
+    });
+}
+
+fn bench_predict_batch_10(c: &mut Criterion) {
+    let surrogate = fit_surrogate(200);
+    let mut rng = rand::thread_rng();
+    let batch: Vec<_> = (0..10)
+        .map(|idx| random_feature(&mut rng, idx % 4, 4))
+        .collect();
+
+    c.bench_function("bench_predict_batch_10", |b| {
+        b.iter(|| surrogate.predict_batch(black_box(&batch)))
+    });
+}
+
+fn bench_fit_100(c: &mut Criterion) {
+    c.bench_function("bench_fit_100", |b| {
+        b.iter(|| {
+            let config = GpRoutingConfig::builder()
+                .buffer_capacity(100)
+                .min_observations(10)
+                .n_backends(4)
+                .build();
+            let surrogate = GpSurrogate::new(config);
+            let buffer = build_buffer(100, 4);
+            surrogate.fit(black_box(&buffer)).expect("fit 100");
+        })
+    });
+}
+
+fn bench_fit_500(c: &mut Criterion) {
+    c.bench_function("bench_fit_500", |b| {
+        b.iter(|| {
+            let config = GpRoutingConfig::builder()
+                .buffer_capacity(500)
+                .min_observations(10)
+                .n_backends(4)
+                .build();
+            let surrogate = GpSurrogate::new(config);
+            let buffer = build_buffer(500, 4);
+            surrogate.fit(black_box(&buffer)).expect("fit 500");
+        })
+    });
+}
+
+fn bench_feature_build(c: &mut Criterion) {
+    let mut rng = rand::thread_rng();
+    c.bench_function("bench_feature_build", |b| {
+        b.iter(|| {
+            let backend = rng.gen_range(0..4);
+            random_feature(black_box(&mut rng), backend, 4)
+        })
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_predict_single,
+    bench_predict_batch_10,
+    bench_fit_100,
+    bench_fit_500,
+    bench_feature_build
+);
+criterion_main!(benches);

--- a/vendor/gp-routing/src/acquisition.rs
+++ b/vendor/gp-routing/src/acquisition.rs
@@ -1,5 +1,5 @@
 // Modified for CCR-Rust: rustfmt normalization only; behavior is unchanged.
-use crate::features::FeatureVector;
+use crate::features::{FeatureVector, BACKEND_SLOTS};
 use crate::surrogate::GpSurrogate;
 use rand::Rng;
 use std::cmp::Ordering;
@@ -47,6 +47,7 @@ pub fn rank_backends(
     n_backends: usize,
     strategy: AcquisitionStrategy,
 ) -> Vec<(usize, f32)> {
+    let n_backends = n_backends.min(BACKEND_SLOTS);
     debug!(n_backends, ?strategy, "ranking backends");
     if n_backends == 0 {
         return Vec::new();

--- a/vendor/gp-routing/src/acquisition.rs
+++ b/vendor/gp-routing/src/acquisition.rs
@@ -1,0 +1,104 @@
+// Modified for CCR-Rust: rustfmt normalization only; behavior is unchanged.
+use crate::features::FeatureVector;
+use crate::surrogate::GpSurrogate;
+use rand::Rng;
+use std::cmp::Ordering;
+use std::f32::consts::TAU;
+use tracing::{debug, info};
+
+/// Strategies for turning GP posteriors into routing scores.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum AcquisitionStrategy {
+    /// Upper confidence bound.
+    Ucb { kappa: f32 },
+    /// Thompson sampling with one posterior draw per backend.
+    Thompson,
+    /// Pure exploitation.
+    Greedy,
+    /// Greedy with occasional random promotion.
+    EpsilonGreedy { epsilon: f32 },
+}
+
+/// Upper confidence bound score.
+#[must_use]
+pub fn ucb_score(mean: f32, variance: f32, kappa: f32) -> f32 {
+    mean + kappa.max(0.0) * variance.max(0.0).sqrt()
+}
+
+/// Draw a Thompson sample from `N(mean, variance)`.
+#[must_use]
+pub fn thompson_sample(mean: f32, variance: f32, rng: &mut impl rand::Rng) -> f32 {
+    let variance = variance.max(0.0);
+    if variance == 0.0 {
+        return mean;
+    }
+
+    let u1 = rng.gen::<f32>().max(f32::MIN_POSITIVE);
+    let u2 = rng.gen::<f32>();
+    let z0 = (-2.0 * u1.ln()).sqrt() * (TAU * u2).cos();
+    mean + variance.sqrt() * z0
+}
+
+/// Score every backend by mutating the backend one-hot slice of `base_features`.
+#[must_use]
+pub fn rank_backends(
+    surrogate: &GpSurrogate,
+    base_features: &FeatureVector,
+    n_backends: usize,
+    strategy: AcquisitionStrategy,
+) -> Vec<(usize, f32)> {
+    debug!(n_backends, ?strategy, "ranking backends");
+    if n_backends == 0 {
+        return Vec::new();
+    }
+
+    let mut rng = rand::thread_rng();
+    let epsilon_pick = match strategy {
+        AcquisitionStrategy::EpsilonGreedy { epsilon } => {
+            let epsilon = epsilon.clamp(0.0, 1.0);
+            if rng.gen::<f32>() < epsilon {
+                Some(rng.gen_range(0..n_backends))
+            } else {
+                None
+            }
+        }
+        _ => None,
+    };
+
+    let mut scored = Vec::with_capacity(n_backends);
+    for backend_idx in 0..n_backends {
+        let features = base_features.with_backend_index(backend_idx, n_backends);
+        let (mean, variance) = surrogate.predict(&features);
+        let score = match strategy {
+            AcquisitionStrategy::Ucb { kappa } => ucb_score(mean, variance, kappa),
+            AcquisitionStrategy::Thompson => thompson_sample(mean, variance, &mut rng),
+            AcquisitionStrategy::Greedy => mean,
+            AcquisitionStrategy::EpsilonGreedy { .. } => {
+                if epsilon_pick == Some(backend_idx) {
+                    mean + 2.0
+                } else {
+                    mean
+                }
+            }
+        };
+        scored.push((backend_idx, score));
+    }
+
+    scored.sort_by(|left, right| {
+        right
+            .1
+            .partial_cmp(&left.1)
+            .unwrap_or(Ordering::Equal)
+            .then_with(|| left.0.cmp(&right.0))
+    });
+    if let Some((best_idx, best_score)) = scored.first() {
+        info!(
+            best_backend = best_idx,
+            best_score,
+            n_backends,
+            ?strategy,
+            "backend ranking complete"
+        );
+    }
+    scored
+}

--- a/vendor/gp-routing/src/config.rs
+++ b/vendor/gp-routing/src/config.rs
@@ -1,6 +1,6 @@
 // Modified for CCR-Rust: derive the input dimension from the expanded local
 // feature layout instead of the upstream 22-dimensional prototype constant.
-use crate::features::FEATURE_DIM;
+use crate::features::{BACKEND_SLOTS, FEATURE_DIM};
 use serde::{Deserialize, Serialize};
 use tracing::info;
 
@@ -126,7 +126,7 @@ impl GpRoutingConfigBuilder {
 
     #[must_use]
     pub fn n_backends(mut self, n_backends: usize) -> Self {
-        self.config.n_backends = n_backends;
+        self.config.n_backends = n_backends.min(BACKEND_SLOTS);
         self
     }
 

--- a/vendor/gp-routing/src/config.rs
+++ b/vendor/gp-routing/src/config.rs
@@ -1,0 +1,145 @@
+// Modified for CCR-Rust: derive the input dimension from the expanded local
+// feature layout instead of the upstream 22-dimensional prototype constant.
+use crate::features::FEATURE_DIM;
+use serde::{Deserialize, Serialize};
+use tracing::info;
+
+/// Configuration for the GP routing surrogate.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct GpRoutingConfig {
+    /// Number of input features in the feature vector.
+    /// Default: [`FEATURE_DIM`].
+    pub input_dim: usize,
+    /// Maximum observations to retain in the ring buffer.
+    pub buffer_capacity: usize,
+    /// Minimum observations before GP fitting is attempted.
+    pub min_observations: usize,
+    /// Number of requests between automatic refits. `0` disables auto-refit.
+    pub refit_interval: usize,
+    /// UCB exploration weight.
+    pub ucb_kappa: f32,
+    /// Nugget (jitter) for numerical stability.
+    pub nugget: f32,
+    /// Optional KPLS dimension reduction.
+    pub kpls_dim: Option<usize>,
+    /// Prior mean returned when the GP is unfitted.
+    pub prior_mean: f32,
+    /// Prior variance returned when the GP is unfitted.
+    pub prior_variance: f32,
+    /// Number of backends in the target router.
+    pub n_backends: usize,
+}
+
+impl Default for GpRoutingConfig {
+    fn default() -> Self {
+        Self {
+            input_dim: FEATURE_DIM,
+            buffer_capacity: 500,
+            min_observations: 40,
+            refit_interval: 200,
+            ucb_kappa: 2.0,
+            nugget: 1e-4,
+            kpls_dim: None,
+            prior_mean: 0.5,
+            prior_variance: 0.25,
+            n_backends: 11,
+        }
+    }
+}
+
+impl GpRoutingConfig {
+    /// Create a builder seeded with [`Default`] values.
+    #[must_use]
+    pub fn builder() -> GpRoutingConfigBuilder {
+        GpRoutingConfigBuilder::default()
+    }
+}
+
+/// Builder for [`GpRoutingConfig`].
+#[derive(Debug, Clone)]
+pub struct GpRoutingConfigBuilder {
+    config: GpRoutingConfig,
+}
+
+impl Default for GpRoutingConfigBuilder {
+    fn default() -> Self {
+        Self {
+            config: GpRoutingConfig::default(),
+        }
+    }
+}
+
+impl GpRoutingConfigBuilder {
+    #[must_use]
+    pub fn input_dim(mut self, input_dim: usize) -> Self {
+        self.config.input_dim = input_dim;
+        self
+    }
+
+    #[must_use]
+    pub fn buffer_capacity(mut self, buffer_capacity: usize) -> Self {
+        self.config.buffer_capacity = buffer_capacity;
+        self
+    }
+
+    #[must_use]
+    pub fn min_observations(mut self, min_observations: usize) -> Self {
+        self.config.min_observations = min_observations;
+        self
+    }
+
+    #[must_use]
+    pub fn refit_interval(mut self, refit_interval: usize) -> Self {
+        self.config.refit_interval = refit_interval;
+        self
+    }
+
+    #[must_use]
+    pub fn ucb_kappa(mut self, ucb_kappa: f32) -> Self {
+        self.config.ucb_kappa = ucb_kappa;
+        self
+    }
+
+    #[must_use]
+    pub fn nugget(mut self, nugget: f32) -> Self {
+        self.config.nugget = nugget;
+        self
+    }
+
+    #[must_use]
+    pub fn kpls_dim(mut self, kpls_dim: Option<usize>) -> Self {
+        self.config.kpls_dim = kpls_dim;
+        self
+    }
+
+    #[must_use]
+    pub fn prior_mean(mut self, prior_mean: f32) -> Self {
+        self.config.prior_mean = prior_mean;
+        self
+    }
+
+    #[must_use]
+    pub fn prior_variance(mut self, prior_variance: f32) -> Self {
+        self.config.prior_variance = prior_variance;
+        self
+    }
+
+    #[must_use]
+    pub fn n_backends(mut self, n_backends: usize) -> Self {
+        self.config.n_backends = n_backends;
+        self
+    }
+
+    #[must_use]
+    pub fn build(self) -> GpRoutingConfig {
+        info!(
+            n_backends = self.config.n_backends,
+            buffer_capacity = self.config.buffer_capacity,
+            min_observations = self.config.min_observations,
+            refit_interval = self.config.refit_interval,
+            kpls_dim = ?self.config.kpls_dim,
+            "gp-routing config built"
+        );
+        self.config
+    }
+}

--- a/vendor/gp-routing/src/features.rs
+++ b/vendor/gp-routing/src/features.rs
@@ -1,0 +1,232 @@
+// Modified for CCR-Rust: support 32 backend slots and encode continuous
+// relative request cost in place of the upstream paid/free bit.
+use ndarray::Array1;
+use serde::{Deserialize, Serialize};
+use std::f32::consts::PI;
+use tracing::debug;
+
+pub const PROMPT_LEN_INDEX: usize = 0;
+pub const PRIORITY_START: usize = 1;
+pub const PRIORITY_SLOTS: usize = 4;
+pub const HAS_VERIFY_INDEX: usize = 5;
+pub const DEP_COUNT_INDEX: usize = 6;
+pub const RETRY_COUNT_INDEX: usize = 7;
+pub const BACKEND_START: usize = 8;
+/// One-hot capacity for configured provider/model routes.
+///
+/// Thirty-two slots provide bounded growth room for larger routing catalogs
+/// while keeping the GP input dimension fixed.
+pub const BACKEND_SLOTS: usize = 32;
+pub const IDLE_RATIO_INDEX: usize = BACKEND_START + BACKEND_SLOTS;
+pub const IN_FLIGHT_RATIO_INDEX: usize = IDLE_RATIO_INDEX + 1;
+pub const HOUR_SIN_INDEX: usize = IN_FLIGHT_RATIO_INDEX + 1;
+pub const HOUR_COS_INDEX: usize = HOUR_SIN_INDEX + 1;
+pub const LOOP_COUNT_INDEX: usize = HOUR_COS_INDEX + 1;
+pub const RELATIVE_COST_INDEX: usize = LOOP_COUNT_INDEX + 1;
+pub const COST_KNOWN_INDEX: usize = RELATIVE_COST_INDEX + 1;
+pub const FEATURE_DIM: usize = COST_KNOWN_INDEX + 1;
+
+fn clip_unit(value: f32) -> f32 {
+    value.clamp(0.0, 1.0)
+}
+
+/// Fixed-size routing feature vector.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct FeatureVector(Array1<f32>);
+
+impl FeatureVector {
+    /// Start a builder using zero-initialized features.
+    #[must_use]
+    pub fn builder() -> FeatureVectorBuilder {
+        FeatureVectorBuilder::default()
+    }
+
+    /// Borrow the underlying feature array.
+    #[must_use]
+    pub fn as_array(&self) -> &Array1<f32> {
+        &self.0
+    }
+
+    /// Return the static feature dimension.
+    #[must_use]
+    pub fn dim() -> usize {
+        FEATURE_DIM
+    }
+
+    /// Clone this feature vector and update only the backend one-hot slice.
+    #[must_use]
+    pub fn with_backend_index(&self, idx: usize, n_backends: usize) -> Self {
+        let mut data = self.0.clone();
+        for slot in BACKEND_START..(BACKEND_START + BACKEND_SLOTS) {
+            data[slot] = 0.0;
+        }
+        if idx < n_backends && idx < BACKEND_SLOTS {
+            data[BACKEND_START + idx] = 1.0;
+        }
+        Self(data)
+    }
+}
+
+/// Builder for [`FeatureVector`].
+#[derive(Clone, Debug, Default)]
+pub struct FeatureVectorBuilder {
+    prompt_len: f32,
+    priority_0: f32,
+    priority_1: f32,
+    priority_2: f32,
+    priority_3: f32,
+    has_verify: f32,
+    dep_count: f32,
+    retry_count: f32,
+    backend: [f32; BACKEND_SLOTS],
+    idle_ratio: f32,
+    in_flight_ratio: f32,
+    hour_sin: f32,
+    hour_cos: f32,
+    loop_count: f32,
+    relative_cost: f32,
+    cost_known: f32,
+}
+
+impl FeatureVectorBuilder {
+    /// Log-scale prompt length and clip it to the unit interval.
+    #[must_use]
+    pub fn prompt_length(mut self, chars: usize) -> Self {
+        let value = (usize::max(chars, 1) as f32).ln() / 18.0;
+        self.prompt_len = clip_unit(value);
+        self
+    }
+
+    /// One-hot encode a priority in the range `0..=3`.
+    #[must_use]
+    pub fn priority(mut self, p: u8) -> Self {
+        self.priority_0 = 0.0;
+        self.priority_1 = 0.0;
+        self.priority_2 = 0.0;
+        self.priority_3 = 0.0;
+        match p {
+            0 => self.priority_0 = 1.0,
+            1 => self.priority_1 = 1.0,
+            2 => self.priority_2 = 1.0,
+            3 => self.priority_3 = 1.0,
+            _ => {}
+        }
+        self
+    }
+
+    /// Encode whether a task provides an explicit verify command.
+    #[must_use]
+    pub fn has_verify(mut self, value: bool) -> Self {
+        self.has_verify = if value { 1.0 } else { 0.0 };
+        self
+    }
+
+    /// Normalize dependency count into `[0, 1]`.
+    #[must_use]
+    pub fn dependency_count(mut self, n: usize) -> Self {
+        self.dep_count = clip_unit((n.min(10) as f32) / 10.0);
+        self
+    }
+
+    /// Normalize retry count into `[0, 1]`.
+    #[must_use]
+    pub fn retry_count(mut self, n: usize) -> Self {
+        self.retry_count = clip_unit((n.min(18) as f32) / 18.0);
+        self
+    }
+
+    /// One-hot encode the backend index over [`BACKEND_SLOTS`] slots.
+    #[must_use]
+    pub fn backend_index(mut self, idx: usize, n_backends: usize) -> Self {
+        self.backend.fill(0.0);
+        if idx < n_backends && idx < BACKEND_SLOTS {
+            self.backend[idx] = 1.0;
+        }
+        self
+    }
+
+    /// Encode the ratio of idle workers to total workers.
+    #[must_use]
+    pub fn idle_ratio(mut self, idle: usize, total: usize) -> Self {
+        let total = total.max(1) as f32;
+        self.idle_ratio = clip_unit((idle as f32) / total);
+        self
+    }
+
+    /// Encode the ratio of in-flight tasks to total workers.
+    #[must_use]
+    pub fn in_flight_ratio(mut self, in_flight: usize, total: usize) -> Self {
+        let total = total.max(1) as f32;
+        self.in_flight_ratio = clip_unit((in_flight as f32) / total);
+        self
+    }
+
+    /// Encode hour of day cyclically.
+    ///
+    /// This preserves circular distance, so the resulting values intentionally
+    /// live in `[-1, 1]` instead of `[0, 1]`.
+    #[must_use]
+    pub fn hour_of_day(mut self, hour: u32) -> Self {
+        let angle = ((hour % 24) as f32) * 2.0 * PI / 24.0;
+        self.hour_sin = angle.sin();
+        self.hour_cos = angle.cos();
+        self
+    }
+
+    /// Normalize loop count into `[0, 1]`.
+    #[must_use]
+    pub fn loop_count(mut self, n: usize) -> Self {
+        self.loop_count = clip_unit((n.min(3) as f32) / 3.0);
+        self
+    }
+
+    /// Encode request cost relative to the most expensive priced candidate.
+    ///
+    /// Callers calculate this ratio per request so the GP receives a bounded,
+    /// continuous signal without a currency-specific magic normalization
+    /// constant. Unknown pricing is represented by the caller, not here.
+    #[must_use]
+    pub fn relative_cost(mut self, relative_cost: Option<f32>) -> Self {
+        if let Some(relative_cost) = relative_cost {
+            self.relative_cost = clip_unit(relative_cost);
+            self.cost_known = 1.0;
+        } else {
+            self.relative_cost = 0.0;
+            self.cost_known = 0.0;
+        }
+        self
+    }
+
+    /// Build the feature vector in the canonical fixed-dimensional order.
+    #[must_use]
+    pub fn build(self) -> FeatureVector {
+        let mut values = vec![
+            self.prompt_len,
+            self.priority_0,
+            self.priority_1,
+            self.priority_2,
+            self.priority_3,
+            self.has_verify,
+            self.dep_count,
+            self.retry_count,
+        ];
+        values.extend(self.backend);
+        values.extend([
+            self.idle_ratio,
+            self.in_flight_ratio,
+            self.hour_sin,
+            self.hour_cos,
+            self.loop_count,
+            self.relative_cost,
+            self.cost_known,
+        ]);
+        debug_assert_eq!(values.len(), FEATURE_DIM);
+        debug!(
+            prompt_len = self.prompt_len,
+            idle_ratio = self.idle_ratio,
+            in_flight_ratio = self.in_flight_ratio,
+            "feature vector built"
+        );
+        FeatureVector(Array1::from(values))
+    }
+}

--- a/vendor/gp-routing/src/lib.rs
+++ b/vendor/gp-routing/src/lib.rs
@@ -1,0 +1,44 @@
+//! # gp-routing
+//!
+//! Gaussian Process surrogate for LLM backend routing and load balancing.
+//!
+//! Uses Kriging (GP regression) with per-dimension ARD lengthscales to learn
+//! which request features predict backend performance. Designed for scenarios
+//! where API calls take 10-20 seconds and the GP refit happens every ~200
+//! requests, making FP32 precision more than adequate.
+//!
+//! ## Quick start
+//!
+//! ```rust,no_run
+//! use gp_routing::{FeatureVector, GpRoutingConfig, GpSurrogate, ObservationBuffer};
+//!
+//! let config = GpRoutingConfig::default();
+//! let mut buffer = ObservationBuffer::new(config.buffer_capacity);
+//! let surrogate = GpSurrogate::new(config.clone());
+//!
+//! let features = FeatureVector::builder()
+//!     .prompt_length(5_000)
+//!     .priority(1)
+//!     .backend_index(2, config.n_backends)
+//!     .hour_of_day(14)
+//!     .build();
+//! buffer.push(features.clone(), 0.85);
+//!
+//! if buffer.len() >= config.min_observations {
+//!     surrogate.fit(&buffer).expect("GP fit should succeed");
+//! }
+//!
+//! let (_mean, _variance) = surrogate.predict(&features);
+//! ```
+
+pub mod acquisition;
+pub mod config;
+pub mod features;
+pub mod ring_buffer;
+pub mod surrogate;
+
+pub use acquisition::{rank_backends, thompson_sample, ucb_score, AcquisitionStrategy};
+pub use config::{GpRoutingConfig, GpRoutingConfigBuilder};
+pub use features::{FeatureVector, FeatureVectorBuilder, FEATURE_DIM};
+pub use ring_buffer::ObservationBuffer;
+pub use surrogate::{GpFitError, GpLoadError, GpSaveError, GpSurrogate};

--- a/vendor/gp-routing/src/ring_buffer.rs
+++ b/vendor/gp-routing/src/ring_buffer.rs
@@ -1,0 +1,117 @@
+// Modified for CCR-Rust: rustfmt normalization only; behavior is unchanged.
+use crate::features::{FeatureVector, FEATURE_DIM};
+use ndarray::{Array1, Array2};
+use tracing::{debug, info};
+
+/// Fixed-capacity observation buffer with FIFO overwrite semantics.
+#[derive(Clone, Debug)]
+pub struct ObservationBuffer {
+    entries: Vec<(Array1<f32>, f32)>,
+    capacity: usize,
+    write_cursor: usize,
+    requests_since_last_fit: usize,
+}
+
+impl ObservationBuffer {
+    /// Create a new observation buffer.
+    #[must_use]
+    pub fn new(capacity: usize) -> Self {
+        let capacity = capacity.max(1);
+        info!(capacity, "observation buffer created");
+        Self {
+            entries: Vec::with_capacity(capacity),
+            capacity,
+            write_cursor: 0,
+            requests_since_last_fit: 0,
+        }
+    }
+
+    /// Push a new observation, evicting the oldest when full.
+    pub fn push(&mut self, features: FeatureVector, outcome: f32) {
+        debug!(
+            outcome,
+            len = self.entries.len(),
+            capacity = self.capacity,
+            "pushing observation"
+        );
+        let clamped_outcome = outcome.clamp(0.0, 1.0);
+        let record = (features.as_array().clone(), clamped_outcome);
+
+        if self.entries.len() < self.capacity {
+            self.entries.push(record);
+            self.write_cursor = self.entries.len() % self.capacity;
+        } else {
+            self.entries[self.write_cursor] = record;
+            self.write_cursor = (self.write_cursor + 1) % self.capacity;
+        }
+
+        self.requests_since_last_fit = self.requests_since_last_fit.saturating_add(1);
+    }
+
+    /// Number of retained observations.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether the buffer is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Configured capacity.
+    #[must_use]
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Return training arrays `(X, y)` in insertion order.
+    #[must_use]
+    pub fn as_training_data(&self) -> (Array2<f32>, Array1<f32>) {
+        let len = self.entries.len();
+        if len == 0 {
+            return (Array2::zeros((0, FEATURE_DIM)), Array1::zeros(0));
+        }
+
+        let mut x = Array2::zeros((len, FEATURE_DIM));
+        let mut y = Array1::zeros(len);
+
+        if len < self.capacity {
+            for (row, (features, outcome)) in self.entries.iter().enumerate() {
+                x.row_mut(row).assign(features);
+                y[row] = *outcome;
+            }
+            return (x, y);
+        }
+
+        for row in 0..len {
+            let idx = (self.write_cursor + row) % self.capacity;
+            let (features, outcome) = &self.entries[idx];
+            x.row_mut(row).assign(features);
+            y[row] = *outcome;
+        }
+
+        (x, y)
+    }
+
+    /// Remove all observations.
+    pub fn clear(&mut self) {
+        let prev_len = self.entries.len();
+        self.entries.clear();
+        self.write_cursor = 0;
+        self.requests_since_last_fit = 0;
+        info!(prev_len, "observation buffer cleared");
+    }
+
+    /// Number of pushes since the last successful fit marker.
+    #[must_use]
+    pub fn requests_since_last_fit(&self) -> usize {
+        self.requests_since_last_fit
+    }
+
+    /// Reset the fit counter after a successful model refresh.
+    pub fn mark_fitted(&mut self) {
+        self.requests_since_last_fit = 0;
+    }
+}

--- a/vendor/gp-routing/src/surrogate.rs
+++ b/vendor/gp-routing/src/surrogate.rs
@@ -33,6 +33,8 @@ struct PersistedState {
 pub enum GpFitError {
     /// Not enough observations are available to train the GP.
     InsufficientData { have: usize, need: usize },
+    /// The surrogate configuration cannot produce a valid model.
+    InvalidConfig(String),
     /// Fitting failed inside `egobox-gp` or `linfa`.
     FitFailed(String),
 }
@@ -43,6 +45,7 @@ impl Display for GpFitError {
             Self::InsufficientData { have, need } => {
                 write!(f, "insufficient data for GP fit: have {have}, need {need}")
             }
+            Self::InvalidConfig(message) => write!(f, "invalid GP configuration: {message}"),
             Self::FitFailed(message) => write!(f, "GP fit failed: {message}"),
         }
     }
@@ -187,6 +190,14 @@ impl GpSurrogate {
 
     /// Fit a GP model from the observation buffer.
     pub fn fit(&self, buffer: &ObservationBuffer) -> Result<(), GpFitError> {
+        if let Some(kpls_dim) = self.config.kpls_dim {
+            if kpls_dim == 0 || kpls_dim > self.config.input_dim {
+                return Err(GpFitError::InvalidConfig(format!(
+                    "kpls_dim must be between 1 and {}; got {kpls_dim}",
+                    self.config.input_dim
+                )));
+            }
+        }
         let (x, y) = buffer.as_training_data();
         let have = y.len();
         if have < self.config.min_observations {

--- a/vendor/gp-routing/src/surrogate.rs
+++ b/vendor/gp-routing/src/surrogate.rs
@@ -1,0 +1,358 @@
+use crate::config::GpRoutingConfig;
+use crate::features::FeatureVector;
+use crate::ring_buffer::ObservationBuffer;
+use egobox_gp::correlation_models::Matern52Corr;
+use egobox_gp::mean_models::ConstantMean;
+use egobox_gp::{GaussianProcess, ThetaTuning};
+use linfa::dataset::Dataset;
+use linfa::prelude::Fit;
+use ndarray::{Array1, Axis};
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+use std::error::Error;
+use std::fmt::{self, Display, Formatter};
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Instant;
+use tracing::{debug, info, warn};
+
+type RoutingModel = GaussianProcess<f32, ConstantMean, Matern52Corr>;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct PersistedState {
+    input_dim: usize,
+    fit_count: u64,
+    last_fit_duration_ms: u64,
+    y_stats: Option<(f32, f32)>,
+    model: RoutingModel,
+}
+
+/// Errors returned by [`GpSurrogate::fit`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum GpFitError {
+    /// Not enough observations are available to train the GP.
+    InsufficientData { have: usize, need: usize },
+    /// Fitting failed inside `egobox-gp` or `linfa`.
+    FitFailed(String),
+}
+
+impl Display for GpFitError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InsufficientData { have, need } => {
+                write!(f, "insufficient data for GP fit: have {have}, need {need}")
+            }
+            Self::FitFailed(message) => write!(f, "GP fit failed: {message}"),
+        }
+    }
+}
+
+impl Error for GpFitError {}
+
+/// Errors returned by [`GpSurrogate::save`].
+#[derive(Debug)]
+pub enum GpSaveError {
+    /// Attempted to save an unfitted model.
+    NotFitted,
+    /// File system error during save.
+    Io(std::io::Error),
+    /// JSON serialization error during save.
+    Serde(serde_json::Error),
+}
+
+impl Display for GpSaveError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotFitted => write!(f, "cannot save an unfitted GP model"),
+            Self::Io(err) => write!(f, "failed to write GP model: {err}"),
+            Self::Serde(err) => write!(f, "failed to serialize GP model: {err}"),
+        }
+    }
+}
+
+impl Error for GpSaveError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::NotFitted => None,
+            Self::Io(err) => Some(err),
+            Self::Serde(err) => Some(err),
+        }
+    }
+}
+
+impl From<std::io::Error> for GpSaveError {
+    fn from(value: std::io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+impl From<serde_json::Error> for GpSaveError {
+    fn from(value: serde_json::Error) -> Self {
+        Self::Serde(value)
+    }
+}
+
+/// Errors returned by [`GpSurrogate::load`].
+#[derive(Debug)]
+pub enum GpLoadError {
+    /// File system error during load.
+    Io(std::io::Error),
+    /// JSON deserialization error during load.
+    Serde(serde_json::Error),
+    /// Persisted feature dimension does not match current configuration.
+    DimensionMismatch { expected: usize, found: usize },
+}
+
+impl Display for GpLoadError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(err) => write!(f, "failed to read GP model: {err}"),
+            Self::Serde(err) => write!(f, "failed to deserialize GP model: {err}"),
+            Self::DimensionMismatch { expected, found } => write!(
+                f,
+                "GP model dimension mismatch: expected {expected}, found {found}"
+            ),
+        }
+    }
+}
+
+impl Error for GpLoadError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Io(err) => Some(err),
+            Self::Serde(err) => Some(err),
+            Self::DimensionMismatch { .. } => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for GpLoadError {
+    fn from(value: std::io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+impl From<serde_json::Error> for GpLoadError {
+    fn from(value: serde_json::Error) -> Self {
+        Self::Serde(value)
+    }
+}
+
+/// Thread-safe wrapper around an `egobox-gp` Gaussian process.
+#[derive(Clone, Debug)]
+pub struct GpSurrogate {
+    model: Arc<RwLock<Option<RoutingModel>>>,
+    config: GpRoutingConfig,
+    fit_count: Arc<AtomicU64>,
+    last_fit_duration_ms: Arc<AtomicU64>,
+    y_stats: Arc<RwLock<Option<(f32, f32)>>>,
+}
+
+impl GpSurrogate {
+    /// Construct an unfitted GP surrogate.
+    #[must_use]
+    pub fn new(config: GpRoutingConfig) -> Self {
+        debug!(input_dim = config.input_dim, nugget = config.nugget, kpls_dim = ?config.kpls_dim, "creating GP surrogate");
+        Self {
+            model: Arc::new(RwLock::new(None)),
+            config,
+            fit_count: Arc::new(AtomicU64::new(0)),
+            last_fit_duration_ms: Arc::new(AtomicU64::new(0)),
+            y_stats: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    /// Whether a fitted model is currently available.
+    #[must_use]
+    pub fn is_fitted(&self) -> bool {
+        self.model.read().is_some()
+    }
+
+    /// Number of successful fits performed by this surrogate.
+    #[must_use]
+    pub fn fit_count(&self) -> u64 {
+        self.fit_count.load(Ordering::Relaxed)
+    }
+
+    /// Duration of the last fit in milliseconds.
+    #[must_use]
+    pub fn last_fit_duration_ms(&self) -> u64 {
+        self.last_fit_duration_ms.load(Ordering::Relaxed)
+    }
+
+    fn prior_pair(&self) -> (f32, f32) {
+        (self.config.prior_mean, self.config.prior_variance)
+    }
+
+    /// Fit a GP model from the observation buffer.
+    pub fn fit(&self, buffer: &ObservationBuffer) -> Result<(), GpFitError> {
+        let (x, y) = buffer.as_training_data();
+        let have = y.len();
+        if have < self.config.min_observations {
+            return Err(GpFitError::InsufficientData {
+                have,
+                need: self.config.min_observations,
+            });
+        }
+
+        let start = Instant::now();
+        let y_min = y.iter().copied().fold(f32::INFINITY, f32::min);
+        let y_max = y.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+        let y_span = (y_max - y_min).max(1e-8);
+        let y_norm: Array1<f32> = y.mapv(|value| ((value - y_min) / y_span).clamp(0.0, 1.0));
+
+        let dataset = Dataset::new(x, y_norm);
+        let theta_dim = self
+            .config
+            .kpls_dim
+            .unwrap_or(self.config.input_dim)
+            .max(1)
+            .min(self.config.input_dim.max(1));
+        let theta = Array1::from_elem(theta_dim, 1e-1_f32);
+
+        // egobox-gp 0.36.x optimizes theta through a generic helper that
+        // unsafely reinterprets `f32` as `f64`, which aborts on macOS/ARM with a
+        // misaligned pointer dereference. Using fixed theta keeps the FP32 path
+        // stable while still giving us a functional ARD-capable GP wrapper.
+        let params = GaussianProcess::<f32, ConstantMean, Matern52Corr>::params(
+            ConstantMean::default(),
+            Matern52Corr::default(),
+        )
+        .nugget(self.config.nugget)
+        .theta_tuning(ThetaTuning::Fixed(theta))
+        .kpls_dim(self.config.kpls_dim);
+
+        let model = params
+            .fit(&dataset)
+            .map_err(|err| GpFitError::FitFailed(err.to_string()))?;
+
+        let duration_ms = start.elapsed().as_millis() as u64;
+        *self.model.write() = Some(model);
+        *self.y_stats.write() = Some((y_min, y_max));
+        self.fit_count.fetch_add(1, Ordering::Relaxed);
+        self.last_fit_duration_ms
+            .store(duration_ms, Ordering::Relaxed);
+
+        info!(
+            observations = have,
+            duration_ms,
+            y_min,
+            y_max,
+            kpls_dim = ?self.config.kpls_dim,
+            "gp-routing fit complete"
+        );
+        Ok(())
+    }
+
+    /// Predict mean and variance for a single feature vector.
+    #[must_use]
+    pub fn predict(&self, features: &FeatureVector) -> (f32, f32) {
+        let guard = self.model.read();
+        let Some(model) = guard.as_ref() else {
+            return self.prior_pair();
+        };
+
+        let input = features.as_array().clone().insert_axis(Axis(0));
+        match model.predict_valvar(&input) {
+            Ok((means, variances)) => {
+                let mean = means.get(0).copied().unwrap_or(self.config.prior_mean);
+                let variance = variances
+                    .get(0)
+                    .copied()
+                    .unwrap_or(self.config.prior_variance)
+                    .max(1e-6);
+                (mean, variance)
+            }
+            Err(err) => {
+                warn!(error = %err, "gp-routing single prediction failed; using prior");
+                self.prior_pair()
+            }
+        }
+    }
+
+    /// Predict mean and variance for a batch of feature vectors.
+    #[must_use]
+    pub fn predict_batch(&self, features: &[FeatureVector]) -> Vec<(f32, f32)> {
+        debug!(batch_size = features.len(), "gp-routing batch prediction");
+        if features.is_empty() {
+            return Vec::new();
+        }
+
+        let guard = self.model.read();
+        let Some(model) = guard.as_ref() else {
+            return vec![self.prior_pair(); features.len()];
+        };
+
+        let mut inputs = ndarray::Array2::zeros((features.len(), self.config.input_dim));
+        for (row, feature) in features.iter().enumerate() {
+            inputs.row_mut(row).assign(feature.as_array());
+        }
+
+        match model.predict_valvar(&inputs) {
+            Ok((means, variances)) => means
+                .iter()
+                .zip(variances.iter())
+                .map(|(mean, variance)| (*mean, (*variance).max(1e-6)))
+                .collect(),
+            Err(err) => {
+                warn!(error = %err, "gp-routing batch prediction failed; using priors");
+                vec![self.prior_pair(); features.len()]
+            }
+        }
+    }
+
+    /// Persist the fitted model to disk as JSON.
+    pub fn save(&self, path: &Path) -> Result<(), GpSaveError> {
+        debug!(path = %path.display(), "saving GP model to disk");
+        let model = self.model.read().clone().ok_or(GpSaveError::NotFitted)?;
+        let state = PersistedState {
+            input_dim: self.config.input_dim,
+            fit_count: self.fit_count(),
+            last_fit_duration_ms: self.last_fit_duration_ms(),
+            y_stats: *self.y_stats.read(),
+            model,
+        };
+
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let tmp_path = path.with_extension("tmp");
+        let payload = serde_json::to_vec_pretty(&state)?;
+        std::fs::write(&tmp_path, payload)?;
+        std::fs::rename(&tmp_path, path)?;
+        info!(path = %path.display(), "GP model saved to disk");
+        Ok(())
+    }
+
+    /// Load a previously persisted model into this surrogate.
+    pub fn load(&self, path: &Path) -> Result<(), GpLoadError> {
+        debug!(path = %path.display(), "loading GP model from disk");
+        let payload = std::fs::read(path)?;
+        let state: PersistedState = serde_json::from_slice(&payload)?;
+        if state.input_dim != self.config.input_dim {
+            return Err(GpLoadError::DimensionMismatch {
+                expected: self.config.input_dim,
+                found: state.input_dim,
+            });
+        }
+
+        let (model_input_dim, _) = state.model.dims();
+        if model_input_dim != self.config.input_dim {
+            return Err(GpLoadError::DimensionMismatch {
+                expected: self.config.input_dim,
+                found: model_input_dim,
+            });
+        }
+
+        *self.model.write() = Some(state.model);
+        *self.y_stats.write() = state.y_stats;
+        self.fit_count.store(state.fit_count, Ordering::Relaxed);
+        self.last_fit_duration_ms
+            .store(state.last_fit_duration_ms, Ordering::Relaxed);
+
+        info!(path = %path.display(), "gp-routing model loaded from disk");
+        Ok(())
+    }
+}

--- a/vendor/gp-routing/tests/integration.rs
+++ b/vendor/gp-routing/tests/integration.rs
@@ -1,0 +1,188 @@
+// Modified for CCR-Rust: exercise the expanded backend and continuous-cost
+// feature contract used by the embedded router.
+use approx::assert_abs_diff_eq;
+use gp_routing::features::{DEP_COUNT_INDEX, HOUR_COS_INDEX, HOUR_SIN_INDEX};
+use gp_routing::{
+    rank_backends, AcquisitionStrategy, FeatureVector, GpRoutingConfig, GpSurrogate,
+    ObservationBuffer, FEATURE_DIM,
+};
+
+fn make_features(backend_idx: usize, sample: usize) -> FeatureVector {
+    FeatureVector::builder()
+        .prompt_length(1_000 + sample * 137)
+        .priority((sample % 4) as u8)
+        .has_verify(sample % 2 == 0)
+        .dependency_count(sample % 10)
+        .retry_count(sample % 7)
+        .backend_index(backend_idx, 2)
+        .idle_ratio(3 + (sample % 4), 10)
+        .in_flight_ratio(2 + (sample % 5), 10)
+        .hour_of_day((sample % 24) as u32)
+        .loop_count(sample % 3)
+        .relative_cost(Some(if backend_idx == 0 { 0.0 } else { 1.0 }))
+        .build()
+}
+
+fn train_two_backend_surrogate() -> GpSurrogate {
+    let config = GpRoutingConfig::builder()
+        .buffer_capacity(128)
+        .min_observations(20)
+        .n_backends(2)
+        .build();
+    let surrogate = GpSurrogate::new(config);
+    let mut buffer = ObservationBuffer::new(128);
+
+    for sample in 0..80 {
+        let backend = sample % 2;
+        let outcome = if backend == 0 { 0.9 } else { 0.3 };
+        buffer.push(make_features(backend, sample), outcome);
+    }
+
+    surrogate.fit(&buffer).expect("surrogate should fit");
+    surrogate
+}
+
+#[test]
+fn test_feature_vector_dimensions() {
+    let features = FeatureVector::builder()
+        .prompt_length(5_000)
+        .priority(2)
+        .has_verify(true)
+        .dependency_count(4)
+        .retry_count(3)
+        .backend_index(1, 4)
+        .idle_ratio(5, 8)
+        .in_flight_ratio(2, 8)
+        .hour_of_day(14)
+        .loop_count(2)
+        .relative_cost(Some(1.0))
+        .build();
+
+    let values = features.as_array();
+    assert_eq!(values.len(), FEATURE_DIM);
+    for (idx, value) in values.iter().enumerate() {
+        if idx == HOUR_SIN_INDEX || idx == HOUR_COS_INDEX {
+            assert!((-1.0..=1.0).contains(value));
+        } else {
+            assert!((0.0..=1.0).contains(value));
+        }
+    }
+}
+
+#[test]
+fn test_backend_capacity_covers_all_thirty_two_slots() {
+    let features = FeatureVector::builder()
+        .backend_index(31, 32)
+        .relative_cost(Some(0.25))
+        .build();
+
+    assert_eq!(gp_routing::features::BACKEND_SLOTS, 32);
+    assert_eq!(
+        features.as_array()[gp_routing::features::BACKEND_START + 31],
+        1.0
+    );
+    assert_eq!(
+        features.as_array()[gp_routing::features::RELATIVE_COST_INDEX],
+        0.25
+    );
+    assert_eq!(
+        features.as_array()[gp_routing::features::COST_KNOWN_INDEX],
+        1.0
+    );
+
+    let unknown_cost = FeatureVector::builder()
+        .backend_index(31, 32)
+        .relative_cost(None)
+        .build();
+    assert_eq!(
+        unknown_cost.as_array()[gp_routing::features::RELATIVE_COST_INDEX],
+        0.0
+    );
+    assert_eq!(
+        unknown_cost.as_array()[gp_routing::features::COST_KNOWN_INDEX],
+        0.0
+    );
+}
+
+#[test]
+fn test_ring_buffer_fifo() {
+    let mut buffer = ObservationBuffer::new(5);
+    for i in 0..10 {
+        let features = FeatureVector::builder().dependency_count(i).build();
+        buffer.push(features, i as f32 / 10.0);
+    }
+
+    assert_eq!(buffer.len(), 5);
+    let (x, y) = buffer.as_training_data();
+    assert_eq!(x.nrows(), 5);
+    for row in 0..5 {
+        let expected = (row + 5) as f32 / 10.0;
+        assert_abs_diff_eq!(x[[row, DEP_COUNT_INDEX]], expected, epsilon = 1e-6);
+        assert_abs_diff_eq!(y[row], expected, epsilon = 1e-6);
+    }
+}
+
+#[test]
+fn test_ring_buffer_training_data_shape() {
+    let mut buffer = ObservationBuffer::new(64);
+    for i in 0..50 {
+        buffer.push(make_features(i % 2, i), (i % 10) as f32 / 10.0);
+    }
+
+    let (x, y) = buffer.as_training_data();
+    assert_eq!(x.dim(), (50, FEATURE_DIM));
+    assert_eq!(y.len(), 50);
+}
+
+#[test]
+fn test_surrogate_unfitted_prior() {
+    let config = GpRoutingConfig::builder()
+        .prior_mean(0.42)
+        .prior_variance(0.19)
+        .build();
+    let surrogate = GpSurrogate::new(config);
+    let features = make_features(0, 0);
+    let (mean, variance) = surrogate.predict(&features);
+
+    assert_abs_diff_eq!(mean, 0.42, epsilon = 1e-6);
+    assert_abs_diff_eq!(variance, 0.19, epsilon = 1e-6);
+}
+
+#[test]
+fn test_surrogate_fit_and_predict() {
+    let surrogate = train_two_backend_surrogate();
+    assert!(surrogate.is_fitted());
+
+    let backend0 = make_features(0, 200);
+    let backend1 = make_features(1, 201);
+    let (mean0, variance0) = surrogate.predict(&backend0);
+    let (mean1, variance1) = surrogate.predict(&backend1);
+
+    assert!(mean0 > mean1, "backend 0 should score above backend 1");
+    assert!(variance0 >= 1e-6);
+    assert!(variance1 >= 1e-6);
+}
+
+#[test]
+fn test_rank_backends_ordering() {
+    let surrogate = train_two_backend_surrogate();
+    let base_features = make_features(0, 500);
+    let ranked = rank_backends(&surrogate, &base_features, 2, AcquisitionStrategy::Greedy);
+
+    assert_eq!(ranked.len(), 2);
+    assert_eq!(ranked[0].0, 0);
+    assert!(ranked[0].1 >= ranked[1].1);
+}
+
+#[test]
+fn test_requests_since_fit_counter() {
+    let mut buffer = ObservationBuffer::new(8);
+    assert_eq!(buffer.requests_since_last_fit(), 0);
+
+    buffer.push(make_features(0, 0), 0.8);
+    buffer.push(make_features(1, 1), 0.2);
+    assert_eq!(buffer.requests_since_last_fit(), 2);
+
+    buffer.mark_fitted();
+    assert_eq!(buffer.requests_since_last_fit(), 0);
+}

--- a/vendor/gp-routing/tests/integration.rs
+++ b/vendor/gp-routing/tests/integration.rs
@@ -6,6 +6,7 @@ use gp_routing::{
     rank_backends, AcquisitionStrategy, FeatureVector, GpFitError, GpRoutingConfig, GpSurrogate,
     ObservationBuffer, FEATURE_DIM,
 };
+use std::time::{SystemTime, UNIX_EPOCH};
 
 fn make_features(backend_idx: usize, sample: usize) -> FeatureVector {
     FeatureVector::builder()
@@ -105,6 +106,21 @@ fn test_backend_capacity_covers_all_thirty_two_slots() {
 }
 
 #[test]
+fn test_backend_counts_are_bounded_to_feature_capacity() {
+    let config = GpRoutingConfig::builder().n_backends(usize::MAX).build();
+    assert_eq!(config.n_backends, gp_routing::features::BACKEND_SLOTS);
+
+    let surrogate = GpSurrogate::new(config);
+    let ranked = rank_backends(
+        &surrogate,
+        &make_features(0, 0),
+        usize::MAX,
+        AcquisitionStrategy::Greedy,
+    );
+    assert_eq!(ranked.len(), gp_routing::features::BACKEND_SLOTS);
+}
+
+#[test]
 fn test_ring_buffer_fifo() {
     let mut buffer = ObservationBuffer::new(5);
     for i in 0..10 {
@@ -182,6 +198,50 @@ fn test_surrogate_fit_and_predict() {
 }
 
 #[test]
+fn test_batch_predictions_match_single_predictions() {
+    let surrogate = train_two_backend_surrogate();
+    let features = vec![make_features(0, 210), make_features(1, 211)];
+    let batch = surrogate.predict_batch(&features);
+
+    for (feature, (batch_mean, batch_variance)) in features.iter().zip(batch) {
+        let (single_mean, single_variance) = surrogate.predict(feature);
+        assert_abs_diff_eq!(batch_mean, single_mean, epsilon = 1e-5);
+        assert_abs_diff_eq!(batch_variance, single_variance, epsilon = 1e-5);
+    }
+}
+
+#[test]
+fn test_fitted_surrogate_persistence_round_trip() {
+    let surrogate = train_two_backend_surrogate();
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock after Unix epoch")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!(
+        "gp-routing-test-{}-{suffix}.json",
+        std::process::id()
+    ));
+    surrogate.save(&path).expect("save fitted surrogate");
+
+    let loaded = GpSurrogate::new(
+        GpRoutingConfig::builder()
+            .buffer_capacity(128)
+            .min_observations(20)
+            .n_backends(2)
+            .build(),
+    );
+    loaded.load(&path).expect("load fitted surrogate");
+    std::fs::remove_file(&path).expect("remove persisted test model");
+
+    for feature in [make_features(0, 220), make_features(1, 221)] {
+        let before = surrogate.predict(&feature);
+        let after = loaded.predict(&feature);
+        assert_abs_diff_eq!(before.0, after.0, epsilon = 1e-5);
+        assert_abs_diff_eq!(before.1, after.1, epsilon = 1e-5);
+    }
+}
+
+#[test]
 fn test_rank_backends_ordering() {
     let surrogate = train_two_backend_surrogate();
     let base_features = make_features(0, 500);
@@ -190,6 +250,23 @@ fn test_rank_backends_ordering() {
     assert_eq!(ranked.len(), 2);
     assert_eq!(ranked[0].0, 0);
     assert!(ranked[0].1 >= ranked[1].1);
+}
+
+#[test]
+fn test_thompson_ranking_is_complete_and_finite() {
+    let surrogate = train_two_backend_surrogate();
+    let ranked = rank_backends(
+        &surrogate,
+        &make_features(0, 510),
+        2,
+        AcquisitionStrategy::Thompson,
+    );
+
+    assert_eq!(ranked.len(), 2);
+    let mut indices = ranked.iter().map(|(index, _)| *index).collect::<Vec<_>>();
+    indices.sort_unstable();
+    assert_eq!(indices, vec![0, 1]);
+    assert!(ranked.iter().all(|(_, score)| score.is_finite()));
 }
 
 #[test]

--- a/vendor/gp-routing/tests/integration.rs
+++ b/vendor/gp-routing/tests/integration.rs
@@ -3,7 +3,7 @@
 use approx::assert_abs_diff_eq;
 use gp_routing::features::{DEP_COUNT_INDEX, HOUR_COS_INDEX, HOUR_SIN_INDEX};
 use gp_routing::{
-    rank_backends, AcquisitionStrategy, FeatureVector, GpRoutingConfig, GpSurrogate,
+    rank_backends, AcquisitionStrategy, FeatureVector, GpFitError, GpRoutingConfig, GpSurrogate,
     ObservationBuffer, FEATURE_DIM,
 };
 
@@ -146,6 +146,24 @@ fn test_surrogate_unfitted_prior() {
 
     assert_abs_diff_eq!(mean, 0.42, epsilon = 1e-6);
     assert_abs_diff_eq!(variance, 0.19, epsilon = 1e-6);
+}
+
+#[test]
+fn test_surrogate_rejects_invalid_kpls_dimensions_before_fitting() {
+    for invalid in [0, FEATURE_DIM + 1] {
+        let config = GpRoutingConfig::builder()
+            .min_observations(1)
+            .kpls_dim(Some(invalid))
+            .build();
+        let surrogate = GpSurrogate::new(config);
+        let mut buffer = ObservationBuffer::new(2);
+        buffer.push(make_features(0, 0), 0.5);
+
+        assert!(matches!(
+            surrogate.fit(&buffer),
+            Err(GpFitError::InvalidConfig(_))
+        ));
+    }
 }
 
 #[test]


### PR DESCRIPTION
Makes GP routing part of the standard build, adds conservative provider/model price metadata and credible-set cost ordering, expands the bounded route encoder to 32 candidates, vendors the pinned Apache-2.0 GP crate, and replaces the sibling sindexer path with a pinned public Git revision. Validation: rustfmt on changed files; clippy all targets/all features with warnings denied; cargo test all features; no-default-features check; vendored crate tests.