### PR TITLE
fix: make debug capture private and bounded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Private bounded debug capture** — Raw provider capture remains explicitly
+  disabled when configuration is absent, defaults to error-only capture when
+  enabled, enforces `0700` directories and `0600` files on Unix, creates files
+  without overwriting existing paths, and applies retention after every write
+  only to current CCR-owned files. Zero or excessive retention limits are now
+  converted to bounded values without deleting legacy captures or unrelated
+  files. Listing and statistics ignore symlinks and legacy files and enforce
+  hard per-file and result-count limits.
+
 - **GP configuration validation** — Reject invalid KPLS dimensions during
   startup validation and before fitting so bad configuration cannot trigger
   repeated failed refits, and cap public backend-ranking inputs to the fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Uncertainty-respecting cost ordering** — Cheaper routes are promoted only
   inside the GP posterior quality credible set, avoiding an arbitrary scalar
   exchange rate between predicted quality and dollars.
+- **CLI-only debug capture access** — Removed the unauthenticated capture HTTP
+  routes. Private captures can now be inspected only from the local
+  `ccr-rust captures` command.
 
 - **Default coding model** — Changed default routing from `glm-5.1` to `glm-5.2` for improved
   reasoning and coding performance with configurable reasoning effort.
@@ -70,8 +73,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   without overwriting existing paths, and applies retention after every write
   only to current CCR-owned files. Zero or excessive retention limits are now
   converted to bounded values without deleting legacy captures or unrelated
-  files. Listing and statistics ignore symlinks and legacy files and enforce
-  hard per-file and result-count limits.
+  files. Body limits are clamped to 2 MiB without splitting UTF-8; optional
+  headers are bounded and redact common credential names; HTTP failures, rate
+  limits, and provider errors embedded in success responses retain failure
+  semantics. Listing and statistics ignore symlinks and legacy files and are
+  capped at 100 captures, 4 MiB per file, and 16 MiB per pass.
 
 - **GP configuration validation** — Reject invalid KPLS dimensions during
   startup validation and before fitting so bad configuration cannot trigger

--- a/config.gemini.json
+++ b/config.gemini.json
@@ -113,13 +113,12 @@
         "redis_prefix": "ccr-rust:persistence:v1"
     },
     "DebugCapture": {
-        "enabled": true,
-        "providers": [
-            "minimax"
-        ],
+        "enabled": false,
+        "providers": [],
         "output_dir": "~/.ccr-rust/captures",
-        "max_files": 1000,
-        "capture_success": true,
+        "max_files": 100,
+        "include_headers": false,
+        "capture_success": false,
         "max_body_size": 1048576
     }
 }

--- a/docs/debug_capture.md
+++ b/docs/debug_capture.md
@@ -1,6 +1,6 @@
 # Debug Capture
 
-Debug capture records raw request/response data from provider interactions, enabling debugging of provider-specific issues like response drift, malformed outputs, or unexpected behavior.
+Debug capture records raw request/response data from provider interactions, enabling debugging of provider-specific issues like response drift, malformed outputs, or unexpected behavior. It is explicitly disabled by default because request and response bodies can contain sensitive user data. Enable it only for a bounded debugging session.
 
 ## Overview
 
@@ -23,8 +23,8 @@ Add the `DebugCapture` section to your `config.json`:
     "enabled": true,
     "providers": ["minimax"],
     "output_dir": "~/.ccr-rust/captures",
-    "max_files": 1000,
-    "capture_success": true,
+    "max_files": 100,
+    "capture_success": false,
     "max_body_size": 1048576
   }
 }
@@ -37,10 +37,17 @@ Add the `DebugCapture` section to your `config.json`:
 | `enabled` | bool | `false` | Enable/disable capture globally |
 | `providers` | string[] | `[]` | Provider names to capture. Empty = capture all |
 | `output_dir` | string | `~/.ccr-rust/captures` | Output directory (supports `~` expansion) |
-| `max_files` | int | `1000` | Maximum capture files before rotation |
-| `capture_success` | bool | `true` | Capture successful responses (not just errors) |
-| `max_body_size` | int | `1048576` | Max response body size in bytes (0 = unlimited) |
-| `include_headers` | bool | `false` | Include HTTP headers in capture |
+| `max_files` | int | `100` | Maximum CCR-owned capture files before rotation (hard maximum: 1000) |
+| `capture_success` | bool | `false` | Capture successful responses (not just errors) |
+| `max_body_size` | int | `1048576` | Max response body size in bytes; every serialized capture also has a hard 4 MiB file cap |
+| `include_headers` | bool | `false` | Include HTTP headers in capture; leave disabled when headers may contain credentials |
+
+On Unix, CCR-Rust enforces mode `0700` on the capture directory and mode
+`0600` on every new capture file. Retention runs after every write and removes
+only files created with the current `ccr_capture_v1_` prefix. Legacy captures,
+task captures, symlinks, and unrelated JSON files are left untouched.
+Capture listing and statistics likewise inspect only current-format regular
+files, cap each file read at 4 MiB, and return at most 1000 entries.
 
 ### Provider Names
 
@@ -225,28 +232,31 @@ curl -s "http://localhost:3456/debug/capture/list?limit=100" | \
 
 ## File Rotation
 
-CCR-Rust automatically rotates capture files when `max_files` is exceeded:
+CCR-Rust automatically rotates its own current-format capture files as soon as
+`max_files` is exceeded. `max_files=0` is not an unlimited mode; it is replaced
+with the bounded default of 100 files.
 
-1. Rotation check runs every 100 captures
+1. Rotation runs after every successful capture write
 2. Files are sorted by modification time
-3. Oldest files are deleted until under the limit
+3. Oldest current-format regular files are deleted until under the limit
+4. If the limit cannot be enforced, the newly written capture is removed
 
 To manually clean up captures:
 
 ```bash
-# Remove all captures
-rm -rf ~/.ccr-rust/captures/*
+# Remove all current-format CCR captures (preserves legacy and task files)
+find ~/.ccr-rust/captures -type f -name 'ccr_capture_v1_*.json' -delete
 
-# Remove captures older than 7 days
-find ~/.ccr-rust/captures -mtime +7 -name "*.json" -delete
+# Remove current-format CCR captures older than 7 days
+find ~/.ccr-rust/captures -type f -mtime +7 -name 'ccr_capture_v1_*.json' -delete
 ```
 
 ## Performance Impact
 
-Debug capture has minimal overhead:
-- Captures are written asynchronously
-- File I/O doesn't block request processing
-- Memory usage is bounded by `max_body_size`
+Debug capture adds bounded disk I/O to captured requests:
+- Capture work runs only after an explicit opt-in
+- Each file is synchronously persisted before the request finishes
+- Serialized files and retained file counts have hard bounds
 
 For high-throughput scenarios, consider:
 - Limiting to specific providers

--- a/docs/debug_capture.md
+++ b/docs/debug_capture.md
@@ -1,21 +1,15 @@
-# Debug Capture
+# Private Debug Capture
 
-Debug capture records raw request/response data from provider interactions, enabling debugging of provider-specific issues like response drift, malformed outputs, or unexpected behavior. It is explicitly disabled by default because request and response bodies can contain sensitive user data. Enable it only for a bounded debugging session.
-
-## Overview
-
-When enabled, CCR-Rust captures:
-- Full request body (JSON payload sent to provider)
-- Full response body (raw text received)
-- Response status code and latency
-- Timestamps and unique request IDs
-- Error messages (for failed requests)
-
-Captures are stored as JSON files in a configurable directory, with automatic rotation to prevent disk exhaustion.
+Debug capture records bounded provider request and response material for a
+short debugging session. Captures can contain source code, prompts, model
+output, and other sensitive user data. The feature is disabled by default and
+is available only through the local `ccr-rust captures` CLI; CCR-Rust exposes
+no debug-capture HTTP routes.
 
 ## Configuration
 
-Add the `DebugCapture` section to your `config.json`:
+Add `DebugCapture` to the CCR-Rust configuration only while diagnosing a
+specific provider failure:
 
 ```json
 {
@@ -24,248 +18,96 @@ Add the `DebugCapture` section to your `config.json`:
     "providers": ["minimax"],
     "output_dir": "~/.ccr-rust/captures",
     "max_files": 100,
+    "include_headers": false,
     "capture_success": false,
     "max_body_size": 1048576
   }
 }
 ```
 
-### Configuration Options
+| Option | Default | Contract |
+| --- | --- | --- |
+| `enabled` | `false` | Capture nothing unless explicitly enabled. |
+| `providers` | `[]` | Provider names to capture; empty means every provider. |
+| `output_dir` | `~/.ccr-rust/captures` | Private local capture directory. |
+| `max_files` | `100` | Retained CCR-owned files; zero becomes 100 and values above 1000 are clamped. |
+| `include_headers` | `false` | Store bounded headers after redacting common credential and cookie names. Leave this off unless headers are essential. |
+| `capture_success` | `false` | Persist successful non-streaming interactions as well as failures. |
+| `max_body_size` | `1048576` | Captured response bytes; zero becomes 1 MiB and values above 2 MiB are clamped. UTF-8 is never split. |
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `enabled` | bool | `false` | Enable/disable capture globally |
-| `providers` | string[] | `[]` | Provider names to capture. Empty = capture all |
-| `output_dir` | string | `~/.ccr-rust/captures` | Output directory (supports `~` expansion) |
-| `max_files` | int | `100` | Maximum CCR-owned capture files before rotation (hard maximum: 1000) |
-| `capture_success` | bool | `false` | Capture successful responses (not just errors) |
-| `max_body_size` | int | `1048576` | Max response body size in bytes; every serialized capture also has a hard 4 MiB file cap |
-| `include_headers` | bool | `false` | Include HTTP headers in capture; leave disabled when headers may contain credentials |
+Request bodies are stored as structured JSON and therefore remain sensitive
+even when header capture is disabled. Each serialized file also has a hard
+4 MiB limit.
 
-On Unix, CCR-Rust enforces mode `0700` on the capture directory and mode
-`0600` on every new capture file. Retention runs after every write and removes
-only files created with the current `ccr_capture_v1_` prefix. Legacy captures,
-task captures, symlinks, and unrelated JSON files are left untouched.
-Capture listing and statistics likewise inspect only current-format regular
-files, cap each file read at 4 MiB, and return at most 1000 entries.
+On Unix, CCR-Rust enforces mode `0700` on the capture directory and mode `0600`
+on newly created files. It refuses a symlink as the capture directory and uses
+exclusive file creation so an existing path is never overwritten.
 
-### Provider Names
+## What is captured
 
-Use the provider name from your `Providers` config, not the tier name:
+For non-streaming requests, CCR-Rust can record connection errors, HTTP error
+responses, provider errors embedded in HTTP 200 bodies, and—only when
+`capture_success` is true—successful responses.
 
-```json
-{
-  "Providers": [
-    { "name": "minimax", "tier_name": "ccr-mm" },
-    { "name": "deepseek", "tier_name": "ccr-ds" }
-  ],
-  "DebugCapture": {
-    "providers": ["minimax", "deepseek"]
-  }
-}
-```
+For streaming requests, capture is deliberately limited to failures known
+before the response stream is handed to the client: connection failures,
+non-success HTTP responses, and an error detected in the initial bounded stream
+peek. Successful stream bodies and errors that occur later in an active stream
+are not persisted.
 
-## API Endpoints
-
-### GET /debug/capture/status
-
-Returns capture configuration and current statistics.
+## Read captures locally
 
 ```bash
-curl -s http://localhost:3456/debug/capture/status | jq .
-```
-
-Response:
-```json
-{
-  "enabled": true,
-  "output_dir": "~/.ccr-rust/captures",
-  "providers": ["minimax"],
-  "stats": {
-    "total_captures": 42,
-    "success_count": 38,
-    "error_count": 4,
-    "avg_latency_ms": 2847,
-    "by_provider": {
-      "minimax": 42
-    }
-  }
-}
-```
-
-### GET /debug/capture/list
-
-Lists recent captures with optional filtering.
-
-Query parameters:
-- `provider` - Filter by provider name (optional)
-- `limit` - Maximum captures to return (default: 20)
-
-```bash
-# All recent captures
-curl -s "http://localhost:3456/debug/capture/list?limit=10" | jq .
-
-# Filter by provider
-curl -s "http://localhost:3456/debug/capture/list?provider=minimax&limit=5" | jq .
-```
-
-### GET /debug/capture/stats
-
-Returns detailed statistics about captured interactions.
-
-```bash
-curl -s http://localhost:3456/debug/capture/stats | jq .
-```
-
-## CLI Commands
-
-The `ccr-rust captures` command provides CLI access to capture data:
-
-```bash
-# List recent captures
+# Recent failures and metadata
 ccr-rust captures --limit 10
 
-# Filter by provider
+# One provider
 ccr-rust captures --provider minimax --limit 20
 
-# Show statistics only
+# Aggregate statistics
 ccr-rust captures --stats
 
-# Show full response bodies
-ccr-rust captures --full
-
-# Custom output directory
-ccr-rust captures --output-dir /tmp/debug-captures
+# Include the complete bounded response body in terminal output
+ccr-rust captures --provider minimax --limit 5 --full
 ```
 
-## Capture File Format
+The CLI reads only regular files whose names begin with
+`ccr_capture_v1_`. A list or statistics pass returns at most 100 valid captures,
+reads no file larger than 4 MiB, and stops at 16 MiB of accepted input. Symlinks,
+legacy files, task captures, and unrelated JSON are ignored.
 
-Captures are stored as JSON files with the naming convention:
-```
-{provider}_{tier_name}_{timestamp}_{request_id}.json
-```
+Avoid redirecting `--full` output into a shared or world-readable location.
 
-Example: `minimax_ccr-mm_20260209_183742_00001234.json`
+## File format
 
-### File Structure
+Files use this naming contract:
 
-```json
-{
-  "request_id": 1234,
-  "provider": "minimax",
-  "tier_name": "ccr-mm",
-  "model": "MiniMax-M2.5",
-  "timestamp": "2026-02-09T18:37:42.123456Z",
-  "url": "https://api.minimax.io/anthropic/v1/messages",
-  "method": "POST",
-  "request_body": {
-    "model": "MiniMax-M2.5",
-    "messages": [...],
-    "max_tokens": 4096
-  },
-  "response_status": 200,
-  "response_body": "{\"id\":\"msg_...\",\"content\":[...]}",
-  "response_truncated": false,
-  "latency_ms": 2847,
-  "is_streaming": false,
-  "success": true,
-  "error": null
-}
+```text
+ccr_capture_v1_{provider}_{tier_name}_{timestamp}_{request_id}.json
 ```
 
-### Fields
+Example:
 
-| Field | Description |
-|-------|-------------|
-| `request_id` | Unique ID for this request |
-| `provider` | Provider name (e.g., "minimax") |
-| `tier_name` | Tier display name (e.g., "ccr-mm") |
-| `model` | Model name used |
-| `timestamp` | ISO 8601 timestamp |
-| `url` | Request URL |
-| `method` | HTTP method |
-| `request_body` | Full request payload as JSON |
-| `response_status` | HTTP status code (0 if connection failed) |
-| `response_body` | Raw response text |
-| `response_truncated` | Whether body was truncated due to `max_body_size` |
-| `latency_ms` | Request duration in milliseconds |
-| `is_streaming` | Whether this was a streaming request |
-| `success` | True if status was 2xx |
-| `error` | Error message for failed requests |
-
-## Use Cases
-
-### Debugging Response Drift
-
-Capture responses over time to identify when provider behavior changes:
-
-```bash
-# Enable capture for a specific provider
-# Edit config.json: "providers": ["minimax"]
-
-# After running tasks, analyze captures
-ccr-rust captures --provider minimax --limit 100 --full > minimax_samples.json
-
-# Compare response patterns
-jq '.[].response_body | fromjson | .content[0].text | length' minimax_samples.json
+```text
+ccr_capture_v1_minimax_ccr-mm_20260709_183742_123456789_42.json
 ```
 
-### Diagnosing Failures
+Each JSON object contains request identity, provider, tier, model, timestamp,
+URL, method, request body, response status and bounded body, latency, streaming
+state, success state, and an optional error. Headers are absent unless
+`include_headers` was explicitly enabled.
 
-Capture error responses for debugging:
+`success` is true only when the status is 2xx and no provider or transport
+error was recorded.
 
-```bash
-# List captures with errors
-curl -s "http://localhost:3456/debug/capture/list?limit=50" | \
-  jq '[.captures[] | select(.success == false)]'
-```
+## Rotation and cleanup
 
-### Latency Analysis
+Retention runs after every successful write and deletes only the oldest
+current-format regular files until `max_files` is satisfied. If retention
+cannot enforce the configured bound, CCR-Rust removes the new file and reports
+the error rather than increasing disk use.
 
-Analyze response times:
-
-```bash
-# Get latency distribution
-curl -s "http://localhost:3456/debug/capture/list?limit=100" | \
-  jq '[.captures[].latency_ms] | sort | {min: .[0], max: .[-1], median: .[length/2|floor]}'
-```
-
-## File Rotation
-
-CCR-Rust automatically rotates its own current-format capture files as soon as
-`max_files` is exceeded. `max_files=0` is not an unlimited mode; it is replaced
-with the bounded default of 100 files.
-
-1. Rotation runs after every successful capture write
-2. Files are sorted by modification time
-3. Oldest current-format regular files are deleted until under the limit
-4. If the limit cannot be enforced, the newly written capture is removed
-
-To manually clean up captures:
-
-```bash
-# Remove all current-format CCR captures (preserves legacy and task files)
-find ~/.ccr-rust/captures -type f -name 'ccr_capture_v1_*.json' -delete
-
-# Remove current-format CCR captures older than 7 days
-find ~/.ccr-rust/captures -type f -mtime +7 -name 'ccr_capture_v1_*.json' -delete
-```
-
-## Performance Impact
-
-Debug capture adds bounded disk I/O to captured requests:
-- Capture work runs only after an explicit opt-in
-- Each file is synchronously persisted before the request finishes
-- Serialized files and retained file counts have hard bounds
-
-For high-throughput scenarios, consider:
-- Limiting to specific providers
-- Reducing `max_files`
-- Disabling `capture_success` to only capture errors
-
-## Disabling Capture
-
-To disable without removing the config:
+Disable capture immediately after the bounded investigation:
 
 ```json
 {
@@ -275,4 +117,11 @@ To disable without removing the config:
 }
 ```
 
-Or remove the `DebugCapture` section entirely, then restart CCR-Rust.
+To remove only current-format captures:
+
+```bash
+find ~/.ccr-rust/captures -type f -name 'ccr_capture_v1_*.json' -delete
+```
+
+Legacy and unrelated files are intentionally left for an operator to review
+and remove separately.

--- a/src/debug_capture.rs
+++ b/src/debug_capture.rs
@@ -12,28 +12,32 @@
 //!     "enabled": true,
 //!     "providers": ["minimax"],
 //!     "output_dir": "~/.ccr-rust/captures",
-//!     "max_files": 1000,
+//!     "max_files": 100,
 //!     "include_headers": false
 //!   }
 //! }
 //! ```
 //!
 //! Captured files are stored as JSON with timestamped filenames:
-//! `{provider}_{timestamp}_{request_id}.json`
+//! `ccr_capture_v1_{provider}_{tier}_{timestamp}_{request_id}.json`
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
-use std::fs::{self, File};
-use std::io::Write;
-use std::path::PathBuf;
+use std::fs::{self, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
-use tokio::sync::RwLock;
+use tokio::sync::Mutex;
 use tracing::{debug, info, warn};
 
 /// Global request counter for unique IDs.
 static REQUEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+const CAPTURE_FILE_PREFIX: &str = "ccr_capture_v1_";
+const DEFAULT_MAX_FILES: usize = 100;
+const HARD_MAX_FILES: usize = 1000;
+const MAX_CAPTURE_FILE_BYTES: usize = 4 * 1024 * 1024;
 
 /// Configuration for debug capture.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -51,7 +55,8 @@ pub struct DebugCaptureConfig {
     #[serde(default = "default_output_dir")]
     pub output_dir: String,
 
-    /// Maximum number of capture files to keep (oldest are deleted).
+    /// Maximum number of CCR-owned capture files to keep (oldest are deleted).
+    /// Values outside the supported bounded range are replaced or clamped.
     #[serde(default = "default_max_files")]
     pub max_files: usize,
 
@@ -63,7 +68,7 @@ pub struct DebugCaptureConfig {
     #[serde(default = "default_capture_success")]
     pub capture_success: bool,
 
-    /// Maximum response body size to capture (bytes). 0 = unlimited.
+    /// Maximum response body size to capture (bytes).
     #[serde(default = "default_max_body_size")]
     pub max_body_size: usize,
 }
@@ -87,11 +92,11 @@ fn default_output_dir() -> String {
 }
 
 fn default_max_files() -> usize {
-    1000
+    DEFAULT_MAX_FILES
 }
 
 fn default_capture_success() -> bool {
-    true
+    false
 }
 
 fn default_max_body_size() -> usize {
@@ -166,17 +171,33 @@ pub struct DebugCapture {
     config: DebugCaptureConfig,
     output_path: PathBuf,
     provider_filter: HashSet<String>,
-    file_count: Arc<RwLock<usize>>,
+    retention_lock: Mutex<()>,
 }
 
 impl DebugCapture {
     /// Create a new debug capture manager.
-    pub fn new(config: DebugCaptureConfig) -> Result<Self> {
+    pub fn new(mut config: DebugCaptureConfig) -> Result<Self> {
+        if config.max_files == 0 {
+            warn!(
+                default = DEFAULT_MAX_FILES,
+                "Debug capture max_files must be bounded; using the default"
+            );
+            config.max_files = DEFAULT_MAX_FILES;
+        } else if config.max_files > HARD_MAX_FILES {
+            warn!(
+                requested = config.max_files,
+                maximum = HARD_MAX_FILES,
+                "Debug capture max_files exceeds the hard limit; clamping"
+            );
+            config.max_files = HARD_MAX_FILES;
+        }
+
         let output_path = expand_tilde(&config.output_dir);
 
-        // Create output directory if it doesn't exist
+        // Capture is opt-in. Merely parsing or constructing the default
+        // configuration must not create a directory on disk.
         if config.enabled {
-            fs::create_dir_all(&output_path)?;
+            ensure_private_directory(&output_path)?;
             info!(
                 "Debug capture enabled: {} (providers: {:?})",
                 output_path.display(),
@@ -195,7 +216,7 @@ impl DebugCapture {
             config,
             output_path,
             provider_filter,
-            file_count: Arc::new(RwLock::new(0)),
+            retention_lock: Mutex::new(()),
         })
     }
 
@@ -243,18 +264,54 @@ impl DebugCapture {
 
         // Generate filename
         let filename = format!(
-            "{}_{}_{}_{}.json",
-            interaction.provider,
-            interaction.tier_name,
-            chrono::Utc::now().format("%Y%m%d_%H%M%S"),
+            "{}{}_{}_{}_{}.json",
+            CAPTURE_FILE_PREFIX,
+            sanitize_filename_segment(&interaction.provider),
+            sanitize_filename_segment(&interaction.tier_name),
+            chrono::Utc::now().format("%Y%m%d_%H%M%S_%f"),
             interaction.request_id
         );
         let filepath = self.output_path.join(&filename);
 
-        // Serialize and write
+        // Serialize and create a new private file without following or
+        // replacing an existing path. The hard byte cap complements bounded
+        // file retention so capture cannot grow without limit.
         let json = serde_json::to_string_pretty(&interaction)?;
-        let mut file = File::create(&filepath)?;
-        file.write_all(json.as_bytes())?;
+        if json.len() > MAX_CAPTURE_FILE_BYTES {
+            bail!(
+                "debug capture exceeds the {} byte file limit",
+                MAX_CAPTURE_FILE_BYTES
+            );
+        }
+        let write_result = (|| -> Result<()> {
+            let mut options = OpenOptions::new();
+            options.write(true).create_new(true);
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::OpenOptionsExt;
+                options.mode(0o600);
+            }
+            let mut file = options.open(&filepath)?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                file.set_permissions(fs::Permissions::from_mode(0o600))?;
+            }
+            file.write_all(json.as_bytes())?;
+            file.sync_all()?;
+            Ok(())
+        })();
+        if let Err(error) = write_result {
+            let _ = fs::remove_file(&filepath);
+            return Err(error);
+        }
+
+        // Manage file rotation
+        if let Err(error) = self.rotate_files().await {
+            // Never make a failed retention pass increase disk usage.
+            let _ = fs::remove_file(&filepath);
+            return Err(error);
+        }
 
         info!(
             "Captured {} interaction: {} ({}ms, status={})",
@@ -264,31 +321,19 @@ impl DebugCapture {
             interaction.response_status
         );
 
-        // Manage file rotation
-        self.rotate_files().await?;
-
         Ok(())
     }
 
-    /// Rotate old capture files if we exceed max_files.
-    /// max_files = 0 means unlimited (no rotation).
+    /// Rotate old CCR-owned capture files if we exceed max_files.
+    ///
+    /// Legacy JSON files, task captures, symlinks, and other unrelated files
+    /// are deliberately ignored so enabling the new policy cannot erase an
+    /// existing corpus.
     async fn rotate_files(&self) -> Result<()> {
-        // 0 means unlimited — never delete
-        if self.config.max_files == 0 {
-            return Ok(());
-        }
-
-        let mut count = self.file_count.write().await;
-
-        // Only check periodically (every 100 captures)
-        *count += 1;
-        if *count % 100 != 0 {
-            return Ok(());
-        }
-
+        let _guard = self.retention_lock.lock().await;
         let entries: Vec<_> = fs::read_dir(&self.output_path)?
             .filter_map(|e| e.ok())
-            .filter(|e| e.path().extension().is_some_and(|ext| ext == "json"))
+            .filter(is_managed_capture_file)
             .collect();
 
         if entries.len() <= self.config.max_files {
@@ -306,20 +351,37 @@ impl DebugCapture {
             })
             .collect();
 
-        files_with_time.sort_by_key(|entry| entry.1);
+        files_with_time
+            .sort_by(|left, right| left.1.cmp(&right.1).then_with(|| left.0.cmp(&right.0)));
 
         // Delete oldest files
         let to_delete = files_with_time.len() - self.config.max_files;
-        for (path, _) in files_with_time.into_iter().take(to_delete) {
-            if let Err(e) = fs::remove_file(&path) {
-                warn!(
-                    "Failed to remove old capture file {}: {}",
-                    path.display(),
-                    e
-                );
-            } else {
-                debug!("Rotated capture file: {}", path.display());
+        let mut deleted = 0;
+        let mut last_error = None;
+        for (path, _) in files_with_time {
+            if deleted >= to_delete {
+                break;
             }
+            match fs::remove_file(&path) {
+                Ok(()) => {
+                    deleted += 1;
+                    debug!("Rotated capture file: {}", path.display());
+                }
+                Err(error) => {
+                    warn!(
+                        "Failed to remove old capture file {}: {}",
+                        path.display(),
+                        error
+                    );
+                    last_error = Some(error);
+                }
+            }
+        }
+        if deleted < to_delete {
+            let detail = last_error
+                .map(|error| error.to_string())
+                .unwrap_or_else(|| "no removable CCR-owned files".to_string());
+            bail!("debug capture retention could not enforce its limit: {detail}")
         }
 
         Ok(())
@@ -335,16 +397,7 @@ impl DebugCapture {
 
         let mut entries: Vec<_> = fs::read_dir(&self.output_path)?
             .filter_map(|e| e.ok())
-            .filter(|e| {
-                let path = e.path();
-                let is_json = path.extension().is_some_and(|ext| ext == "json");
-                let matches_provider = provider.is_none_or(|p| {
-                    path.file_stem()
-                        .and_then(|s| s.to_str())
-                        .is_some_and(|name| name.starts_with(&format!("{}_", p)))
-                });
-                is_json && matches_provider
-            })
+            .filter(is_managed_capture_file)
             .collect();
 
         // Sort by modification time (newest first)
@@ -359,10 +412,14 @@ impl DebugCapture {
                 )
         });
 
-        for entry in entries.into_iter().take(limit) {
-            match fs::read_to_string(entry.path()) {
-                Ok(content) => {
-                    if let Ok(capture) = serde_json::from_str::<CapturedInteraction>(&content) {
+        let bounded_limit = limit.min(HARD_MAX_FILES);
+        for entry in entries {
+            if captures.len() >= bounded_limit {
+                break;
+            }
+            match read_managed_capture(&entry.path()) {
+                Ok(capture) => {
+                    if provider.is_none_or(|expected| capture.provider == expected) {
                         captures.push(capture);
                     }
                 }
@@ -383,27 +440,25 @@ impl DebugCapture {
     pub fn get_stats(&self) -> Result<CaptureStats> {
         let mut stats = CaptureStats::default();
 
-        for entry in fs::read_dir(&self.output_path)?.filter_map(|e| e.ok()) {
-            let path = entry.path();
-            if path.extension().is_some_and(|ext| ext == "json") {
+        for entry in fs::read_dir(&self.output_path)?
+            .filter_map(|entry| entry.ok())
+            .filter(is_managed_capture_file)
+            .take(HARD_MAX_FILES)
+        {
+            if let Ok(capture) = read_managed_capture(&entry.path()) {
                 stats.total_captures += 1;
+                *stats
+                    .by_provider
+                    .entry(capture.provider.clone())
+                    .or_insert(0) += 1;
 
-                if let Ok(content) = fs::read_to_string(&path) {
-                    if let Ok(capture) = serde_json::from_str::<CapturedInteraction>(&content) {
-                        *stats
-                            .by_provider
-                            .entry(capture.provider.clone())
-                            .or_insert(0) += 1;
-
-                        if capture.success {
-                            stats.success_count += 1;
-                        } else {
-                            stats.error_count += 1;
-                        }
-
-                        stats.total_latency_ms += capture.latency_ms;
-                    }
+                if capture.success {
+                    stats.success_count += 1;
+                } else {
+                    stats.error_count += 1;
                 }
+
+                stats.total_latency_ms += capture.latency_ms;
             }
         }
 
@@ -434,6 +489,86 @@ fn expand_tilde(path: &str) -> PathBuf {
         }
     }
     PathBuf::from(path)
+}
+
+fn ensure_private_directory(path: &Path) -> Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            bail!("debug capture directory must not be a symlink")
+        }
+        Ok(metadata) if !metadata.is_dir() => {
+            bail!("debug capture path exists but is not a directory")
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            fs::create_dir_all(path)?;
+        }
+        Err(error) => return Err(error.into()),
+    }
+
+    let metadata = fs::symlink_metadata(path)?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        bail!("debug capture path is not a private directory")
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700))?;
+    }
+
+    Ok(())
+}
+
+fn sanitize_filename_segment(value: &str) -> String {
+    let sanitized: String = value
+        .chars()
+        .take(64)
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    if sanitized.is_empty() {
+        "unknown".to_string()
+    } else {
+        sanitized
+    }
+}
+
+fn is_managed_capture_file(entry: &fs::DirEntry) -> bool {
+    let Ok(file_type) = entry.file_type() else {
+        return false;
+    };
+    if !file_type.is_file() {
+        return false;
+    }
+    entry
+        .file_name()
+        .to_str()
+        .is_some_and(|name| name.starts_with(CAPTURE_FILE_PREFIX) && name.ends_with(".json"))
+}
+
+fn read_managed_capture(path: &Path) -> Result<CapturedInteraction> {
+    let metadata = fs::symlink_metadata(path)?;
+    if !metadata.file_type().is_file() {
+        bail!("debug capture entry is not a regular file")
+    }
+
+    let mut file = fs::File::open(path)?;
+    let mut bytes = Vec::with_capacity(
+        usize::try_from(metadata.len())
+            .unwrap_or(MAX_CAPTURE_FILE_BYTES)
+            .min(MAX_CAPTURE_FILE_BYTES),
+    );
+    Read::take(&mut file, (MAX_CAPTURE_FILE_BYTES + 1) as u64).read_to_end(&mut bytes)?;
+    if bytes.len() > MAX_CAPTURE_FILE_BYTES {
+        bail!("debug capture exceeds the read limit")
+    }
+    Ok(serde_json::from_slice(&bytes)?)
 }
 
 /// Builder for captured interactions.
@@ -571,6 +706,13 @@ mod tests {
     use super::*;
     use tempfile::tempdir;
 
+    fn interaction(request_id: u64) -> CapturedInteraction {
+        CaptureBuilder::new(request_id, "minimax", "ccr-mm")
+            .model("MiniMax-M2.5")
+            .request_body(serde_json::json!({"request": request_id}))
+            .complete(500, r#"{"error": "test"}"#, None, Some("test".to_string()))
+    }
+
     #[test]
     fn test_capture_builder() {
         let capture = CaptureBuilder::new(1, "minimax", "ccr-mm")
@@ -674,5 +816,135 @@ mod tests {
 
         let capture_mgr = DebugCapture::new(config).unwrap();
         assert!(!capture_mgr.should_capture("minimax"));
+    }
+
+    #[test]
+    fn test_capture_is_disabled_when_configuration_is_absent() {
+        let config: DebugCaptureConfig = serde_json::from_str("{}").unwrap();
+        assert!(!config.enabled);
+        assert!(!config.capture_success);
+
+        let dir = tempdir().unwrap();
+        let output = dir.path().join("not-created");
+        let manager = DebugCapture::new(DebugCaptureConfig {
+            output_dir: output.to_string_lossy().to_string(),
+            ..config
+        })
+        .unwrap();
+
+        assert!(!manager.should_capture("minimax"));
+        assert!(!output.exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_capture_directory_and_file_are_private() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir().unwrap();
+        let output = dir.path().join("captures");
+        fs::create_dir(&output).unwrap();
+        fs::set_permissions(&output, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let manager = DebugCapture::new(DebugCaptureConfig {
+            enabled: true,
+            output_dir: output.to_string_lossy().to_string(),
+            ..Default::default()
+        })
+        .unwrap();
+        manager.record(interaction(11)).await.unwrap();
+
+        assert_eq!(
+            fs::metadata(&output).unwrap().permissions().mode() & 0o777,
+            0o700
+        );
+        let capture_path = fs::read_dir(&output)
+            .unwrap()
+            .filter_map(|entry| entry.ok())
+            .find(is_managed_capture_file)
+            .unwrap()
+            .path();
+        assert_eq!(
+            fs::metadata(capture_path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+
+    #[tokio::test]
+    async fn test_retention_is_immediate_bounded_and_preserves_legacy_files() {
+        let dir = tempdir().unwrap();
+        let output = dir.path().join("captures");
+        fs::create_dir(&output).unwrap();
+        let legacy = output.join("legacy_capture.json");
+        fs::write(&legacy, "legacy").unwrap();
+
+        #[cfg(unix)]
+        let legacy_symlink = {
+            use std::os::unix::fs::symlink;
+            let path = output.join("ccr_capture_v1_legacy_symlink.json");
+            symlink(&legacy, &path).unwrap();
+            Some(path)
+        };
+
+        let manager = DebugCapture::new(DebugCaptureConfig {
+            enabled: true,
+            output_dir: output.to_string_lossy().to_string(),
+            max_files: 2,
+            ..Default::default()
+        })
+        .unwrap();
+
+        for request_id in 1..=3 {
+            manager.record(interaction(request_id)).await.unwrap();
+        }
+
+        let managed_count = fs::read_dir(&output)
+            .unwrap()
+            .filter_map(|entry| entry.ok())
+            .filter(is_managed_capture_file)
+            .count();
+        assert_eq!(managed_count, 2);
+        assert_eq!(manager.list_captures(None, usize::MAX).unwrap().len(), 2);
+        assert_eq!(manager.get_stats().unwrap().total_captures, 2);
+        assert_eq!(fs::read_to_string(&legacy).unwrap(), "legacy");
+        #[cfg(unix)]
+        assert!(legacy_symlink.unwrap().symlink_metadata().is_ok());
+    }
+
+    #[test]
+    fn test_unbounded_retention_value_is_replaced() {
+        let manager = DebugCapture::new(DebugCaptureConfig {
+            max_files: 0,
+            ..Default::default()
+        })
+        .unwrap();
+        assert_eq!(manager.config.max_files, DEFAULT_MAX_FILES);
+
+        let manager = DebugCapture::new(DebugCaptureConfig {
+            max_files: HARD_MAX_FILES + 1,
+            ..Default::default()
+        })
+        .unwrap();
+        assert_eq!(manager.config.max_files, HARD_MAX_FILES);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_capture_directory_symlink_is_rejected() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempdir().unwrap();
+        let actual = dir.path().join("actual");
+        let linked = dir.path().join("linked");
+        fs::create_dir(&actual).unwrap();
+        symlink(&actual, &linked).unwrap();
+
+        let result = DebugCapture::new(DebugCaptureConfig {
+            enabled: true,
+            output_dir: linked.to_string_lossy().to_string(),
+            ..Default::default()
+        });
+
+        assert!(result.is_err());
     }
 }

--- a/src/debug_capture.rs
+++ b/src/debug_capture.rs
@@ -19,7 +19,7 @@
 //! ```
 //!
 //! Captured files are stored as JSON with timestamped filenames:
-//! `ccr_capture_v1_{provider}_{tier}_{timestamp}_{request_id}.json`
+//! `ccr_capture_v1_{provider}_{tier_name}_{timestamp}_{request_id}.json`
 
 use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
@@ -38,6 +38,9 @@ const CAPTURE_FILE_PREFIX: &str = "ccr_capture_v1_";
 const DEFAULT_MAX_FILES: usize = 100;
 const HARD_MAX_FILES: usize = 1000;
 const MAX_CAPTURE_FILE_BYTES: usize = 4 * 1024 * 1024;
+const HARD_MAX_BODY_BYTES: usize = 2 * 1024 * 1024;
+const MAX_LIST_FILES: usize = 100;
+const MAX_LIST_BYTES: u64 = 16 * 1024 * 1024;
 
 /// Configuration for debug capture.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -81,7 +84,7 @@ impl Default for DebugCaptureConfig {
             output_dir: default_output_dir(),
             max_files: default_max_files(),
             include_headers: false,
-            capture_success: true,
+            capture_success: default_capture_success(),
             max_body_size: default_max_body_size(),
         }
     }
@@ -191,6 +194,20 @@ impl DebugCapture {
             );
             config.max_files = HARD_MAX_FILES;
         }
+        if config.max_body_size == 0 {
+            warn!(
+                default = default_max_body_size(),
+                "Debug capture max_body_size must be bounded; using the default"
+            );
+            config.max_body_size = default_max_body_size();
+        } else if config.max_body_size > HARD_MAX_BODY_BYTES {
+            warn!(
+                requested = config.max_body_size,
+                maximum = HARD_MAX_BODY_BYTES,
+                "Debug capture max_body_size exceeds the hard limit; clamping"
+            );
+            config.max_body_size = HARD_MAX_BODY_BYTES;
+        }
 
         let output_path = expand_tilde(&config.output_dir);
 
@@ -245,6 +262,18 @@ impl DebugCapture {
     /// Generate a new request ID.
     pub fn next_request_id(&self) -> u64 {
         REQUEST_COUNTER.fetch_add(1, Ordering::SeqCst)
+    }
+
+    /// Create a builder with all configured privacy limits applied.
+    pub fn builder(&self, provider: &str, tier_name: &str) -> CaptureBuilder {
+        CaptureBuilder::new(self.next_request_id(), provider, tier_name)
+            .include_headers(self.config.include_headers)
+            .max_body_size(self.config.max_body_size)
+    }
+
+    /// Return whether explicitly requested sanitized headers should be stored.
+    pub fn headers_enabled(&self) -> bool {
+        self.config.include_headers
     }
 
     /// Record a captured interaction.
@@ -336,10 +365,6 @@ impl DebugCapture {
             .filter(is_managed_capture_file)
             .collect();
 
-        if entries.len() <= self.config.max_files {
-            return Ok(());
-        }
-
         // Sort by modification time (oldest first)
         let mut files_with_time: Vec<_> = entries
             .into_iter()
@@ -353,6 +378,10 @@ impl DebugCapture {
 
         files_with_time
             .sort_by(|left, right| left.1.cmp(&right.1).then_with(|| left.0.cmp(&right.0)));
+
+        if files_with_time.len() <= self.config.max_files {
+            return Ok(());
+        }
 
         // Delete oldest files
         let to_delete = files_with_time.len() - self.config.max_files;
@@ -412,14 +441,24 @@ impl DebugCapture {
                 )
         });
 
-        let bounded_limit = limit.min(HARD_MAX_FILES);
+        let bounded_limit = limit.min(MAX_LIST_FILES);
+        let mut listed_bytes = 0_u64;
         for entry in entries {
             if captures.len() >= bounded_limit {
                 break;
             }
+            let Ok(metadata) = entry.metadata() else {
+                continue;
+            };
+            if metadata.len() > MAX_CAPTURE_FILE_BYTES as u64
+                || listed_bytes.saturating_add(metadata.len()) > MAX_LIST_BYTES
+            {
+                continue;
+            }
             match read_managed_capture(&entry.path()) {
                 Ok(capture) => {
                     if provider.is_none_or(|expected| capture.provider == expected) {
+                        listed_bytes += metadata.len();
                         captures.push(capture);
                     }
                 }
@@ -440,12 +479,24 @@ impl DebugCapture {
     pub fn get_stats(&self) -> Result<CaptureStats> {
         let mut stats = CaptureStats::default();
 
+        let mut inspected_bytes = 0_u64;
         for entry in fs::read_dir(&self.output_path)?
             .filter_map(|entry| entry.ok())
             .filter(is_managed_capture_file)
-            .take(HARD_MAX_FILES)
         {
+            if stats.total_captures >= MAX_LIST_FILES {
+                break;
+            }
+            let Ok(metadata) = entry.metadata() else {
+                continue;
+            };
+            if metadata.len() > MAX_CAPTURE_FILE_BYTES as u64
+                || inspected_bytes.saturating_add(metadata.len()) > MAX_LIST_BYTES
+            {
+                continue;
+            }
             if let Ok(capture) = read_managed_capture(&entry.path()) {
+                inspected_bytes += metadata.len();
                 stats.total_captures += 1;
                 *stats
                     .by_provider
@@ -631,7 +682,11 @@ impl CaptureBuilder {
     }
 
     pub fn max_body_size(mut self, size: usize) -> Self {
-        self.max_body_size = size;
+        self.max_body_size = if size == 0 {
+            default_max_body_size()
+        } else {
+            size.min(HARD_MAX_BODY_BYTES)
+        };
         self
     }
 
@@ -658,12 +713,8 @@ impl CaptureBuilder {
             .map(|t| t.elapsed().as_millis() as u64)
             .unwrap_or(0);
 
-        let (body, truncated) =
-            if self.max_body_size > 0 && response_body.len() > self.max_body_size {
-                (response_body[..self.max_body_size].to_string(), true)
-            } else {
-                (response_body.to_string(), false)
-            };
+        let (body, truncated) = truncate_utf8(response_body, self.max_body_size);
+        let success = error.is_none() && (200..300).contains(&status);
 
         CapturedInteraction {
             request_id: self.request_id,
@@ -689,7 +740,7 @@ impl CaptureBuilder {
             response_truncated: truncated,
             latency_ms,
             is_streaming: self.is_streaming,
-            success: (200..300).contains(&status),
+            success,
             error,
             metadata: None,
         }
@@ -699,6 +750,17 @@ impl CaptureBuilder {
     pub fn complete_with_error(self, error: impl Into<String>) -> CapturedInteraction {
         self.complete(0, "", None, Some(error.into()))
     }
+}
+
+fn truncate_utf8(value: &str, max_bytes: usize) -> (String, bool) {
+    if value.len() <= max_bytes {
+        return (value.to_string(), false);
+    }
+    let mut end = max_bytes.min(value.len());
+    while end > 0 && !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    (value[..end].to_string(), true)
 }
 
 #[cfg(test)]
@@ -755,6 +817,54 @@ mod tests {
         assert_eq!(capture.response_body.len(), 1000);
     }
 
+    #[test]
+    fn test_truncation_preserves_utf8_boundaries() {
+        let capture = CaptureBuilder::new(4, "minimax", "ccr-mm")
+            .max_body_size(3)
+            .complete(500, "éé", None, Some("failed".to_string()));
+
+        assert!(capture.response_truncated);
+        assert_eq!(capture.response_body, "é");
+    }
+
+    #[test]
+    fn test_http_200_with_error_is_not_successful() {
+        let capture = CaptureBuilder::new(5, "minimax", "ccr-mm").complete(
+            200,
+            r#"{"error":"quota"}"#,
+            None,
+            Some("embedded provider error".to_string()),
+        );
+
+        assert!(!capture.success);
+    }
+
+    #[test]
+    fn test_builder_applies_header_and_body_privacy_config() {
+        let dir = tempdir().unwrap();
+        let manager = DebugCapture::new(DebugCaptureConfig {
+            enabled: true,
+            output_dir: dir.path().to_string_lossy().to_string(),
+            include_headers: false,
+            max_body_size: 3,
+            ..Default::default()
+        })
+        .unwrap();
+        let capture = manager
+            .builder("minimax", "ccr-mm")
+            .request_headers(serde_json::json!({"authorization": "secret"}))
+            .complete(
+                500,
+                "éé",
+                Some(serde_json::json!({"set-cookie": "secret"})),
+                Some("failed".to_string()),
+            );
+
+        assert!(capture.request_headers.is_none());
+        assert!(capture.response_headers.is_none());
+        assert_eq!(capture.response_body, "é");
+    }
+
     #[tokio::test]
     async fn test_debug_capture_manager() {
         let dir = tempdir().unwrap();
@@ -763,6 +873,7 @@ mod tests {
             providers: vec!["minimax".to_string()],
             output_dir: dir.path().to_string_lossy().to_string(),
             max_files: 10,
+            capture_success: true,
             ..Default::default()
         };
 
@@ -820,6 +931,7 @@ mod tests {
 
     #[test]
     fn test_capture_is_disabled_when_configuration_is_absent() {
+        assert!(!DebugCaptureConfig::default().capture_success);
         let config: DebugCaptureConfig = serde_json::from_str("{}").unwrap();
         assert!(!config.enabled);
         assert!(!config.capture_success);
@@ -926,6 +1038,45 @@ mod tests {
         })
         .unwrap();
         assert_eq!(manager.config.max_files, HARD_MAX_FILES);
+    }
+
+    #[test]
+    fn test_unbounded_body_limit_is_replaced_or_clamped() {
+        let manager = DebugCapture::new(DebugCaptureConfig {
+            max_body_size: 0,
+            ..Default::default()
+        })
+        .unwrap();
+        assert_eq!(manager.config.max_body_size, default_max_body_size());
+
+        let manager = DebugCapture::new(DebugCaptureConfig {
+            max_body_size: HARD_MAX_BODY_BYTES + 1,
+            ..Default::default()
+        })
+        .unwrap();
+        assert_eq!(manager.config.max_body_size, HARD_MAX_BODY_BYTES);
+    }
+
+    #[tokio::test]
+    async fn test_listing_and_statistics_have_hard_result_caps() {
+        let dir = tempdir().unwrap();
+        let manager = DebugCapture::new(DebugCaptureConfig {
+            enabled: true,
+            output_dir: dir.path().to_string_lossy().to_string(),
+            max_files: HARD_MAX_FILES,
+            ..Default::default()
+        })
+        .unwrap();
+
+        for request_id in 0..=MAX_LIST_FILES as u64 {
+            manager.record(interaction(request_id)).await.unwrap();
+        }
+
+        assert_eq!(
+            manager.list_captures(None, usize::MAX).unwrap().len(),
+            MAX_LIST_FILES
+        );
+        assert_eq!(manager.get_stats().unwrap().total_captures, MAX_LIST_FILES);
     }
 
     #[cfg(unix)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -422,10 +422,6 @@ async fn run_server(
         )
         .route("/health", get(health))
         .route("/metrics", get(metrics::metrics_handler))
-        // Debug capture API
-        .route("/debug/capture/status", get(debug_capture_status))
-        .route("/debug/capture/list", get(debug_capture_list))
-        .route("/debug/capture/stats", get(debug_capture_stats))
         .layer(CorsLayer::permissive())
         .layer(TraceLayer::new_for_http())
         .with_state(state);
@@ -643,65 +639,6 @@ async fn latencies_handler(State(state): State<AppState>) -> impl axum::response
 
 async fn health() -> &'static str {
     "ok"
-}
-
-// Debug capture API handlers
-async fn debug_capture_status(State(state): State<AppState>) -> impl axum::response::IntoResponse {
-    match &state.debug_capture {
-        Some(capture) => {
-            let stats = capture.get_stats().unwrap_or_default();
-            axum::Json(serde_json::json!({
-                "enabled": true,
-                "output_dir": state.config.debug_capture().output_dir,
-                "providers": state.config.debug_capture().providers,
-                "stats": stats
-            }))
-        }
-        None => axum::Json(serde_json::json!({
-            "enabled": false,
-            "message": "Debug capture not configured. Add DebugCapture to config.json"
-        })),
-    }
-}
-
-async fn debug_capture_list(
-    State(state): State<AppState>,
-    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
-) -> impl axum::response::IntoResponse {
-    let provider = params.get("provider").map(|s| s.as_str());
-    let limit: usize = params
-        .get("limit")
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(20);
-
-    match &state.debug_capture {
-        Some(capture) => match capture.list_captures(provider, limit) {
-            Ok(captures) => axum::Json(serde_json::json!({
-                "captures": captures,
-                "count": captures.len()
-            })),
-            Err(e) => axum::Json(serde_json::json!({
-                "error": format!("Failed to list captures: {}", e)
-            })),
-        },
-        None => axum::Json(serde_json::json!({
-            "error": "Debug capture not enabled"
-        })),
-    }
-}
-
-async fn debug_capture_stats(State(state): State<AppState>) -> impl axum::response::IntoResponse {
-    match &state.debug_capture {
-        Some(capture) => match capture.get_stats() {
-            Ok(stats) => axum::Json(serde_json::json!(stats)),
-            Err(e) => axum::Json(serde_json::json!({
-                "error": format!("Failed to get stats: {}", e)
-            })),
-        },
-        None => axum::Json(serde_json::json!({
-            "error": "Debug capture not enabled"
-        })),
-    }
 }
 
 #[cfg(all(test, feature = "gp"))]

--- a/src/router/dispatch.rs
+++ b/src/router/dispatch.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use tracing::{trace, warn};
 
 use super::streaming::{
-    BoxByteStream, stream_anthropic_response_with_tracking, stream_response_translated,
+    stream_anthropic_response_with_tracking, stream_response_translated, BoxByteStream,
 };
 use super::translate_request::translate_request_anthropic_to_openai;
 use super::translate_response::{build_transformer_chain, translate_response_openai_to_anthropic};
@@ -21,6 +21,52 @@ use crate::sse::{SseFrameDecoder, StreamVerifyCtx};
 use crate::transform::openai_to_anthropic::OpenAiToAnthropicTransformer;
 use crate::transformer::{Transformer, TransformerChain, TransformerRegistry};
 use futures::StreamExt;
+
+fn sanitized_capture_headers(headers: &reqwest::header::HeaderMap) -> serde_json::Value {
+    let mut values = serde_json::Map::new();
+    for (name, value) in headers.iter().take(64) {
+        let normalized = name.as_str().to_ascii_lowercase();
+        let sensitive = matches!(
+            normalized.as_str(),
+            "authorization" | "proxy-authorization" | "cookie" | "set-cookie"
+        ) || normalized.contains("api-key")
+            || normalized.contains("apikey")
+            || normalized.contains("credential")
+            || normalized.ends_with("-token")
+            || normalized.ends_with("_token");
+        let rendered = if sensitive {
+            "[REDACTED]".to_string()
+        } else {
+            value
+                .to_str()
+                .unwrap_or("[NON_UTF8]")
+                .chars()
+                .take(512)
+                .collect()
+        };
+        values.insert(
+            name.as_str().to_string(),
+            serde_json::Value::String(rendered),
+        );
+    }
+    serde_json::Value::Object(values)
+}
+
+async fn persist_debug_capture(
+    capture: Option<&Arc<DebugCapture>>,
+    builder: Option<CaptureBuilder>,
+    status: u16,
+    response_body: &str,
+    response_headers: Option<serde_json::Value>,
+    error: Option<String>,
+) {
+    if let (Some(capture), Some(builder)) = (capture, builder) {
+        let interaction = builder.complete(status, response_body, response_headers, error);
+        if let Err(capture_err) = capture.record(interaction).await {
+            warn!("Failed to record debug capture: {}", capture_err);
+        }
+    }
+}
 
 /// Peek at the first chunk of a streaming response to detect error payloads
 /// wrapped in HTTP 200 (e.g. Z.AI returns quota errors as raw JSON in a
@@ -117,9 +163,8 @@ async fn check_stream_for_embedded_error(
             }
             Ok(Ok(None)) => {
                 if buf.is_empty() {
-                    let empty: BoxByteStream = Box::pin(
-                        futures::stream::empty::<Result<bytes::Bytes, reqwest::Error>>(),
-                    );
+                    let empty: BoxByteStream =
+                        Box::pin(futures::stream::empty::<Result<bytes::Bytes, reqwest::Error>>());
                     return Ok(empty);
                 }
                 break;
@@ -550,14 +595,16 @@ pub(super) async fn try_request_via_openai_protocol(
     // Set up capture if enabled for this provider
     let capture_builder = if let Some(ref capture) = debug_capture {
         if capture.should_capture(&provider.name) {
-            Some(
-                CaptureBuilder::new(capture.next_request_id(), &provider.name, tier_name)
-                    .model(model_name)
-                    .url(&url)
-                    .request_body(openai_request_value.clone())
-                    .streaming(stream_flag)
-                    .start(),
-            )
+            let mut builder = capture
+                .builder(&provider.name, tier_name)
+                .model(model_name)
+                .url(&url)
+                .request_body(openai_request_value.clone())
+                .streaming(stream_flag);
+            if capture.headers_enabled() {
+                builder = builder.request_headers(sanitized_capture_headers(&headers));
+            }
+            Some(builder.start())
         } else {
             None
         }
@@ -590,15 +637,43 @@ pub(super) async fn try_request_via_openai_protocol(
 
     if !resp.status().is_success() {
         let status = resp.status();
+        let retry_after = resp
+            .headers()
+            .get("retry-after")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse::<u64>().ok())
+            .map(std::time::Duration::from_secs);
+        let captured_headers = debug_capture
+            .as_ref()
+            .filter(|capture| capture.headers_enabled())
+            .map(|_| sanitized_capture_headers(resp.headers()));
+        let body = match resp.text().await {
+            Ok(body) => body,
+            Err(error) => {
+                persist_debug_capture(
+                    debug_capture.as_ref(),
+                    capture_builder,
+                    status.as_u16(),
+                    "",
+                    captured_headers,
+                    Some(error.to_string()),
+                )
+                .await;
+                return Err(TryRequestError::Other(error.into()));
+            }
+        };
+        let provider_error = format!("Provider returned {status} from {url}");
+        persist_debug_capture(
+            debug_capture.as_ref(),
+            capture_builder,
+            status.as_u16(),
+            &body,
+            captured_headers,
+            Some(provider_error),
+        )
+        .await;
 
         if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
-            let retry_after = resp
-                .headers()
-                .get("retry-after")
-                .and_then(|v| v.to_str().ok())
-                .and_then(|s| s.parse::<u64>().ok())
-                .map(std::time::Duration::from_secs);
-
             record_rate_limit_hit(tier_name);
             ratelimit_tracker.record_429(tier_name, retry_after);
             record_rate_limit_backoff(tier_name);
@@ -606,10 +681,6 @@ pub(super) async fn try_request_via_openai_protocol(
             return Err(TryRequestError::RateLimited(retry_after));
         }
 
-        let body = resp
-            .text()
-            .await
-            .map_err(|e| TryRequestError::Other(e.into()))?;
         return Err(TryRequestError::Other(anyhow::anyhow!(
             "Provider returned {} from {}: {}",
             status,
@@ -622,10 +693,34 @@ pub(super) async fn try_request_via_openai_protocol(
     if stream_flag {
         // For streaming, we need to translate OpenAI SSE events to Anthropic SSE.
         let rate_limit_info = extract_rate_limit_headers(&resp);
+        let resp_status = resp.status().as_u16();
+        let captured_headers = debug_capture
+            .as_ref()
+            .filter(|capture| capture.headers_enabled())
+            .map(|_| sanitized_capture_headers(resp.headers()));
 
         // Peek at first chunk to detect errors embedded in 200 streams.
-        let byte_stream =
-            check_stream_for_embedded_error(resp, tier_name, stream_first_event_timeout).await?;
+        let byte_stream = match check_stream_for_embedded_error(
+            resp,
+            tier_name,
+            stream_first_event_timeout,
+        )
+        .await
+        {
+            Ok(stream) => stream,
+            Err(error) => {
+                persist_debug_capture(
+                    debug_capture.as_ref(),
+                    capture_builder,
+                    resp_status,
+                    "",
+                    captured_headers,
+                    Some(error.to_string()),
+                )
+                .await;
+                return Err(error);
+            }
+        };
 
         let ctx = StreamVerifyCtx {
             tier_name: tier_name.to_string(),
@@ -649,6 +744,10 @@ pub(super) async fn try_request_via_openai_protocol(
 
         // For non-streaming, translate the full response.
         let resp_status = resp.status().as_u16();
+        let captured_headers = debug_capture
+            .as_ref()
+            .filter(|capture| capture.headers_enabled())
+            .map(|_| sanitized_capture_headers(resp.headers()));
         let body = resp
             .bytes()
             .await
@@ -656,7 +755,19 @@ pub(super) async fn try_request_via_openai_protocol(
 
         // Check for embedded error in 200 body BEFORE recording success,
         // otherwise a failed request corrupts tier rate-limit state.
-        check_body_for_embedded_error(&body, tier_name)?;
+        if let Err(error) = check_body_for_embedded_error(&body, tier_name) {
+            let body_str = String::from_utf8_lossy(&body);
+            persist_debug_capture(
+                debug_capture.as_ref(),
+                capture_builder,
+                resp_status,
+                &body_str,
+                captured_headers,
+                Some(error.to_string()),
+            )
+            .await;
+            return Err(error);
+        }
 
         ratelimit_tracker.record_success(tier_name, rate_limit_info.0, rate_limit_info.1);
 
@@ -664,7 +775,7 @@ pub(super) async fn try_request_via_openai_protocol(
 
         // Record capture for non-streaming response
         if let (Some(builder), Some(capture)) = (capture_builder, debug_capture.clone()) {
-            let interaction = builder.complete(resp_status, &body_str, None, None);
+            let interaction = builder.complete(resp_status, &body_str, captured_headers, None);
             if let Err(capture_err) = capture.record(interaction).await {
                 warn!("Failed to record debug capture: {}", capture_err);
             }
@@ -772,14 +883,16 @@ pub(super) async fn try_request_via_anthropic_protocol(
     // Set up capture if enabled for this provider
     let capture_builder = if let Some(ref capture) = debug_capture {
         if capture.should_capture(&provider.name) {
-            Some(
-                CaptureBuilder::new(capture.next_request_id(), &provider.name, tier_name)
-                    .model(model_name)
-                    .url(&url)
-                    .request_body(normalized_request_value)
-                    .streaming(request.stream.unwrap_or(false))
-                    .start(),
-            )
+            let mut builder = capture
+                .builder(&provider.name, tier_name)
+                .model(model_name)
+                .url(&url)
+                .request_body(normalized_request_value)
+                .streaming(request.stream.unwrap_or(false));
+            if capture.headers_enabled() {
+                builder = builder.request_headers(sanitized_capture_headers(&headers));
+            }
+            Some(builder.start())
         } else {
             None
         }
@@ -812,16 +925,44 @@ pub(super) async fn try_request_via_anthropic_protocol(
 
     if !resp.status().is_success() {
         let status = resp.status();
+        let retry_after = resp
+            .headers()
+            .get("retry-after")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse::<u64>().ok())
+            .map(std::time::Duration::from_secs);
+        let captured_headers = debug_capture
+            .as_ref()
+            .filter(|capture| capture.headers_enabled())
+            .map(|_| sanitized_capture_headers(resp.headers()));
+        let body = match resp.text().await {
+            Ok(body) => body,
+            Err(error) => {
+                persist_debug_capture(
+                    debug_capture.as_ref(),
+                    capture_builder,
+                    status.as_u16(),
+                    "",
+                    captured_headers,
+                    Some(error.to_string()),
+                )
+                .await;
+                return Err(TryRequestError::Other(error.into()));
+            }
+        };
+        let provider_error = format!("Provider returned {status} from {url}");
+        persist_debug_capture(
+            debug_capture.as_ref(),
+            capture_builder,
+            status.as_u16(),
+            &body,
+            captured_headers,
+            Some(provider_error),
+        )
+        .await;
 
         // For 429 rate limit, pass through to let coordinator/client handle routing
         if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
-            let retry_after = resp
-                .headers()
-                .get("retry-after")
-                .and_then(|v| v.to_str().ok())
-                .and_then(|s| s.parse::<u64>().ok())
-                .map(std::time::Duration::from_secs);
-
             record_rate_limit_hit(tier_name);
             ratelimit_tracker.record_429(tier_name, retry_after);
             record_rate_limit_backoff(tier_name);
@@ -829,10 +970,6 @@ pub(super) async fn try_request_via_anthropic_protocol(
             return Err(TryRequestError::RateLimited(retry_after));
         }
 
-        let body = resp
-            .text()
-            .await
-            .map_err(|e| TryRequestError::Other(e.into()))?;
         return Err(TryRequestError::Other(anyhow::anyhow!(
             "Provider returned {} from {}: {}",
             status,
@@ -844,10 +981,34 @@ pub(super) async fn try_request_via_anthropic_protocol(
     if request.stream.unwrap_or(false) {
         // Use streaming token tracking for Anthropic protocol
         let rate_limit_info = extract_rate_limit_headers(&resp);
+        let resp_status = resp.status().as_u16();
+        let captured_headers = debug_capture
+            .as_ref()
+            .filter(|capture| capture.headers_enabled())
+            .map(|_| sanitized_capture_headers(resp.headers()));
 
         // Peek at first chunk to detect errors embedded in 200 streams.
-        let byte_stream =
-            check_stream_for_embedded_error(resp, tier_name, stream_first_event_timeout).await?;
+        let byte_stream = match check_stream_for_embedded_error(
+            resp,
+            tier_name,
+            stream_first_event_timeout,
+        )
+        .await
+        {
+            Ok(stream) => stream,
+            Err(error) => {
+                persist_debug_capture(
+                    debug_capture.as_ref(),
+                    capture_builder,
+                    resp_status,
+                    "",
+                    captured_headers,
+                    Some(error.to_string()),
+                )
+                .await;
+                return Err(error);
+            }
+        };
 
         let ctx = StreamVerifyCtx {
             tier_name: tier_name.to_string(),
@@ -872,13 +1033,29 @@ pub(super) async fn try_request_via_anthropic_protocol(
 
         let resp_status = resp.status().as_u16();
         let status = reqwest_status_to_axum(resp.status());
+        let captured_headers = debug_capture
+            .as_ref()
+            .filter(|capture| capture.headers_enabled())
+            .map(|_| sanitized_capture_headers(resp.headers()));
         let body = resp
             .bytes()
             .await
             .map_err(|e| TryRequestError::Other(e.into()))?;
 
         // Check for embedded error before recording success.
-        check_body_for_embedded_error(&body, tier_name)?;
+        if let Err(error) = check_body_for_embedded_error(&body, tier_name) {
+            let body_str = String::from_utf8_lossy(&body);
+            persist_debug_capture(
+                debug_capture.as_ref(),
+                capture_builder,
+                resp_status,
+                &body_str,
+                captured_headers,
+                Some(error.to_string()),
+            )
+            .await;
+            return Err(error);
+        }
 
         ratelimit_tracker.record_success(tier_name, rate_limit_info.0, rate_limit_info.1);
 
@@ -886,7 +1063,7 @@ pub(super) async fn try_request_via_anthropic_protocol(
 
         // Record capture for non-streaming Anthropic response
         if let (Some(builder), Some(capture)) = (capture_builder, debug_capture.clone()) {
-            let interaction = builder.complete(resp_status, &body_str, None, None);
+            let interaction = builder.complete(resp_status, &body_str, captured_headers, None);
             if let Err(capture_err) = capture.record(interaction).await {
                 warn!("Failed to record debug capture: {}", capture_err);
             }
@@ -996,5 +1173,28 @@ mod tests {
 
         assert_eq!(headers.get("authorization").unwrap(), "Bearer ak-test");
         assert!(headers.get("x-api-key").is_none());
+    }
+
+    #[test]
+    fn debug_capture_headers_are_bounded_and_redacted() {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            reqwest::header::AUTHORIZATION,
+            reqwest::header::HeaderValue::from_static("Bearer secret"),
+        );
+        headers.insert(
+            reqwest::header::HeaderName::from_static("x-api-key"),
+            reqwest::header::HeaderValue::from_static("also-secret"),
+        );
+        headers.insert(
+            reqwest::header::HeaderName::from_static("x-request-id"),
+            reqwest::header::HeaderValue::from_static("request-123"),
+        );
+
+        let captured = sanitized_capture_headers(&headers);
+
+        assert_eq!(captured["authorization"], "[REDACTED]");
+        assert_eq!(captured["x-api-key"], "[REDACTED]");
+        assert_eq!(captured["x-request-id"], "request-123");
     }
 }


### PR DESCRIPTION
## Summary
- disable raw provider capture by default and default enabled capture to errors only
- enforce private directories/files, create-new writes, hard byte/count bounds, and current-prefix-only retention
- keep legacy corpus untouched while making listing/statistics symlink-safe and bounded

## Verification
- cargo test --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- git diff --check