### PR TITLE
chore: apply rustfmt reflow across mcp, router, and transform modules

### DIFF
--- a/src/mcp/catalog.rs
+++ b/src/mcp/catalog.rs
@@ -12,7 +12,11 @@ pub struct ToolCatalog {
 
 impl ToolCatalog {
     pub fn add_backend_tools(&mut self, idx: usize, tools: Vec<McpTool>) {
-        info!(backend_idx = idx, tool_count = tools.len(), "registering backend tools");
+        info!(
+            backend_idx = idx,
+            tool_count = tools.len(),
+            "registering backend tools"
+        );
         for tool in tools {
             let name = tool.name.clone();
             self.routes.insert(name.clone(), idx);

--- a/src/mcp/tools/context7.rs
+++ b/src/mcp/tools/context7.rs
@@ -27,9 +27,10 @@ impl NativeTool for Context7Tool {
         vec![
             McpTool {
                 name: "resolve-library-id".to_string(),
-                description: "Resolves a package/product name to a Context7-compatible library ID. \
+                description:
+                    "Resolves a package/product name to a Context7-compatible library ID. \
                     Call this before query-docs to obtain a valid library ID."
-                    .to_string(),
+                        .to_string(),
                 inputSchema: json!({
                     "type": "object",
                     "properties": {

--- a/src/mcp/tools/exa.rs
+++ b/src/mcp/tools/exa.rs
@@ -167,7 +167,11 @@ impl ExaTool {
             )));
         }
 
-        info!(url_count = urls.len(), response_len = text.len(), "exa fetch succeeded");
+        info!(
+            url_count = urls.len(),
+            response_len = text.len(),
+            "exa fetch succeeded"
+        );
         Ok(ToolResult::text(text))
     }
 }

--- a/src/mcp/tools/memory.rs
+++ b/src/mcp/tools/memory.rs
@@ -71,119 +71,155 @@ impl MemoryTool {
 impl NativeTool for MemoryTool {
     fn tools(&self) -> Vec<McpTool> {
         vec![
-            tool_def("create_entities", "Create multiple new entities in the knowledge graph", json!({
-                "type": "object",
-                "properties": {
-                    "entities": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "name": { "type": "string" },
-                                "entityType": { "type": "string" },
-                                "observations": { "type": "array", "items": { "type": "string" } }
-                            },
-                            "required": ["name", "entityType", "observations"]
+            tool_def(
+                "create_entities",
+                "Create multiple new entities in the knowledge graph",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": { "type": "string" },
+                                    "entityType": { "type": "string" },
+                                    "observations": { "type": "array", "items": { "type": "string" } }
+                                },
+                                "required": ["name", "entityType", "observations"]
+                            }
                         }
-                    }
-                },
-                "required": ["entities"]
-            })),
-            tool_def("create_relations", "Create multiple new relations between entities in the knowledge graph", json!({
-                "type": "object",
-                "properties": {
-                    "relations": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "from": { "type": "string" },
-                                "to": { "type": "string" },
-                                "relationType": { "type": "string" }
-                            },
-                            "required": ["from", "to", "relationType"]
+                    },
+                    "required": ["entities"]
+                }),
+            ),
+            tool_def(
+                "create_relations",
+                "Create multiple new relations between entities in the knowledge graph",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "relations": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "from": { "type": "string" },
+                                    "to": { "type": "string" },
+                                    "relationType": { "type": "string" }
+                                },
+                                "required": ["from", "to", "relationType"]
+                            }
                         }
-                    }
-                },
-                "required": ["relations"]
-            })),
-            tool_def("add_observations", "Add new observations to existing entities", json!({
-                "type": "object",
-                "properties": {
-                    "observations": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "entityName": { "type": "string" },
-                                "contents": { "type": "array", "items": { "type": "string" } }
-                            },
-                            "required": ["entityName", "contents"]
+                    },
+                    "required": ["relations"]
+                }),
+            ),
+            tool_def(
+                "add_observations",
+                "Add new observations to existing entities",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "observations": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "entityName": { "type": "string" },
+                                    "contents": { "type": "array", "items": { "type": "string" } }
+                                },
+                                "required": ["entityName", "contents"]
+                            }
                         }
-                    }
-                },
-                "required": ["observations"]
-            })),
-            tool_def("delete_entities", "Delete multiple entities and their associated relations", json!({
-                "type": "object",
-                "properties": {
-                    "entityNames": { "type": "array", "items": { "type": "string" } }
-                },
-                "required": ["entityNames"]
-            })),
-            tool_def("delete_observations", "Delete specific observations from entities", json!({
-                "type": "object",
-                "properties": {
-                    "deletions": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "entityName": { "type": "string" },
-                                "observations": { "type": "array", "items": { "type": "string" } }
-                            },
-                            "required": ["entityName", "observations"]
+                    },
+                    "required": ["observations"]
+                }),
+            ),
+            tool_def(
+                "delete_entities",
+                "Delete multiple entities and their associated relations",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "entityNames": { "type": "array", "items": { "type": "string" } }
+                    },
+                    "required": ["entityNames"]
+                }),
+            ),
+            tool_def(
+                "delete_observations",
+                "Delete specific observations from entities",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "deletions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "entityName": { "type": "string" },
+                                    "observations": { "type": "array", "items": { "type": "string" } }
+                                },
+                                "required": ["entityName", "observations"]
+                            }
                         }
-                    }
-                },
-                "required": ["deletions"]
-            })),
-            tool_def("delete_relations", "Delete multiple relations from the knowledge graph", json!({
-                "type": "object",
-                "properties": {
-                    "relations": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "from": { "type": "string" },
-                                "to": { "type": "string" },
-                                "relationType": { "type": "string" }
-                            },
-                            "required": ["from", "to", "relationType"]
+                    },
+                    "required": ["deletions"]
+                }),
+            ),
+            tool_def(
+                "delete_relations",
+                "Delete multiple relations from the knowledge graph",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "relations": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "from": { "type": "string" },
+                                    "to": { "type": "string" },
+                                    "relationType": { "type": "string" }
+                                },
+                                "required": ["from", "to", "relationType"]
+                            }
                         }
-                    }
-                },
-                "required": ["relations"]
-            })),
-            tool_def("read_graph", "Read the entire knowledge graph", json!({
-                "type": "object",
-                "properties": {}
-            })),
-            tool_def("search_nodes", "Search for nodes in the knowledge graph based on a query", json!({
-                "type": "object",
-                "properties": {
-                    "query": { "type": "string", "description": "Search query to match against entity names, types, and observations" }
-                },
-                "required": ["query"]
-            })),
-            tool_def("open_nodes", "Open specific nodes in the knowledge graph by their names", json!({
-                "type": "object",
-                "properties": {
-                    "names": { "type": "array", "items": { "type": "string" } }
-                },
-                "required": ["names"]
-            })),
+                    },
+                    "required": ["relations"]
+                }),
+            ),
+            tool_def(
+                "read_graph",
+                "Read the entire knowledge graph",
+                json!({
+                    "type": "object",
+                    "properties": {}
+                }),
+            ),
+            tool_def(
+                "search_nodes",
+                "Search for nodes in the knowledge graph based on a query",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "query": { "type": "string", "description": "Search query to match against entity names, types, and observations" }
+                    },
+                    "required": ["query"]
+                }),
+            ),
+            tool_def(
+                "open_nodes",
+                "Open specific nodes in the knowledge graph by their names",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "names": { "type": "array", "items": { "type": "string" } }
+                    },
+                    "required": ["names"]
+                }),
+            ),
         ]
     }
 
@@ -207,12 +243,9 @@ impl NativeTool for MemoryTool {
 impl MemoryTool {
     fn create_entities(&self, args: Value) -> Result<ToolResult> {
         debug!("creating entities in knowledge graph");
-        let input: Vec<Entity> = serde_json::from_value(
-            args.get("entities")
-                .cloned()
-                .context("missing entities")?,
-        )
-        .context("invalid entities")?;
+        let input: Vec<Entity> =
+            serde_json::from_value(args.get("entities").cloned().context("missing entities")?)
+                .context("invalid entities")?;
 
         let mut graph = self.graph.write();
         let mut created = Vec::new();
@@ -232,9 +265,9 @@ impl MemoryTool {
         self.persist();
 
         info!(created_count = created.len(), "entities created");
-        Ok(ToolResult::text(
-            serde_json::to_string(&json!({ "entities": created }))?,
-        ))
+        Ok(ToolResult::text(serde_json::to_string(
+            &json!({ "entities": created }),
+        )?))
     }
 
     fn create_relations(&self, args: Value) -> Result<ToolResult> {
@@ -259,9 +292,9 @@ impl MemoryTool {
         drop(graph);
         self.persist();
 
-        Ok(ToolResult::text(
-            serde_json::to_string(&json!({ "relations": created }))?,
-        ))
+        Ok(ToolResult::text(serde_json::to_string(
+            &json!({ "relations": created }),
+        )?))
     }
 
     fn add_observations(&self, args: Value) -> Result<ToolResult> {
@@ -296,9 +329,9 @@ impl MemoryTool {
         drop(graph);
         self.persist();
 
-        Ok(ToolResult::text(
-            serde_json::to_string(&json!({ "results": results }))?,
-        ))
+        Ok(ToolResult::text(serde_json::to_string(
+            &json!({ "results": results }),
+        )?))
     }
 
     fn delete_entities(&self, args: Value) -> Result<ToolResult> {
@@ -317,9 +350,9 @@ impl MemoryTool {
         drop(graph);
         self.persist();
 
-        Ok(ToolResult::text(
-            serde_json::to_string(&json!({ "success": true, "message": "entities deleted" }))?,
-        ))
+        Ok(ToolResult::text(serde_json::to_string(
+            &json!({ "success": true, "message": "entities deleted" }),
+        )?))
     }
 
     fn delete_observations(&self, args: Value) -> Result<ToolResult> {
@@ -331,10 +364,7 @@ impl MemoryTool {
 
         let mut graph = self.graph.write();
         for del in deletions {
-            let entity_name = del
-                .get("entityName")
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
+            let entity_name = del.get("entityName").and_then(|v| v.as_str()).unwrap_or("");
             let obs_to_del: Vec<String> = del
                 .get("observations")
                 .and_then(|v| serde_json::from_value(v.clone()).ok())
@@ -346,9 +376,9 @@ impl MemoryTool {
         drop(graph);
         self.persist();
 
-        Ok(ToolResult::text(
-            serde_json::to_string(&json!({ "success": true, "message": "observations deleted" }))?,
-        ))
+        Ok(ToolResult::text(serde_json::to_string(
+            &json!({ "success": true, "message": "observations deleted" }),
+        )?))
     }
 
     fn delete_relations(&self, args: Value) -> Result<ToolResult> {
@@ -367,9 +397,9 @@ impl MemoryTool {
         drop(graph);
         self.persist();
 
-        Ok(ToolResult::text(
-            serde_json::to_string(&json!({ "success": true, "message": "relations deleted" }))?,
-        ))
+        Ok(ToolResult::text(serde_json::to_string(
+            &json!({ "success": true, "message": "relations deleted" }),
+        )?))
     }
 
     fn read_graph(&self) -> Result<ToolResult> {
@@ -402,7 +432,9 @@ impl MemoryTool {
         let matched_relations: Vec<&Relation> = graph
             .relations
             .iter()
-            .filter(|r| matched_names.contains(&r.from.as_str()) || matched_names.contains(&r.to.as_str()))
+            .filter(|r| {
+                matched_names.contains(&r.from.as_str()) || matched_names.contains(&r.to.as_str())
+            })
             .collect();
 
         Ok(ToolResult::text(serde_json::to_string(&json!({
@@ -426,7 +458,9 @@ impl MemoryTool {
         let matched_relations: Vec<&Relation> = graph
             .relations
             .iter()
-            .filter(|r| matched_names.contains(&r.from.as_str()) || matched_names.contains(&r.to.as_str()))
+            .filter(|r| {
+                matched_names.contains(&r.from.as_str()) || matched_names.contains(&r.to.as_str())
+            })
             .collect();
 
         Ok(ToolResult::text(serde_json::to_string(&json!({

--- a/src/mcp/tools/sindexer.rs
+++ b/src/mcp/tools/sindexer.rs
@@ -34,9 +34,11 @@ impl NativeTool for SindexerTool {
         vec![
             McpTool {
                 name: "index_codebase".to_string(),
-                description: "Index a codebase directory for semantic code search. Walks the directory, \
+                description:
+                    "Index a codebase directory for semantic code search. Walks the directory, \
                     parses source files, extracts code chunks, and generates embeddings. \
-                    Use force=true to re-index an already indexed codebase.".to_string(),
+                    Use force=true to re-index an already indexed codebase."
+                        .to_string(),
                 inputSchema: json!({
                     "type": "object",
                     "properties": {
@@ -56,7 +58,8 @@ impl NativeTool for SindexerTool {
             McpTool {
                 name: "search_code".to_string(),
                 description: "Search indexed code using natural language or code queries. \
-                    Returns the most semantically similar code chunks from the indexed codebase.".to_string(),
+                    Returns the most semantically similar code chunks from the indexed codebase."
+                    .to_string(),
                 inputSchema: json!({
                     "type": "object",
                     "properties": {
@@ -135,7 +138,8 @@ impl NativeTool for SindexerTool {
             },
             McpTool {
                 name: "drop_collection".to_string(),
-                description: "Drop a specific collection from the vector database by name.".to_string(),
+                description: "Drop a specific collection from the vector database by name."
+                    .to_string(),
                 inputSchema: json!({
                     "type": "object",
                     "properties": {
@@ -167,17 +171,29 @@ impl NativeTool for SindexerTool {
 
 impl SindexerTool {
     async fn index_codebase(&self, args: Value) -> Result<ToolResult> {
-        let path = args.get("path").and_then(|v| v.as_str()).context("missing path")?;
+        let path = args
+            .get("path")
+            .and_then(|v| v.as_str())
+            .context("missing path")?;
         let force = args.get("force").and_then(|v| v.as_bool()).unwrap_or(false);
         let path = PathBuf::from(path);
 
         match self.sindexer.index(&path, force).await {
             Ok(result) => {
-                let mode = if result.lexical_only { " (lexical only)" } else { "" };
+                let mode = if result.lexical_only {
+                    " (lexical only)"
+                } else {
+                    ""
+                };
                 let msg = if result.warnings.is_empty() {
                     format!("Indexed {}{}", path.display(), mode)
                 } else {
-                    format!("Indexed {} ({}){}", path.display(), result.warnings.join("; "), mode)
+                    format!(
+                        "Indexed {} ({}){}",
+                        path.display(),
+                        result.warnings.join("; "),
+                        mode
+                    )
                 };
                 Ok(ToolResult::text(serde_json::to_string(&json!({
                     "success": true,
@@ -193,8 +209,14 @@ impl SindexerTool {
     }
 
     async fn search_code(&self, args: Value) -> Result<ToolResult> {
-        let path = args.get("path").and_then(|v| v.as_str()).context("missing path")?;
-        let query = args.get("query").and_then(|v| v.as_str()).context("missing query")?;
+        let path = args
+            .get("path")
+            .and_then(|v| v.as_str())
+            .context("missing path")?;
+        let query = args
+            .get("query")
+            .and_then(|v| v.as_str())
+            .context("missing query")?;
         let limit = args.get("limit").and_then(|v| v.as_u64()).unwrap_or(10) as usize;
         let extensions: Vec<String> = args
             .get("extensions")
@@ -228,14 +250,20 @@ impl SindexerTool {
     }
 
     async fn get_indexing_status(&self, args: Value) -> Result<ToolResult> {
-        let path = args.get("path").and_then(|v| v.as_str()).context("missing path")?;
+        let path = args
+            .get("path")
+            .and_then(|v| v.as_str())
+            .context("missing path")?;
         let path = PathBuf::from(path);
         let status = self.sindexer.status(&path);
         Ok(ToolResult::text(serde_json::to_string(&status)?))
     }
 
     async fn clear_index(&self, args: Value) -> Result<ToolResult> {
-        let path = args.get("path").and_then(|v| v.as_str()).context("missing path")?;
+        let path = args
+            .get("path")
+            .and_then(|v| v.as_str())
+            .context("missing path")?;
         let path = PathBuf::from(path);
 
         match self.sindexer.clear(&path).await {

--- a/src/router/openai_compat.rs
+++ b/src/router/openai_compat.rs
@@ -98,9 +98,9 @@ pub(super) fn anthropic_response_to_internal(
             output_tokens: response.usage.output_tokens,
             input_tokens_details: None,
         }),
-        extra_data: response.reasoning_content.map(|rc| {
-            serde_json::json!({ "reasoning_content": rc })
-        }),
+        extra_data: response
+            .reasoning_content
+            .map(|rc| serde_json::json!({ "reasoning_content": rc })),
     }
 }
 

--- a/src/router/translate_request.rs
+++ b/src/router/translate_request.rs
@@ -156,7 +156,11 @@ pub(super) fn translate_request_anthropic_to_openai(
     anthropic_req: &AnthropicRequest,
     model: &str,
 ) -> OpenAIRequest {
-    debug!(model, message_count = anthropic_req.messages.len(), "translating Anthropic request to OpenAI format");
+    debug!(
+        model,
+        message_count = anthropic_req.messages.len(),
+        "translating Anthropic request to OpenAI format"
+    );
     let mut messages: Vec<OpenAIMessage> = Vec::new();
     let model_lower = model.to_lowercase();
     let is_reasoning_model = model_lower.contains("reasoner")

--- a/src/router/translate_response.rs
+++ b/src/router/translate_response.rs
@@ -20,9 +20,10 @@ pub(super) fn translate_response_openai_to_anthropic(
     };
 
     // Extract reasoning_content from the first choice for preservation
-    let reasoning_content = openai_resp.choices.first().and_then(|choice| {
-        choice.message.reasoning_content.clone()
-    });
+    let reasoning_content = openai_resp
+        .choices
+        .first()
+        .and_then(|choice| choice.message.reasoning_content.clone());
 
     let content = if let Some(choice) = openai_resp.choices.first() {
         let mut blocks: Vec<AnthropicContentBlock> = Vec::new();

--- a/src/transform/glm.rs
+++ b/src/transform/glm.rs
@@ -232,7 +232,10 @@ impl Transformer for GlmTransformer {
         // Inject reasoning_effort for supported models if not already set
         if supports_reasoning_effort(&model) && !obj.contains_key("reasoning_effort") {
             // Default to "medium" effort for balanced performance
-            obj.insert("reasoning_effort".to_string(), Value::String("medium".to_string()));
+            obj.insert(
+                "reasoning_effort".to_string(),
+                Value::String("medium".to_string()),
+            );
             trace!("Injected reasoning_effort=medium for model {}", model);
         }
 

--- a/src/transform/minimax.rs
+++ b/src/transform/minimax.rs
@@ -45,9 +45,7 @@ fn is_m3_model(model: &str) -> bool {
 
 /// Check if a model is an M2.x model (reasoning_split format)
 fn is_m2_model(model: &str) -> bool {
-    M2_MODELS
-        .iter()
-        .any(|m| model.eq_ignore_ascii_case(m))
+    M2_MODELS.iter().any(|m| model.eq_ignore_ascii_case(m))
 }
 
 #[derive(Debug, Clone)]
@@ -145,10 +143,10 @@ impl Transformer for MinimaxTransformer {
                         let combined_thinking = thinking_text.join("\n\n");
                         content_array.insert(
                             0,
-            serde_json::json!({
-                "type": "text",
-                "text": format!("[Thinking]\n{}", combined_thinking)
-            }),
+                            serde_json::json!({
+                                "type": "text",
+                                "text": format!("[Thinking]\n{}", combined_thinking)
+                            }),
                         );
                     }
                 }

--- a/src/transform/output_compress/patterns/mod.rs
+++ b/src/transform/output_compress/patterns/mod.rs
@@ -33,7 +33,10 @@ pub fn strip_progress_bars(text: &str) -> String {
 /// Apply all pattern-based compressions to text.
 /// Returns the cleaned/compressed text.
 pub fn compress(text: &str) -> String {
-    debug!(input_len = text.len(), "output compress: applying pattern compression");
+    debug!(
+        input_len = text.len(),
+        "output compress: applying pattern compression"
+    );
     // Clean first
     let cleaned = strip_ansi(text);
     let cleaned = collapse_blank_lines(&cleaned);
@@ -56,7 +59,10 @@ pub fn compress(text: &str) -> String {
         return result;
     }
 
-    debug!(output_len = cleaned.len(), "output compress: no pattern matched, returning cleaned text");
+    debug!(
+        output_len = cleaned.len(),
+        "output compress: no pattern matched, returning cleaned text"
+    );
     cleaned
 }
 

--- a/src/transformer/builtin.rs
+++ b/src/transformer/builtin.rs
@@ -4,8 +4,8 @@
 //! These transformers handle format conversions between various LLM API formats
 //! (Anthropic ↔ OpenAI), token limits, reasoning tags, and tool metadata.
 
-use super::Transformer;
 use super::uuid_nopanic;
+use super::Transformer;
 use anyhow::Result;
 use regex::Regex;
 use serde_json::Value;


### PR DESCRIPTION
## Summary

Pure `cargo fmt` output across 12 files (mcp catalog/tools, router translation, transform modules); byte-identical to running `cargo fmt` on current `main`. No functional changes. Restores a clean `cargo fmt --check`.

This commits formatting churn that had been sitting uncommitted in a working tree (previously snapshotted on `wip/preserved-submodule-worktree-20260710`, which this supersedes).

## Validation

- Every changed file verified byte-identical to fresh `cargo fmt` output on `main`.
- Combined with the sibling PR #20, the resulting tree passes `cargo fmt --check`, `cargo clippy --all-features --tests`, and `cargo test --all-features` (465 passed, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted internal logging, tool descriptions, request/response transformations, and JSON construction for improved code consistency.
  * Reordered imports and simplified several code expressions without changing behavior.
* **Refactor**
  * Clarified argument extraction and formatting across memory and code-indexing tools while preserving existing validation, responses, and operations.
  * Maintained existing model reasoning, translation, compression, and MCP tool behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->