### PR TITLE
fix: authenticate the native MCP daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Authenticated native MCP daemon** — `mcp-daemon` now requires a bearer token
+  from `--auth-token` or `CCR_MCP_AUTH_TOKEN`, compares presented credentials in
+  constant time, and protects both `/health` and `/mcp`.
+- **Private configurable Pyright workspaces** — Pyright now requires
+  `--pyright-workspace-dir` or `CCR_MCP_PYRIGHT_WORKSPACE_DIR` alongside the
+  project root, enforces mode `0700`, and removes stale CCR-owned UUID
+  workspaces at daemon startup without traversing symlink targets.
 - **GP routing enabled in standard builds** — Added `gp` to the default feature
   set, expanded the encoder and default candidate limit from 8 to 32 routes,
   and reject GP-enabled configuration when using an explicitly GP-free build.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,6 +447,7 @@ dependencies = [
  "shellexpand",
  "sindexer",
  "smallvec",
+ "subtle",
  "tempfile",
  "tiktoken-rs",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ serde_json = "1.0"
 sha2 = "0.10"
 shellexpand = "3"
 smallvec = "1.13"
+subtle = "2.6"
 tiktoken-rs = "0.9"
 tokio = { version = "1.35", features = ["full"] }
 tokio-stream = "0.1"

--- a/README.md
+++ b/README.md
@@ -97,6 +97,34 @@ That means you can keep using Claude Code as your interface even when the actual
 | `/health`              | GET    | Health check                |
 | `/metrics`             | GET    | Prometheus metrics          |
 
+### Native MCP daemon
+
+The separate native MCP daemon requires bearer authentication on both `/health`
+and `/mcp`. Prefer the environment variable so the token is not exposed in the
+process argument list:
+
+```bash
+export CCR_MCP_AUTH_TOKEN="replace-with-a-private-random-token"
+ccr-rust mcp-daemon
+
+curl -H "Authorization: Bearer ${CCR_MCP_AUTH_TOKEN}" \
+  http://127.0.0.1:3457/health
+```
+
+`--auth-token` supplies the same value explicitly. To enable the Pyright MCP
+tool, configure both the project and its dedicated private workspace root:
+
+```bash
+ccr-rust mcp-daemon \
+  --pyright-root /path/to/project \
+  --pyright-workspace-dir ~/.cache/ccr-rust/pyright-workspaces
+```
+
+The equivalent environment variables are `PYRIGHT_PROJECT_ROOT` and
+`CCR_MCP_PYRIGHT_WORKSPACE_DIR`. CCR-Rust enforces mode `0700` on the workspace
+root and each request directory and removes stale CCR-owned request directories
+when the daemon starts.
+
 ## Configuration
 
 CCR-Rust reads `~/.claude-code-router/config.json`. Supports `${ENV_VAR}` substitution.

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,6 +139,10 @@ enum Commands {
         #[arg(long, default_value = "127.0.0.1", env = "CCR_MCP_DAEMON_HOST")]
         host: String,
 
+        /// Bearer token required by the health and MCP endpoints
+        #[arg(long, env = "CCR_MCP_AUTH_TOKEN", hide_env_values = true)]
+        auth_token: String,
+
         /// Directory for memory graph persistence
         #[arg(long, env = "CCR_MCP_MEMORY_DIR")]
         memory_dir: Option<String>,
@@ -146,6 +150,10 @@ enum Commands {
         /// Project root for Pyright type-checking
         #[arg(long, env = "PYRIGHT_PROJECT_ROOT")]
         pyright_root: Option<String>,
+
+        /// Private directory for ephemeral Pyright request workspaces
+        #[arg(long, env = "CCR_MCP_PYRIGHT_WORKSPACE_DIR")]
+        pyright_workspace_dir: Option<String>,
     },
     /// List and analyze debug captures.
     Captures {
@@ -587,14 +595,18 @@ async fn main() -> Result<()> {
         Some(Commands::McpDaemon {
             port,
             host,
+            auth_token,
             memory_dir,
             pyright_root,
+            pyright_workspace_dir,
         }) => {
             ccr_rust::mcp::daemon::run(ccr_rust::mcp::daemon::DaemonArgs {
                 port,
                 host,
+                auth_token,
                 memory_dir: memory_dir.map(std::path::PathBuf::from),
                 pyright_root: pyright_root.map(std::path::PathBuf::from),
+                pyright_workspace_dir: pyright_workspace_dir.map(std::path::PathBuf::from),
             })
             .await?;
         }

--- a/src/mcp/auth.rs
+++ b/src/mcp/auth.rs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+use anyhow::{bail, Result};
+use axum::http::{header::AUTHORIZATION, HeaderMap};
+use sha2::{Digest, Sha256};
+use subtle::ConstantTimeEq;
+
+pub(super) struct BearerAuth {
+    token_digest: [u8; 32],
+}
+
+impl BearerAuth {
+    pub(super) fn new(token: String) -> Result<Self> {
+        if token.is_empty()
+            || !token.is_ascii()
+            || token
+                .bytes()
+                .any(|byte| byte.is_ascii_whitespace() || byte.is_ascii_control())
+        {
+            bail!("MCP daemon bearer token must be nonempty ASCII without whitespace");
+        }
+
+        Ok(Self {
+            token_digest: Sha256::digest(token.as_bytes()).into(),
+        })
+    }
+
+    pub(super) fn authorizes(&self, headers: &HeaderMap) -> bool {
+        let Some(value) = headers.get(AUTHORIZATION) else {
+            return false;
+        };
+        let bytes = value.as_bytes();
+        let Some(separator) = bytes.iter().position(|byte| *byte == b' ') else {
+            return false;
+        };
+        let (scheme, token) = bytes.split_at(separator);
+        let token = &token[1..];
+        if !scheme.eq_ignore_ascii_case(b"Bearer") || token.is_empty() {
+            return false;
+        }
+
+        let candidate_digest: [u8; 32] = Sha256::digest(token).into();
+        self.token_digest.ct_eq(&candidate_digest).into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+
+    #[test]
+    fn bearer_auth_rejects_missing_and_wrong_tokens() {
+        let auth = BearerAuth::new("correct-token".to_string()).unwrap();
+        assert!(!auth.authorizes(&HeaderMap::new()));
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_static("Bearer wrong-token"),
+        );
+        assert!(!auth.authorizes(&headers));
+    }
+
+    #[test]
+    fn bearer_auth_accepts_correct_token_and_case_insensitive_scheme() {
+        let auth = BearerAuth::new("correct-token".to_string()).unwrap();
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_static("bearer correct-token"),
+        );
+        assert!(auth.authorizes(&headers));
+    }
+
+    #[test]
+    fn bearer_auth_rejects_unsafe_configured_tokens() {
+        assert!(BearerAuth::new(String::new()).is_err());
+        assert!(BearerAuth::new("has whitespace".to_string()).is_err());
+        assert!(BearerAuth::new("non-ascii-é".to_string()).is_err());
+    }
+}

--- a/src/mcp/daemon.rs
+++ b/src/mcp/daemon.rs
@@ -5,14 +5,16 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use axum::extract::State;
-use axum::http::{HeaderMap, StatusCode};
-use axum::response::IntoResponse;
+use axum::extract::{Request, State};
+use axum::http::{header::WWW_AUTHENTICATE, HeaderMap, StatusCode};
+use axum::middleware::{self, Next};
+use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::Router;
 use reqwest::Client;
 use serde_json::{json, Value};
 
+use crate::mcp::auth::BearerAuth;
 use crate::mcp::protocol::JsonRpcMessage;
 use crate::mcp::tools::context7::Context7Tool;
 use crate::mcp::tools::exa::ExaTool;
@@ -22,6 +24,7 @@ use crate::mcp::tools::ToolRegistry;
 
 struct DaemonState {
     registry: ToolRegistry,
+    auth: BearerAuth,
 }
 
 pub struct DaemonArgs {
@@ -29,9 +32,21 @@ pub struct DaemonArgs {
     pub host: String,
     pub memory_dir: Option<PathBuf>,
     pub pyright_root: Option<PathBuf>,
+    pub pyright_workspace_dir: Option<PathBuf>,
+    pub auth_token: String,
 }
 
 pub async fn run(args: DaemonArgs) -> Result<()> {
+    let DaemonArgs {
+        port,
+        host,
+        memory_dir,
+        pyright_root,
+        pyright_workspace_dir,
+        auth_token,
+    } = args;
+    let auth = BearerAuth::new(auth_token)?;
+
     let http_client = Client::builder()
         .user_agent("ccr-rust-mcp-daemon")
         .timeout(std::time::Duration::from_secs(30))
@@ -50,7 +65,7 @@ pub async fn run(args: DaemonArgs) -> Result<()> {
     tracing::info!("context7 tool enabled");
     tools.push(Box::new(Context7Tool::new(http_client.clone())));
 
-    let memory_path = args.memory_dir.map(|dir| {
+    let memory_path = memory_dir.map(|dir| {
         std::fs::create_dir_all(&dir).ok();
         dir.join("memory.json")
     });
@@ -64,26 +79,44 @@ pub async fn run(args: DaemonArgs) -> Result<()> {
         tools.push(Box::new(SindexerTool::new()));
     }
 
-    if let Some(ref pyright_root) = args.pyright_root {
-        tracing::info!(root = %pyright_root.display(), "pyright tool enabled");
-        tools.push(Box::new(PyrightTool::new(
-            pyright_root.clone(),
-            PathBuf::from("/tmp/ccr-pyright-workspaces"),
-            3,
-        )));
+    match (pyright_root, pyright_workspace_dir) {
+        (Some(project_root), Some(workspace_dir)) => {
+            tracing::info!(
+                project_root = %project_root.display(),
+                workspace_dir = %workspace_dir.display(),
+                "pyright tool enabled"
+            );
+            tools.push(Box::new(PyrightTool::new(
+                project_root,
+                workspace_dir,
+                3,
+            )?));
+        }
+        (Some(_), None) => anyhow::bail!(
+            "--pyright-workspace-dir or CCR_MCP_PYRIGHT_WORKSPACE_DIR is required with --pyright-root"
+        ),
+        (None, Some(_)) => anyhow::bail!(
+            "--pyright-root or PYRIGHT_PROJECT_ROOT is required with --pyright-workspace-dir"
+        ),
+        (None, None) => {}
     }
 
     let state = Arc::new(DaemonState {
         registry: ToolRegistry::new(tools),
+        auth,
     });
 
     let app = Router::new()
         .route("/mcp", post(handle_mcp))
         .route("/health", get(handle_health))
+        .route_layer(middleware::from_fn_with_state(
+            state.clone(),
+            require_bearer,
+        ))
         .with_state(state);
 
-    let host: std::net::IpAddr = args.host.parse().context("invalid host address")?;
-    let addr = SocketAddr::from((host, args.port));
+    let host: std::net::IpAddr = host.parse().context("invalid host address")?;
+    let addr = SocketAddr::from((host, port));
     tracing::info!("mcp-daemon listening on {addr}");
 
     let listener = tokio::net::TcpListener::bind(addr)
@@ -92,6 +125,23 @@ pub async fn run(args: DaemonArgs) -> Result<()> {
     axum::serve(listener, app).await.context("server error")?;
 
     Ok(())
+}
+
+async fn require_bearer(
+    State(state): State<Arc<DaemonState>>,
+    request: Request,
+    next: Next,
+) -> Response {
+    if state.auth.authorizes(request.headers()) {
+        next.run(request).await
+    } else {
+        (
+            StatusCode::UNAUTHORIZED,
+            [(WWW_AUTHENTICATE, "Bearer")],
+            String::new(),
+        )
+            .into_response()
+    }
 }
 
 async fn handle_health() -> impl IntoResponse {

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+mod auth;
 pub mod backend;
 pub mod catalog;
 pub mod daemon;

--- a/src/mcp/tools/mod.rs
+++ b/src/mcp/tools/mod.rs
@@ -3,6 +3,7 @@ pub mod context7;
 pub mod exa;
 pub mod memory;
 pub mod pyright;
+mod pyright_workspace;
 #[cfg(feature = "sindexer")]
 pub mod sindexer;
 

--- a/src/mcp/tools/pyright.rs
+++ b/src/mcp/tools/pyright.rs
@@ -8,8 +8,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use tokio::sync::Semaphore;
 use tracing::{debug, info, warn};
-use uuid::Uuid;
 
+use super::pyright_workspace::PrivateWorkspaceRoot;
 use super::{NativeTool, ToolResult};
 use crate::mcp::protocol::McpTool;
 
@@ -18,7 +18,7 @@ const PYRIGHT_TIMEOUT_SECS: u64 = 60;
 
 pub struct PyrightTool {
     project_root: PathBuf,
-    scratch_dir: PathBuf,
+    workspaces: PrivateWorkspaceRoot,
     semaphore: Arc<Semaphore>,
 }
 
@@ -87,13 +87,17 @@ struct PyrightPosition {
 }
 
 impl PyrightTool {
-    pub fn new(project_root: PathBuf, scratch_dir: PathBuf, max_concurrent: usize) -> Self {
-        std::fs::create_dir_all(&scratch_dir).ok();
-        Self {
+    pub fn new(
+        project_root: PathBuf,
+        workspace_dir: PathBuf,
+        max_concurrent: usize,
+    ) -> Result<Self> {
+        let workspaces = PrivateWorkspaceRoot::prepare(workspace_dir)?;
+        Ok(Self {
             project_root,
-            scratch_dir,
+            workspaces,
             semaphore: Arc::new(Semaphore::new(max_concurrent)),
-        }
+        })
     }
 
     async fn type_check(&self, args: Value) -> Result<ToolResult> {
@@ -129,8 +133,7 @@ impl PyrightTool {
 
         let _permit = self.semaphore.acquire().await.context("semaphore closed")?;
 
-        let ws_path = self.scratch_dir.join(Uuid::new_v4().to_string());
-        std::fs::create_dir_all(&ws_path).context("failed to create temp workspace")?;
+        let ws_path = self.workspaces.create_request_directory()?;
 
         let result = self.run_in_workspace(&ws_path, &files).await;
 
@@ -328,6 +331,7 @@ impl PyrightTool {
                 .arg("--outputjson")
                 .arg("--project")
                 .arg(ws_path)
+                .env_remove("CCR_MCP_AUTH_TOKEN")
                 .stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::piped())
                 .output(),
@@ -465,7 +469,13 @@ mod tests {
             }
         }"#;
 
-        let tool = PyrightTool::new(PathBuf::from("/project"), PathBuf::from("/tmp/scratch"), 1);
+        let scratch = tempfile::tempdir().unwrap();
+        let tool = PyrightTool::new(
+            PathBuf::from("/project"),
+            scratch.path().join("workspaces"),
+            1,
+        )
+        .unwrap();
         let diagnostics = tool.parse_output(raw, Path::new("/tmp/ws"));
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].file, "alphaheng/worker/agent.py");
@@ -481,7 +491,13 @@ mod tests {
             .enable_all()
             .build()
             .unwrap();
-        let tool = PyrightTool::new(PathBuf::from("/project"), PathBuf::from("/tmp/scratch"), 1);
+        let scratch = tempfile::tempdir().unwrap();
+        let tool = PyrightTool::new(
+            PathBuf::from("/project"),
+            scratch.path().join("workspaces"),
+            1,
+        )
+        .unwrap();
         let result = rt.block_on(tool.type_check(json!({
             "files": [{ "path": "/etc/passwd" }]
         })));
@@ -495,7 +511,13 @@ mod tests {
             .enable_all()
             .build()
             .unwrap();
-        let tool = PyrightTool::new(PathBuf::from("/project"), PathBuf::from("/tmp/scratch"), 1);
+        let scratch = tempfile::tempdir().unwrap();
+        let tool = PyrightTool::new(
+            PathBuf::from("/project"),
+            scratch.path().join("workspaces"),
+            1,
+        )
+        .unwrap();
         let result = rt.block_on(tool.type_check(json!({
             "files": [{ "path": "../../etc/passwd" }]
         })));
@@ -506,6 +528,7 @@ mod tests {
     #[test]
     fn prepare_workspace_preserves_sibling_modules_for_nested_overlay() {
         let project = tempfile::tempdir().unwrap();
+        let scratch = tempfile::tempdir().unwrap();
         let ws = tempfile::tempdir().unwrap();
 
         std::fs::create_dir(project.path().join("pkg")).unwrap();
@@ -523,9 +546,10 @@ mod tests {
 
         let tool = PyrightTool::new(
             project.path().to_path_buf(),
-            tempfile::tempdir().unwrap().path().to_path_buf(),
+            scratch.path().join("workspaces"),
             1,
-        );
+        )
+        .unwrap();
         tool.prepare_workspace(
             ws.path(),
             &[FileInput {

--- a/src/mcp/tools/pyright_workspace.rs
+++ b/src/mcp/tools/pyright_workspace.rs
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+use std::fs::{DirBuilder, Permissions};
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use tracing::{debug, info, warn};
+use uuid::Uuid;
+
+#[cfg(unix)]
+use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
+
+pub(super) struct PrivateWorkspaceRoot {
+    path: PathBuf,
+}
+
+impl PrivateWorkspaceRoot {
+    pub(super) fn prepare(path: PathBuf) -> Result<Self> {
+        ensure_private_directory(&path, true).with_context(|| {
+            format!(
+                "failed to prepare private Pyright workspace root: {}",
+                path.display()
+            )
+        })?;
+
+        let root = Self { path };
+        root.clean_stale_workspaces()?;
+        Ok(root)
+    }
+
+    pub(super) fn create_request_directory(&self) -> Result<PathBuf> {
+        for _ in 0..8 {
+            let path = self.path.join(Uuid::new_v4().to_string());
+            match create_private_directory(&path, false) {
+                Ok(()) => return Ok(path),
+                Err(err)
+                    if err
+                        .downcast_ref::<std::io::Error>()
+                        .is_some_and(|io_err| io_err.kind() == ErrorKind::AlreadyExists) =>
+                {
+                    continue;
+                }
+                Err(err) => return Err(err).context("failed to create private request workspace"),
+            }
+        }
+        bail!("failed to allocate a unique Pyright request workspace");
+    }
+
+    fn clean_stale_workspaces(&self) -> Result<()> {
+        let mut removed = 0usize;
+        for entry in std::fs::read_dir(&self.path).with_context(|| {
+            format!(
+                "failed to inspect Pyright workspace root: {}",
+                self.path.display()
+            )
+        })? {
+            let entry = entry.context("failed to inspect Pyright workspace entry")?;
+            let name = entry.file_name();
+            let Some(name) = name.to_str() else {
+                warn!("ignoring non-UTF-8 entry in Pyright workspace root");
+                continue;
+            };
+            let Ok(workspace_id) = Uuid::parse_str(name) else {
+                debug!(entry = name, "ignoring non-CCR Pyright workspace entry");
+                continue;
+            };
+            if workspace_id.hyphenated().to_string() != name {
+                debug!(entry = name, "ignoring non-canonical workspace entry");
+                continue;
+            }
+
+            let path = entry.path();
+            let metadata = std::fs::symlink_metadata(&path)
+                .context("failed to inspect stale Pyright workspace")?;
+            if metadata.file_type().is_symlink() {
+                std::fs::remove_file(&path)
+                    .context("failed to unlink stale Pyright workspace symlink")?;
+                removed += 1;
+            } else if metadata.is_dir() {
+                // remove_dir_all does not traverse symlink entries. Limiting cleanup to
+                // UUID-named direct children further confines deletion to CCR-owned paths.
+                std::fs::remove_dir_all(&path)
+                    .context("failed to remove stale Pyright workspace directory")?;
+                removed += 1;
+            } else {
+                warn!(
+                    entry = name,
+                    "ignoring non-directory Pyright workspace entry"
+                );
+            }
+        }
+
+        if removed > 0 {
+            info!(removed, "removed stale Pyright request workspaces");
+        }
+        Ok(())
+    }
+}
+
+fn ensure_private_directory(path: &Path, recursive: bool) -> Result<()> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) => validate_directory(path, &metadata)?,
+        Err(err) if err.kind() == ErrorKind::NotFound => create_private_directory(path, recursive)?,
+        Err(err) => return Err(err.into()),
+    }
+
+    let metadata = std::fs::symlink_metadata(path)?;
+    validate_directory(path, &metadata)?;
+    set_private_permissions(path)?;
+    Ok(())
+}
+
+fn create_private_directory(path: &Path, recursive: bool) -> Result<()> {
+    let mut builder = DirBuilder::new();
+    builder.recursive(recursive);
+    #[cfg(unix)]
+    builder.mode(0o700);
+    builder.create(path)?;
+
+    let metadata = std::fs::symlink_metadata(path)?;
+    validate_directory(path, &metadata)?;
+    set_private_permissions(path)?;
+    Ok(())
+}
+
+fn validate_directory(path: &Path, metadata: &std::fs::Metadata) -> Result<()> {
+    if metadata.file_type().is_symlink() {
+        bail!(
+            "private workspace path must not be a symlink: {}",
+            path.display()
+        );
+    }
+    if !metadata.is_dir() {
+        bail!(
+            "private workspace path must be a directory: {}",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_private_permissions(path: &Path) -> Result<()> {
+    std::fs::set_permissions(path, Permissions::from_mode(0o700))?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn set_private_permissions(path: &Path) -> Result<()> {
+    let mut permissions = std::fs::metadata(path)?.permissions();
+    permissions.set_readonly(false);
+    std::fs::set_permissions(path, permissions)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn prepare_enforces_permissions_and_cleans_only_owned_entries() {
+        let base = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(outside.path().join("sentinel"), "keep").unwrap();
+
+        let root = base.path().join("scratch");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::set_permissions(&root, Permissions::from_mode(0o755)).unwrap();
+
+        let stale_name = Uuid::new_v4().to_string();
+        let stale = root.join(&stale_name);
+        std::fs::create_dir(&stale).unwrap();
+        std::os::unix::fs::symlink(outside.path(), stale.join("unsafe-link")).unwrap();
+
+        let link_name = Uuid::new_v4().to_string();
+        std::os::unix::fs::symlink(outside.path(), root.join(&link_name)).unwrap();
+
+        let unrelated = root.join("operator-owned");
+        std::fs::create_dir(&unrelated).unwrap();
+
+        let prepared = PrivateWorkspaceRoot::prepare(root.clone()).unwrap();
+        assert_eq!(prepared.path, root);
+        assert_eq!(
+            std::fs::metadata(&prepared.path)
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o700
+        );
+        assert!(!prepared.path.join(stale_name).exists());
+        assert!(std::fs::symlink_metadata(prepared.path.join(link_name)).is_err());
+        assert!(unrelated.exists());
+        assert_eq!(
+            std::fs::read_to_string(outside.path().join("sentinel")).unwrap(),
+            "keep"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn request_directories_are_private() {
+        let base = tempfile::tempdir().unwrap();
+        let root = PrivateWorkspaceRoot::prepare(base.path().join("scratch")).unwrap();
+        let request = root.create_request_directory().unwrap();
+
+        assert_eq!(
+            std::fs::metadata(request).unwrap().permissions().mode() & 0o777,
+            0o700
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn workspace_root_must_not_be_a_symlink() {
+        let base = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let link = base.path().join("scratch");
+        std::os::unix::fs::symlink(outside.path(), &link).unwrap();
+
+        assert!(PrivateWorkspaceRoot::prepare(link).is_err());
+    }
+}

--- a/tests/test_mcp_daemon.rs
+++ b/tests/test_mcp_daemon.rs
@@ -1,13 +1,17 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 use serde_json::{json, Value};
 
+const AUTH_TOKEN: &str = "mcp-daemon-test-token";
+
 async fn start_daemon(port: u16) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         ccr_rust::mcp::daemon::run(ccr_rust::mcp::daemon::DaemonArgs {
             port,
             host: "127.0.0.1".to_string(),
+            auth_token: AUTH_TOKEN.to_string(),
             memory_dir: None,
             pyright_root: None,
+            pyright_workspace_dir: None,
         })
         .await
         .ok();
@@ -15,14 +19,21 @@ async fn start_daemon(port: u16) -> tokio::task::JoinHandle<()> {
 }
 
 async fn mcp_post(port: u16, body: &Value) -> Value {
-    let client = reqwest::Client::new();
-    let resp = client
-        .post(format!("http://127.0.0.1:{port}/mcp"))
-        .json(body)
-        .send()
-        .await
-        .expect("request failed");
+    let resp = send_mcp(port, body, Some(AUTH_TOKEN)).await;
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
     resp.json().await.expect("json parse failed")
+}
+
+async fn send_mcp(port: u16, body: &Value, auth_token: Option<&str>) -> reqwest::Response {
+    let client = reqwest::Client::new();
+    let request = client
+        .post(format!("http://127.0.0.1:{port}/mcp"))
+        .json(body);
+    let request = match auth_token {
+        Some(token) => request.bearer_auth(token),
+        None => request,
+    };
+    request.send().await.expect("request failed")
 }
 
 #[tokio::test]
@@ -163,9 +174,61 @@ async fn test_health_endpoint() {
     let client = reqwest::Client::new();
     let resp = client
         .get(format!("http://127.0.0.1:{port}/health"))
+        .bearer_auth(AUTH_TOKEN)
         .send()
         .await
         .expect("health check failed");
     assert_eq!(resp.status(), 200);
     assert_eq!(resp.text().await.unwrap(), "ok");
+}
+
+#[tokio::test]
+async fn test_health_and_mcp_require_correct_bearer_auth() {
+    let port = 13460;
+    let _handle = start_daemon(port).await;
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let client = reqwest::Client::new();
+    for auth_token in [None, Some("wrong-token")] {
+        let request = client.get(format!("http://127.0.0.1:{port}/health"));
+        let request = match auth_token {
+            Some(token) => request.bearer_auth(token),
+            None => request,
+        };
+        let response = request.send().await.unwrap();
+        assert_eq!(response.status(), reqwest::StatusCode::UNAUTHORIZED);
+        assert_eq!(
+            response
+                .headers()
+                .get(reqwest::header::WWW_AUTHENTICATE)
+                .unwrap(),
+            "Bearer"
+        );
+    }
+
+    let health = client
+        .get(format!("http://127.0.0.1:{port}/health"))
+        .bearer_auth(AUTH_TOKEN)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(health.status(), reqwest::StatusCode::OK);
+
+    let ping = json!({"jsonrpc": "2.0", "id": "ping", "method": "ping"});
+    for auth_token in [None, Some("wrong-token")] {
+        let response = send_mcp(port, &ping, auth_token).await;
+        assert_eq!(response.status(), reqwest::StatusCode::UNAUTHORIZED);
+        assert_eq!(
+            response
+                .headers()
+                .get(reqwest::header::WWW_AUTHENTICATE)
+                .unwrap(),
+            "Bearer"
+        );
+    }
+
+    let response = send_mcp(port, &ping, Some(AUTH_TOKEN)).await;
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    let body: Value = response.json().await.unwrap();
+    assert_eq!(body["result"], json!({}));
 }


### PR DESCRIPTION
## Summary
- require bearer authentication for CCR-Rust MCP health and protocol endpoints
- move Pyright request workspaces into an explicit private directory
- clean only canonical CCR-owned workspaces without following symlinks

## Verification
- cargo test --test test_mcp_daemon
- cargo test --lib mcp::
- cargo test --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- cargo install --path . --force
- git diff --check