### PR TITLE
docs: use Rust Index CLI in wrapper examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,3 +76,6 @@ jobs:
 
       - name: Test
         run: cargo test --locked --all-targets --all-features
+
+      - name: Test documentation
+        run: cargo test --locked --doc --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,17 +20,19 @@ jobs:
     name: RustSec audit
     runs-on: ubuntu-latest
     permissions:
-      checks: write # publish the RustSec status check
       contents: read
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           persist-credentials: false
 
-      - name: Audit Rust dependencies
-        uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed # v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          tool: cargo-audit@0.22.2
+
+      - name: Audit Rust dependencies
+        run: cargo audit
 
   ci:
     name: CI (${{ matrix.os }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,15 @@ permissions:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   audit:
     name: RustSec audit
     runs-on: ubuntu-latest
+    permissions:
+      checks: write # publish the RustSec status check
+      contents: read
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,26 @@ env:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  audit:
+    name: RustSec audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Audit Rust dependencies
+        uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
   ci:
+    name: CI (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,11 @@ jobs:
         with:
           tool: cargo-audit@0.22.2
 
+      - name: Validate locked dependency graph
+        run: cargo metadata --locked --format-version 1 --no-deps > /dev/null
+
       - name: Audit Rust dependencies
-        run: cargo audit
+        run: cargo audit --file Cargo.lock
 
   ci:
     name: CI (${{ matrix.os }})
@@ -66,10 +69,10 @@ jobs:
         run: cargo fmt --check
 
       - name: Clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --locked --all-targets --all-features -- -D warnings
 
       - name: Build
-        run: cargo build --release
+        run: cargo build --locked --release --all-features
 
       - name: Test
-        run: cargo test
+        run: cargo test --locked --all-targets --all-features

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,27 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  audit:
+    name: RustSec audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed # v2
+        with:
+          tool: cargo-audit@0.22.2
+
+      - name: Validate locked dependency graph
+        run: cargo metadata --locked --format-version 1 --no-deps > /dev/null
+
+      - name: Audit Rust dependencies
+        run: cargo audit --file Cargo.lock
+
   build:
+    needs: audit
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -50,7 +70,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Build
-        run: cargo build --release --target ${{ matrix.target }} --features openssl/vendored
+        run: cargo build --locked --release --target ${{ matrix.target }} --features openssl/vendored
 
       - name: Package (Unix)
         if: runner.os != 'Windows'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   request input and reasoning summaries now also survive the complete
   Responses-client pseudo-streaming path. Reasoning remains a distinct Responses
   output item, parallel streamed tool calls retain their original indices, and
-  cached/reasoning token details survive both adapter directions. Native
+  cached/reasoning token details survive both adapter directions and cached
+  input is included in operator usage metrics. Refusals remain typed Responses
+  refusal blocks instead of being flattened into ordinary answer text, and
+  malformed text blocks fail locally. Native
   Anthropic pseudo-streams omit unsigned reasoning summaries, Responses request
-  bodies and decompression are bounded, and malformed empty requests fail locally.
+  bodies and zstd windows are bounded, oversized bodies return HTTP 413, and
+  malformed empty requests fail locally. Pseudo-stream tool calls use dense
+  OpenAI indices even when internal text or reasoning blocks precede them.
+  Streaming regression coverage uses a deterministic upstream-tail gate rather
+  than a machine-load-sensitive wall-clock race.
   The optional sindexer integration is pinned to its reviewed task-aware
   embedding-prefix release on `main`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Responses and stream edge cases** — Normalize empty function arguments,
+  accept RFC 3339 response timestamps, ignore duplicate terminal stream events,
+  preserve non-object `error` metadata, and remove stale entity headers when
+  JSON responses are rewritten as SSE.
+
 ### Added
 
 - **Quickstart-oriented documentation** — README restructured around a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cached/reasoning token details survive both adapter directions and cached
   input is included in operator usage metrics. Refusals remain typed Responses
   refusal blocks instead of being flattened into ordinary answer text,
-  reasoning controls reach Responses upstreams, incomplete terminal metadata
-  survives both response modes, compressed oversize requests return HTTP 413,
+  reasoning controls and continuation IDs reach Responses upstreams, incomplete
+  terminal metadata survives both response modes, Anthropic callers receive
+  refusal-only results as text, compressed oversize requests return HTTP 413,
   and malformed text blocks fail locally. Native
   Anthropic pseudo-streams omit unsigned reasoning summaries, Responses request
   bodies and zstd windows are bounded, oversized bodies return HTTP 413, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,8 +61,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   added/done/completed items authoritative. Native function, custom-tool,
   computer, local-shell, shell, apply-patch, and MCP-approval continuation
   results now pass pre-routing validation and reach Responses providers intact.
-  Responses stream adapters emit translated deltas before upstream EOF, bound
-  their reconstruction buffer, and preserve exhausted-tier HTTP 429 responses.
+  Responses stream adapters emit translated deltas before upstream EOF, parse
+  each frame once within a bounded byte budget, preserve the active response
+  identity on adapter failures, and preserve exhausted-tier HTTP 429 responses.
+  Live OpenAI streams also retain cached and reasoning token details through
+  Anthropic translation.
   The optional sindexer integration is pinned to its reviewed task-aware
   embedding-prefix release on `main`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pseudo-stream deltas carry their preserved item IDs and output indices, and
   function-call arguments stream after an empty initial item. Ambiguous
   flattened deltas are suppressed when a native envelope has multiple matching
-  items or content blocks, leaving exact added/done/completed items authoritative.
+  items or content blocks, including summary-only reasoning, leaving exact
+  added/done/completed items authoritative.
   The optional sindexer integration is pinned to its reviewed task-aware
   embedding-prefix release on `main`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   remove stale entity headers when JSON responses are rewritten as SSE. String
   request input and reasoning summaries now also survive the complete
   Responses-client pseudo-streaming path. Reasoning remains a distinct Responses
-  output item, and parallel streamed tool calls retain their original indices.
+  output item, parallel streamed tool calls retain their original indices, and
+  cached/reasoning token details survive both adapter directions.
   The optional sindexer integration is pinned to its reviewed task-aware
   embedding-prefix release on `main`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,10 +39,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   validated and translated symmetrically, terminal event types preserve failed
   and cancelled states, absent metadata is omitted instead of serialized as
   `null`, and unsupported request encodings return HTTP 415.
-  Native Responses-to-Responses routing now also preserves file inputs,
-  structured-output schemas, native tool output items, and citation annotations;
-  invalid tool controls are rejected locally and internal bridge metadata cannot
-  be injected by ordinary Chat clients.
+  Native Responses-to-Responses routing now also preserves file inputs, the
+  complete upstream response envelope, native tool output items, citation
+  annotations, and exact pseudo-stream item events. Chat structured-output
+  schemas are translated to Responses `text.format`; invalid tool controls and
+  malformed reasoning objects are rejected locally. Trusted native envelopes
+  travel through response extensions instead of client-visible JSON bridge
+  fields, so neither callers nor upstream providers can inject internal state.
   The optional sindexer integration is pinned to its reviewed task-aware
   embedding-prefix release on `main`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   request input and reasoning summaries now also survive the complete
   Responses-client pseudo-streaming path. Reasoning remains a distinct Responses
   output item, parallel streamed tool calls retain their original indices, and
-  cached/reasoning token details survive both adapter directions.
+  cached/reasoning token details survive both adapter directions. Native
+  Anthropic pseudo-streams omit unsigned reasoning summaries, Responses request
+  bodies and decompression are bounded, and malformed empty requests fail locally.
   The optional sindexer integration is pinned to its reviewed task-aware
   embedding-prefix release on `main`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fields, so neither callers nor upstream providers can inject internal state.
   Native background Responses may remain queued or in progress with empty
   output while their complete tracking envelope is returned unchanged; chat
-  adapters still reject unusable empty results.
+  adapters still reject unusable empty results. Native failed envelopes retain
+  their response identity and error receipt, pseudo-streams use stable output
+  indices and empty initial items before replayed deltas, queued streams retain
+  their non-terminal event type, and explicit null continuation IDs are omitted.
   The optional sindexer integration is pinned to its reviewed task-aware
   embedding-prefix release on `main`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   input is included in operator usage metrics. Refusals remain typed Responses
   refusal blocks instead of being flattened into ordinary answer text,
   reasoning controls reach Responses upstreams, incomplete terminal metadata
-  survives both response modes, and malformed text blocks fail locally. Native
+  survives both response modes, compressed oversize requests return HTTP 413,
+  and malformed text blocks fail locally. Native
   Anthropic pseudo-streams omit unsigned reasoning summaries, Responses request
   bodies and zstd windows are bounded, oversized bodies return HTTP 413, and
   malformed empty requests fail locally. Pseudo-stream tool calls use dense

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Rust dependency security refresh** — Updated `quinn-proto`,
   `crossbeam-epoch`, `anyhow`, and `memmap2` to patched releases and added a
   SHA-pinned RustSec audit job so future vulnerable lockfile changes fail CI.
+  Updated the `cargo-deny` policy for the current schema, reviewed license and
+  Git-source allowances, and made path/Git dependency versions explicit.
 - **Authenticated native MCP daemon** — `mcp-daemon` now requires a bearer token
   from `--auth-token` or `CCR_MCP_AUTH_TOKEN`, compares presented credentials in
   constant time, and protects both `/health` and `/mcp`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   indices and empty initial items before replayed deltas, queued streams retain
   their non-terminal event type, and explicit null continuation IDs are omitted.
   The native-envelope error bypass is restricted to actual Responses providers,
-  so Chat-protocol HTTP-200 error bodies still trigger tier fallback.
+  so Chat-protocol HTTP-200 error bodies still trigger tier fallback. Replayed
+  pseudo-stream deltas carry their preserved item IDs and output indices, and
+  function-call arguments stream after an empty initial item.
   The optional sindexer integration is pinned to its reviewed task-aware
   embedding-prefix release on `main`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   malformed empty requests fail locally. Pseudo-stream tool calls use dense
   OpenAI indices even when internal text or reasoning blocks precede them.
   Streaming regression coverage uses a deterministic upstream-tail gate rather
-  than a machine-load-sensitive wall-clock race.
+  than a machine-load-sensitive wall-clock race. Same-protocol Responses routes
+  retain native tools and one response identity, reasoning controls are
+  validated and translated symmetrically, terminal event types preserve failed
+  and cancelled states, absent metadata is omitted instead of serialized as
+  `null`, and unsupported request encodings return HTTP 415.
   The optional sindexer integration is pinned to its reviewed task-aware
   embedding-prefix release on `main`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The native-envelope error bypass is restricted to actual Responses providers,
   so Chat-protocol HTTP-200 error bodies still trigger tier fallback. Replayed
   pseudo-stream deltas carry their preserved item IDs and output indices, and
-  function-call arguments stream after an empty initial item.
+  function-call arguments stream after an empty initial item. Ambiguous
+  flattened deltas are suppressed when a native envelope has multiple matching
+  items or content blocks, leaving exact added/done/completed items authoritative.
   The optional sindexer integration is pinned to its reviewed task-aware
   embedding-prefix release on `main`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Rust dependency security refresh** — Updated `quinn-proto`,
   `crossbeam-epoch`, `anyhow`, and `memmap2` to patched releases and added a
   SHA-pinned RustSec audit job so future vulnerable lockfile changes fail CI.
+  Migrated the direct HTTP client to `reqwest` 0.12, removing the unmaintained
+  `rustls-pemfile` dependency from the resolved graph.
   Updated the `cargo-deny` policy for the current schema, reviewed license and
   Git-source allowances, and made path/Git dependency versions explicit.
 - **Authenticated native MCP daemon** — `mcp-daemon` now requires a bearer token

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   incompatible transformed-provider route rather than silently dropping
   Responses-only fields. Synthesized text streams now emit the Responses
   content-part lifecycle, and every non-null embedded error keeps cascading
-  instead of turning a malformed HTTP 200 into a false success.
+  instead of turning a malformed HTTP 200 into a false success, including in
+  wrapped gateway envelopes. Chat image detail hints also survive Responses
+  conversion.
   The optional sindexer integration is pinned to its reviewed task-aware
   embedding-prefix release on `main`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   each frame once within a bounded byte budget, preserve the active response
   identity on adapter failures, and preserve exhausted-tier HTTP 429 responses.
   Live OpenAI streams also retain cached and reasoning token details through
-  Anthropic translation.
+  Anthropic translation. Anthropic-native tool-use frames become Responses
+  function-call events, encoded upstream streams fail explicitly instead of
+  corrupting translated bytes, and Chat fallbacks omit continuation identity
+  metadata from tool-result content.
   The optional sindexer integration is pinned to its reviewed task-aware
   embedding-prefix release on `main`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   duplicate terminal stream events, preserve non-object `error` metadata, and
   remove stale entity headers when JSON responses are rewritten as SSE. String
   request input and reasoning summaries now also survive the complete
-  Responses-client pseudo-streaming path. The optional sindexer integration is
-  pinned to its reviewed task-aware embedding-prefix release on `main`.
+  Responses-client pseudo-streaming path. Reasoning remains a distinct Responses
+  output item, and parallel streamed tool calls retain their original indices.
+  The optional sindexer integration is pinned to its reviewed task-aware
+  embedding-prefix release on `main`.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Migrated the direct HTTP client to `reqwest` 0.12, removing the unmaintained
   `rustls-pemfile` dependency from the resolved graph.
   Updated the `cargo-deny` policy for the current schema, reviewed license and
-  Git-source allowances, and made path/Git dependency versions explicit.
+  Git-source allowances, made path/Git dependency versions explicit, and made
+  CI validate and use the checked-in lockfile for every dependency-sensitive job.
 - **Authenticated native MCP daemon** — `mcp-daemon` now requires a bearer token
   from `--auth-token` or `CCR_MCP_AUTH_TOKEN`, compares presented credentials in
   constant time, and protects both `/health` and `/mcp`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   configs plus a smoke-test script. CLI `--help` output now includes usage
   examples for every command, and `docs/cli.md` documents the previously
   missing `dashboard`, `mcp`, `mcp-daemon`, and `captures` commands.
+- **Responses API upstream protocol** — Providers may set
+  `protocol: "responses"` to send bounded non-streaming requests to
+  `/responses`. CCR-Rust converts chat messages, multimodal input, tools,
+  function-call history, completed text, tool calls, and usage while preserving
+  the existing Anthropic and OpenAI client contracts. Responses upstreams are
+  forced through the existing JSON-to-SSE wrapper when a client requests a
+  stream.
 
 - **Per-request token audit on `/v1/token-audit`** — New read-only endpoint
   exposing recent per-request telemetry (timestamp, tier, and the pre-request
@@ -102,6 +109,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   variants to the tier ordering).
 
 ### Fixed
+
+- **OpenAI gateway envelope and lifecycle compatibility** — Non-streaming
+  OpenAI-compatible responses wrapped as `{success:true,data:{...}}` are
+  normalized before deserialization, and `content_block_stop` now follows the
+  streaming Anthropic-to-OpenAI path. Strict OpenAI clients no longer receive
+  a raw Anthropic lifecycle frame. Anthropic input/output token fields are
+  mapped to OpenAI prompt/completion/total usage, and translated streams end
+  with a standard choices-empty usage chunk.
 
 - **Streamed SSE usage matches recorded usage** — In the OpenAI→Anthropic
   translated streaming path, the prompt-token fallback to the pre-request

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,8 +58,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   function-call arguments stream after an empty initial item. Ambiguous
   flattened deltas are suppressed when a native envelope has multiple matching
   items or content blocks, including summary-only reasoning, leaving exact
-  added/done/completed items authoritative. Native computer-call continuation
-  outputs now pass pre-routing validation and reach Responses providers intact.
+  added/done/completed items authoritative. Native function, custom-tool,
+  computer, local-shell, shell, apply-patch, and MCP-approval continuation
+  results now pass pre-routing validation and reach Responses providers intact.
   The optional sindexer integration is pinned to its reviewed task-aware
   embedding-prefix release on `main`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Responses protocol validation and streaming contracts** — Accept completed
+  payloads with null error fields, preserve flat function tools, reject malformed
+  images and unsupported tools, normalize wrapped Responses payloads before
+  success accounting, retain tier headers during pseudo-streaming, and emit
+  OpenAI usage exactly once on the terminal stream chunk.
 - **OpenAI gateway envelope and lifecycle compatibility** — Non-streaming
   OpenAI-compatible responses wrapped as `{success:true,data:{...}}` are
   normalized before deserialization, and `content_block_stop` now follows the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   malformed reasoning objects are rejected locally. Trusted native envelopes
   travel through response extensions instead of client-visible JSON bridge
   fields, so neither callers nor upstream providers can inject internal state.
+  Native background Responses may remain queued or in progress with empty
+  output while their complete tracking envelope is returned unchanged; chat
+  adapters still reject unusable empty results.
   The optional sindexer integration is pinned to its reviewed task-aware
   embedding-prefix release on `main`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   their response identity and error receipt, pseudo-streams use stable output
   indices and empty initial items before replayed deltas, queued streams retain
   their non-terminal event type, and explicit null continuation IDs are omitted.
+  The native-envelope error bypass is restricted to actual Responses providers,
+  so Chat-protocol HTTP-200 error bodies still trigger tier fallback.
   The optional sindexer integration is pinned to its reviewed task-aware
   embedding-prefix release on `main`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Responses and stream edge cases** — Normalize empty function arguments,
   preserve reasoning summaries, accept RFC 3339 response timestamps, ignore
   duplicate terminal stream events, preserve non-object `error` metadata, and
-  remove stale entity headers when JSON responses are rewritten as SSE.
+  remove stale entity headers when JSON responses are rewritten as SSE. String
+  request input and reasoning summaries now also survive the complete
+  Responses-client pseudo-streaming path. The optional sindexer integration is
+  pinned to its reviewed task-aware embedding-prefix release on `main`.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   added/done/completed items authoritative. Native function, custom-tool,
   computer, local-shell, shell, apply-patch, and MCP-approval continuation
   results now pass pre-routing validation and reach Responses providers intact.
+  Responses stream adapters emit translated deltas before upstream EOF, bound
+  their reconstruction buffer, and preserve exhausted-tier HTTP 429 responses.
   The optional sindexer integration is pinned to its reviewed task-aware
   embedding-prefix release on `main`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `rustls-pemfile` dependency from the resolved graph.
   Updated the `cargo-deny` policy for the current schema, reviewed license and
   Git-source allowances, made path/Git dependency versions explicit, and made
-  CI validate and use the checked-in lockfile for every dependency-sensitive job.
+  CI validate and use the checked-in lockfile for every dependency-sensitive
+  job. Release tags now run the same RustSec audit before any platform build,
+  and release builds remain locked to that audited dependency graph.
 - **Authenticated native MCP daemon** — `mcp-daemon` now requires a bearer token
   from `--auth-token` or `CCR_MCP_AUTH_TOKEN`, compares presented credentials in
   constant time, and protects both `/health` and `/mcp`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Responses and stream edge cases** — Normalize empty function arguments,
-  accept RFC 3339 response timestamps, ignore duplicate terminal stream events,
-  preserve non-object `error` metadata, and remove stale entity headers when
-  JSON responses are rewritten as SSE.
+  preserve reasoning summaries, accept RFC 3339 response timestamps, ignore
+  duplicate terminal stream events, preserve non-object `error` metadata, and
+  remove stale entity headers when JSON responses are rewritten as SSE.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   corrupting translated bytes, and Chat fallbacks omit continuation identity
   metadata from tool-result content. Native Responses requests now fail an
   incompatible transformed-provider route rather than silently dropping
-  Responses-only fields.
+  Responses-only fields. Synthesized text streams now emit the Responses
+  content-part lifecycle, and every non-null embedded error keeps cascading
+  instead of turning a malformed HTTP 200 into a false success.
   The optional sindexer integration is pinned to its reviewed task-aware
   embedding-prefix release on `main`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Rust dependency security refresh** — Updated `quinn-proto`,
+  `crossbeam-epoch`, `anyhow`, and `memmap2` to patched releases and added a
+  SHA-pinned RustSec audit job so future vulnerable lockfile changes fail CI.
 - **Authenticated native MCP daemon** — `mcp-daemon` now requires a bearer token
   from `--auth-token` or `CCR_MCP_AUTH_TOKEN`, compares presented credentials in
   constant time, and protects both `/health` and `/mcp`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   validated and translated symmetrically, terminal event types preserve failed
   and cancelled states, absent metadata is omitted instead of serialized as
   `null`, and unsupported request encodings return HTTP 415.
+  Native Responses-to-Responses routing now also preserves file inputs,
+  structured-output schemas, native tool output items, and citation annotations;
+  invalid tool controls are rejected locally and internal bridge metadata cannot
+  be injected by ordinary Chat clients.
   The optional sindexer integration is pinned to its reviewed task-aware
   embedding-prefix release on `main`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   output item, parallel streamed tool calls retain their original indices, and
   cached/reasoning token details survive both adapter directions and cached
   input is included in operator usage metrics. Refusals remain typed Responses
-  refusal blocks instead of being flattened into ordinary answer text, and
-  malformed text blocks fail locally. Native
+  refusal blocks instead of being flattened into ordinary answer text,
+  reasoning controls reach Responses upstreams, incomplete terminal metadata
+  survives both response modes, and malformed text blocks fail locally. Native
   Anthropic pseudo-streams omit unsigned reasoning summaries, Responses request
   bodies and zstd windows are bounded, oversized bodies return HTTP 413, and
   malformed empty requests fail locally. Pseudo-stream tool calls use dense

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   function-call arguments stream after an empty initial item. Ambiguous
   flattened deltas are suppressed when a native envelope has multiple matching
   items or content blocks, including summary-only reasoning, leaving exact
-  added/done/completed items authoritative.
+  added/done/completed items authoritative. Native computer-call continuation
+  outputs now pass pre-routing validation and reach Responses providers intact.
   The optional sindexer integration is pinned to its reviewed task-aware
   embedding-prefix release on `main`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Anthropic translation. Anthropic-native tool-use frames become Responses
   function-call events, encoded upstream streams fail explicitly instead of
   corrupting translated bytes, and Chat fallbacks omit continuation identity
-  metadata from tool-result content.
+  metadata from tool-result content. Native Responses requests now fail an
+  incompatible transformed-provider route rather than silently dropping
+  Responses-only fields.
   The optional sindexer integration is pinned to its reviewed task-aware
   embedding-prefix release on `main`.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,7 +951,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1100,7 +1100,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1878,7 +1878,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2398,7 +2398,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3423,7 +3423,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3710,7 +3710,7 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 [[package]]
 name = "sindexer"
 version = "0.1.0"
-source = "git+https://github.com/RESMP-DEV/rust_sindexer.git?rev=b7c8d998732b8325b59aa2ca9fbde643c898da78#b7c8d998732b8325b59aa2ca9fbde643c898da78"
+source = "git+https://github.com/RESMP-DEV/rust_sindexer.git?rev=d87cf842c08605e98a9d3df48306640f0e567ca7#d87cf842c08605e98a9d3df48306640f0e567ca7"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -4079,7 +4079,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5097,7 +5097,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,9 +104,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"
@@ -718,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2270,9 +2270,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -3007,9 +3007,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,10 +187,10 @@ dependencies = [
  "axum-core",
  "bytes",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit",
@@ -203,7 +203,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower 0.5.3",
  "tower-layer",
@@ -220,13 +220,13 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -440,7 +440,7 @@ dependencies = [
  "ratatui",
  "redis",
  "regex",
- "reqwest 0.11.27",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2",
@@ -951,7 +951,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1100,7 +1100,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1446,25 +1446,6 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
@@ -1474,7 +1455,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
+ "http",
  "indexmap",
  "slab",
  "tokio",
@@ -1547,17 +1528,6 @@ checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -1568,23 +1538,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http",
 ]
 
 [[package]]
@@ -1595,8 +1554,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -1620,30 +1579,6 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
@@ -1652,9 +1587,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
- "http 1.4.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -1670,8 +1605,8 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.0",
- "hyper 1.9.0",
+ "http",
+ "hyper",
  "hyper-util",
  "rustls",
  "tokio",
@@ -1682,15 +1617,18 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
- "hyper 0.14.32",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1703,17 +1641,19 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "hyper 1.9.0",
+ "http",
+ "http-body",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.3",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1938,7 +1878,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2045,7 +1985,7 @@ dependencies = [
  "percent-encoding",
  "referencing",
  "regex-syntax",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "uuid-simd",
@@ -2458,7 +2398,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3369,65 +3309,28 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-tls",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pemfile",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration",
- "tokio",
- "tokio-native-tls",
- "tokio-util",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams",
- "web-sys",
- "winreg",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -3436,15 +3339,18 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
+ "tokio-util",
  "tower 0.5.3",
  "tower-http 0.6.8",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
 ]
@@ -3517,7 +3423,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3532,15 +3438,6 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -3823,7 +3720,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "rayon",
- "reqwest 0.12.28",
+ "reqwest",
  "schemars",
  "serde",
  "serde_json",
@@ -3886,16 +3783,6 @@ checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3995,12 +3882,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -4021,20 +3902,20 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
 [[package]]
 name = "system-configuration-sys"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4198,7 +4079,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4504,7 +4385,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -4519,8 +4400,8 @@ checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
  "bitflags 2.11.0",
  "bytes",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "pin-project-lite",
  "tower-layer",
@@ -4537,8 +4418,8 @@ dependencies = [
  "bitflags 2.11.0",
  "bytes",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "iri-string",
  "pin-project-lite",
  "tower 0.5.3",
@@ -5216,7 +5097,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5267,6 +5148,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5286,20 +5178,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -5308,7 +5191,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -5322,40 +5205,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -5365,21 +5227,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5395,21 +5245,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5419,37 +5257,15 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "wiremock"
@@ -5461,9 +5277,9 @@ dependencies = [
  "base64 0.22.1",
  "deadpool",
  "futures",
- "http 1.4.0",
+ "http",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper",
  "hyper-util",
  "log",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ env_logger = "0.11"
 flate2 = "1.0"
 futures = "0.3"
 gp-routing = { version = "0.1.0", path = "vendor/gp-routing", optional = true }
-sindexer = { version = "0.1.0", git = "https://github.com/RESMP-DEV/rust_sindexer.git", rev = "b7c8d998732b8325b59aa2ca9fbde643c898da78", default-features = false, optional = true }
+sindexer = { version = "0.1.0", git = "https://github.com/RESMP-DEV/rust_sindexer.git", rev = "d87cf842c08605e98a9d3df48306640f0e567ca7", default-features = false, optional = true }
 hex = "0.4"
 humantime = "2"
 jsonschema = "0.29"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ futures = "0.3"
 gp-routing = { version = "0.1.0", path = "vendor/gp-routing", optional = true }
 sindexer = { version = "0.1.0", git = "https://github.com/RESMP-DEV/rust_sindexer.git", rev = "d87cf842c08605e98a9d3df48306640f0e567ca7", default-features = false, optional = true }
 hex = "0.4"
+http-body-util = "0.1"
 humantime = "2"
 jsonschema = "0.29"
 lazy_static = "1.4"
@@ -58,7 +59,6 @@ zstd = "0.13"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
-http-body-util = "0.1"
 tempfile = "3"
 tower = { version = "0.4", features = ["util"] }
 wiremock = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ dirs = "6"
 env_logger = "0.11"
 flate2 = "1.0"
 futures = "0.3"
-gp-routing = { path = "vendor/gp-routing", optional = true }
-sindexer = { git = "https://github.com/RESMP-DEV/rust_sindexer.git", rev = "b7c8d998732b8325b59aa2ca9fbde643c898da78", default-features = false, optional = true }
+gp-routing = { version = "0.1.0", path = "vendor/gp-routing", optional = true }
+sindexer = { version = "0.1.0", git = "https://github.com/RESMP-DEV/rust_sindexer.git", rev = "b7c8d998732b8325b59aa2ca9fbde643c898da78", default-features = false, optional = true }
 hex = "0.4"
 humantime = "2"
 jsonschema = "0.29"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ rand = "=0.8.6"                                                     # GHSA-cq8v-
 ratatui = { version = "=0.30.0", features = ["serde"] }           # GHSA-rhfx-m35p-ff5j
 redis = { version = "0.24", features = ["json"] }
 regex = "1.10"
-reqwest = { version = "0.11", features = ["json", "stream"] }
+reqwest = { version = "0.12", features = ["json", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"

--- a/deny.toml
+++ b/deny.toml
@@ -8,7 +8,7 @@ targets = ["aarch64-apple-darwin", "x86_64-unknown-linux-gnu"]
 # Vulnerabilities are denied by default. Limit unmaintained advisories to
 # workspace crates; cargo-audit reports transitive maintenance warnings.
 unmaintained = "workspace"
-# Update the advisory database on every check
+# Fetch advisory databases with the Git CLI instead of gix
 git-fetch-with-cli = true
 
 [licenses]

--- a/deny.toml
+++ b/deny.toml
@@ -5,11 +5,9 @@
 targets = ["aarch64-apple-darwin", "x86_64-unknown-linux-gnu"]
 
 [advisories]
-# Deny any crate with a known security advisory
-vulnerability = "deny"
-unmaintained = "warn"
-yanked = "warn"
-notice = "warn"
+# Vulnerabilities are denied by default. Limit unmaintained advisories to
+# workspace crates; cargo-audit reports transitive maintenance warnings.
+unmaintained = "workspace"
 # Update the advisory database on every check
 git-fetch-with-cli = true
 
@@ -17,17 +15,20 @@ git-fetch-with-cli = true
 # Allow only these licenses
 allow = [
     "MIT",
+    "MIT-0",
     "Apache-2.0",
+    "AGPL-3.0-or-later",
     "BSD-2-Clause",
     "BSD-3-Clause",
+    "CDLA-Permissive-2.0",
     "ISC",
+    "MPL-2.0",
     "Unicode-3.0",
     "Unicode-DFS-2016",
     "Zlib",
     "OpenSSL",
     "BSL-1.0",
 ]
-copyleft = "deny"
 
 [bans]
 # Deny multiple versions of the same crate
@@ -54,4 +55,4 @@ deny = [
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = []
+allow-git = ["https://github.com/RESMP-DEV/rust_sindexer.git"]

--- a/docs/token_optimization.md
+++ b/docs/token_optimization.md
@@ -173,7 +173,7 @@ When CCR-Rust aggregates tool catalogs from multiple MCP backends, the combined 
 ```bash
 ccr-rust mcp --level medium \
   --wrap "npx @anthropic/mcp-server-filesystem" \
-  --wrap "npx @zilliz/claude-context-mcp@latest"
+  --wrap "contrib/rust_sindexer/target/release/sindexer"
 ```
 
 ### Recommendation

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -461,6 +461,20 @@ mod tests {
     }
 
     #[test]
+    fn provider_with_responses_protocol() {
+        let p = parse_provider(
+            r#"{
+                "name": "meta-muse",
+                "api_base_url": "https://api.meta.ai/v1",
+                "api_key": "meta-test",
+                "models": ["muse-spark-1.1"],
+                "protocol": "responses"
+            }"#,
+        );
+        assert_eq!(p.protocol, ProviderProtocol::Responses);
+    }
+
+    #[test]
     fn should_bypass_logic() {
         let t = parse_transformer(r#"{"use": ["anthropic"]}"#);
         assert!(t.should_bypass("anthropic", "some-model"));

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -252,6 +252,7 @@ pub struct Provider {
     ///
     /// - `openai` (default): send OpenAI-compatible `/chat/completions` requests.
     /// - `anthropic`: send Anthropic-compatible `/messages` requests.
+    /// - `responses`: send OpenAI Responses-compatible `/responses` requests.
     #[serde(default)]
     pub protocol: ProviderProtocol,
 
@@ -330,6 +331,7 @@ pub enum ProviderProtocol {
     #[default]
     Openai,
     Anthropic,
+    Responses,
 }
 
 /// Configuration for web search routing.

--- a/src/frontend/claude_code.rs
+++ b/src/frontend/claude_code.rs
@@ -268,10 +268,27 @@ impl Frontend for ClaudeCodeFrontend {
         // Always include usage — Claude CLI crashes on missing/null usage
         // ("undefined is not an object (evaluating '_.input_tokens')")
         let usage = response.usage.unwrap_or_default();
-        anthropic_response["usage"] = serde_json::json!({
+        let mut anthropic_usage = serde_json::json!({
             "input_tokens": usage.input_tokens,
             "output_tokens": usage.output_tokens
         });
+        if let Some(cached_tokens) = usage
+            .input_tokens_details
+            .as_ref()
+            .and_then(|details| details.get("cached_tokens"))
+            .and_then(Value::as_u64)
+        {
+            anthropic_usage["cache_read_input_tokens"] = serde_json::json!(cached_tokens);
+        }
+        if let Some(reasoning_tokens) = usage
+            .output_tokens_details
+            .as_ref()
+            .and_then(|details| details.get("reasoning_tokens"))
+            .and_then(Value::as_u64)
+        {
+            anthropic_usage["reasoning_tokens"] = serde_json::json!(reasoning_tokens);
+        }
+        anthropic_response["usage"] = anthropic_usage;
 
         // Add extra data if present
         if let Some(extra) = response.extra_data {
@@ -494,6 +511,7 @@ mod tests {
                 input_tokens: 10,
                 output_tokens: 5,
                 input_tokens_details: None,
+                output_tokens_details: None,
             }),
             extra_data: None,
         };

--- a/src/frontend/codex.rs
+++ b/src/frontend/codex.rs
@@ -430,11 +430,18 @@ impl Frontend for CodexFrontend {
 
         // Add usage if available
         if let Some(usage) = &response.usage {
-            openai_response["usage"] = serde_json::json!({
+            let mut openai_usage = serde_json::json!({
                 "prompt_tokens": usage.input_tokens,
                 "completion_tokens": usage.output_tokens,
                 "total_tokens": usage.input_tokens + usage.output_tokens
             });
+            if let Some(details) = &usage.input_tokens_details {
+                openai_usage["prompt_tokens_details"] = details.clone();
+            }
+            if let Some(details) = &usage.output_tokens_details {
+                openai_usage["completion_tokens_details"] = details.clone();
+            }
+            openai_response["usage"] = openai_usage;
         }
 
         // Add extra data if present
@@ -836,6 +843,7 @@ mod tests {
                 input_tokens: 10,
                 output_tokens: 5,
                 input_tokens_details: None,
+                output_tokens_details: None,
             }),
             extra_data: None,
         };

--- a/src/frontend/codex.rs
+++ b/src/frontend/codex.rs
@@ -402,6 +402,11 @@ impl Frontend for CodexFrontend {
                         message["reasoning_content"] = Value::String(rc.to_string());
                     }
                 }
+                if let Some(refusal) = obj.get("refusal").and_then(|v| v.as_str()) {
+                    if !refusal.is_empty() {
+                        message["refusal"] = Value::String(refusal.to_string());
+                    }
+                }
             }
         }
 

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -105,6 +105,9 @@ pub struct Usage {
     /// Breakdown of input tokens (e.g., cache hits/misses)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub input_tokens_details: Option<Value>,
+    /// Breakdown of output tokens (e.g., reasoning tokens)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_tokens_details: Option<Value>,
 }
 
 /// Internal normalized request format.
@@ -345,6 +348,7 @@ mod tests {
                 input_tokens: 10,
                 output_tokens: 5,
                 input_tokens_details: None,
+                output_tokens_details: None,
             }),
             extra_data: None,
         };

--- a/src/router/dispatch.rs
+++ b/src/router/dispatch.rs
@@ -610,6 +610,10 @@ pub(super) async fn try_request_via_openai_protocol(
     // frontend) and no transformers need to modify it, reuse the original body
     // directly with only a model-name swap.  This eliminates the wasteful
     // OpenAI → Anthropic → deserialize → translate → OpenAI round-trip.
+    let preserve_responses_output = openai_passthrough_body
+        .as_ref()
+        .and_then(|body| body.get(super::RESPONSES_REQUEST_PASSTHROUGH_KEY))
+        .is_some();
     let (mut openai_request_value, stream_flag) = if let Some(mut body) = openai_passthrough_body {
         // Swap model name to the backend's expected value.
         if let Some(obj) = body.as_object_mut() {
@@ -641,7 +645,7 @@ pub(super) async fn try_request_via_openai_protocol(
     };
     if provider.protocol != ProviderProtocol::Responses {
         if let Some(object) = openai_request_value.as_object_mut() {
-            object.remove(super::RESPONSES_REASONING_PASSTHROUGH_KEY);
+            object.remove(super::RESPONSES_REQUEST_PASSTHROUGH_KEY);
         }
     }
     let (request_value, stream_flag) = if provider.protocol == ProviderProtocol::Responses {
@@ -837,8 +841,15 @@ pub(super) async fn try_request_via_openai_protocol(
             serde_json::from_slice::<serde_json::Value>(&body)
                 .map_err(|error| TryRequestError::Other(error.into()))
                 .and_then(|response_value| {
-                    responses_response_to_openai_chat(&response_value, model_name)
-                        .map_err(TryRequestError::Other)
+                    let mut converted =
+                        responses_response_to_openai_chat(&response_value, model_name)
+                            .map_err(TryRequestError::Other)?;
+                    if preserve_responses_output {
+                        if let Some(output) = response_value.get("output") {
+                            converted[super::RESPONSES_OUTPUT_PASSTHROUGH_KEY] = output.clone();
+                        }
+                    }
+                    Ok(converted)
                 })
                 .and_then(|openai_value| {
                     serde_json::to_vec(&openai_value)
@@ -905,11 +916,14 @@ pub(super) async fn try_request_via_openai_protocol(
             // Translate to Anthropic format.
             let mut anthropic_resp =
                 translate_response_openai_to_anthropic(openai_resp, model_name);
-            if render_refusal_as_anthropic_text && anthropic_resp.content.is_empty() {
-                if let Some(refusal) = anthropic_resp.refusal.take() {
-                    anthropic_resp
-                        .content
-                        .push(AnthropicContentBlock::Text { text: refusal });
+            if render_refusal_as_anthropic_text {
+                let refusal = anthropic_resp.refusal.take();
+                if anthropic_resp.content.is_empty() {
+                    if let Some(refusal) = refusal {
+                        anthropic_resp
+                            .content
+                            .push(AnthropicContentBlock::Text { text: refusal });
+                    }
                 }
             }
 

--- a/src/router/dispatch.rs
+++ b/src/router/dispatch.rs
@@ -332,6 +332,25 @@ pub(super) async fn try_request(args: TryRequestArgs<'_>) -> Result<Response, Tr
     // Build transformer chain from provider config
     let chain = build_transformer_chain(registry, provider, tier.split(',').nth(1).unwrap_or(tier));
 
+    // Native Responses payloads intentionally retain fields that have no
+    // lossless Anthropic or Chat Completions representation. Existing request
+    // transformers operate on the Anthropic-shaped request, so combining the
+    // two would silently drop inputs such as files, hosted tools, text.format,
+    // and metadata. Reject this incompatible route instead of forwarding a
+    // lossy reconstruction; ordinary Chat clients may still use a transformed
+    // Responses provider through the conversion path below.
+    if provider.protocol == ProviderProtocol::Responses
+        && !chain.is_empty()
+        && openai_passthrough_body
+            .and_then(|body| body.get(super::RESPONSES_REQUEST_PASSTHROUGH_KEY))
+            .is_some()
+    {
+        return Err(TryRequestError::Other(anyhow::anyhow!(
+            "Responses provider '{}' cannot apply request transformers to a native Responses payload",
+            provider.name
+        )));
+    }
+
     // Extract the actual model name from the tier (format: "provider,model")
     let model_name = tier.split(',').nth(1).unwrap_or(tier);
 

--- a/src/router/dispatch.rs
+++ b/src/router/dispatch.rs
@@ -133,16 +133,17 @@ fn embedded_stream_error(payload: &str) -> Option<(String, String)> {
 
     let candidate = json_candidate?;
     let json = serde_json::from_str::<serde_json::Value>(&candidate).ok()?;
-    json.get("error")?.as_object()?;
-
-    let msg = json["error"]["message"]
+    let error = json.get("error").filter(|error| !error.is_null())?;
+    let msg = error["message"]
         .as_str()
+        .or_else(|| error.as_str())
         .unwrap_or("Unknown error in stream body")
         .to_string();
-    let code = json["error"]["code"]
+    let code = error["code"]
         .as_str()
-        .unwrap_or("unknown")
-        .to_string();
+        .map(str::to_string)
+        .or_else(|| error.get("code").map(serde_json::Value::to_string))
+        .unwrap_or_else(|| "unknown".to_string());
     Some((code, msg))
 }
 
@@ -242,14 +243,19 @@ async fn check_stream_for_embedded_error(
 /// Check a non-streaming response body for an embedded error in a 200.
 fn check_body_for_embedded_error(body: &[u8], tier_name: &str) -> Result<(), TryRequestError> {
     if let Ok(json) = serde_json::from_slice::<serde_json::Value>(body) {
-        if json.get("error").is_some_and(serde_json::Value::is_object) {
-            let msg = json["error"]["message"]
+        if let Some(error) = json.get("error").filter(|error| !error.is_null()) {
+            let msg = error["message"]
                 .as_str()
+                .or_else(|| error.as_str())
                 .unwrap_or("Unknown error in response body");
-            let code = json["error"]["code"].as_str().unwrap_or("unknown");
+            let code = error["code"]
+                .as_str()
+                .map(str::to_string)
+                .or_else(|| error.get("code").map(serde_json::Value::to_string))
+                .unwrap_or_else(|| "unknown".to_string());
             warn!(
                 tier = tier_name,
-                error_code = code,
+                error_code = %code,
                 "Provider returned error in 200 body: {}",
                 msg
             );
@@ -1400,15 +1406,17 @@ mod tests {
     }
 
     #[test]
-    fn non_object_error_metadata_is_not_an_embedded_error() {
+    fn every_non_null_error_value_is_an_embedded_error() {
         for body in [
-            br#"{"error":"none","output":[]}"#.as_slice(),
+            br#"{"error":"rate limited","output":[]}"#.as_slice(),
             br#"{"error":[],"output":[]}"#.as_slice(),
-            br#"{"error":null,"output":[]}"#.as_slice(),
         ] {
-            assert!(check_body_for_embedded_error(body, "test-tier").is_ok());
-            assert!(embedded_stream_error(std::str::from_utf8(body).unwrap()).is_none());
+            assert!(check_body_for_embedded_error(body, "test-tier").is_err());
+            assert!(embedded_stream_error(std::str::from_utf8(body).unwrap()).is_some());
         }
+        let null_error = br#"{"error":null,"output":[]}"#;
+        assert!(check_body_for_embedded_error(null_error, "test-tier").is_ok());
+        assert!(embedded_stream_error(std::str::from_utf8(null_error).unwrap()).is_none());
     }
 
     #[test]

--- a/src/router/dispatch.rs
+++ b/src/router/dispatch.rs
@@ -580,6 +580,16 @@ pub(super) fn build_anthropic_headers(
     Ok(headers)
 }
 
+fn should_preserve_responses_response(
+    protocol: ProviderProtocol,
+    openai_passthrough_body: Option<&serde_json::Value>,
+) -> bool {
+    protocol == ProviderProtocol::Responses
+        && openai_passthrough_body
+            .and_then(|body| body.get(super::RESPONSES_REQUEST_PASSTHROUGH_KEY))
+            .is_some()
+}
+
 pub(super) async fn try_request_via_openai_protocol(
     config: &Config,
     provider: &crate::config::Provider,
@@ -610,10 +620,8 @@ pub(super) async fn try_request_via_openai_protocol(
     // frontend) and no transformers need to modify it, reuse the original body
     // directly with only a model-name swap.  This eliminates the wasteful
     // OpenAI → Anthropic → deserialize → translate → OpenAI round-trip.
-    let preserve_responses_response = openai_passthrough_body
-        .as_ref()
-        .and_then(|body| body.get(super::RESPONSES_REQUEST_PASSTHROUGH_KEY))
-        .is_some();
+    let preserve_responses_response =
+        should_preserve_responses_response(provider.protocol, openai_passthrough_body.as_ref());
     let (mut openai_request_value, stream_flag) = if let Some(mut body) = openai_passthrough_body {
         // Swap model name to the backend's expected value.
         if let Some(obj) = body.as_object_mut() {
@@ -1382,6 +1390,26 @@ mod tests {
             assert!(check_body_for_embedded_error(body, "test-tier").is_ok());
             assert!(embedded_stream_error(std::str::from_utf8(body).unwrap()).is_none());
         }
+    }
+
+    #[test]
+    fn native_response_preservation_requires_responses_provider() {
+        let mut body = serde_json::json!({});
+        body[super::super::RESPONSES_REQUEST_PASSTHROUGH_KEY] =
+            serde_json::json!({"input": "test"});
+
+        assert!(should_preserve_responses_response(
+            ProviderProtocol::Responses,
+            Some(&body)
+        ));
+        assert!(!should_preserve_responses_response(
+            ProviderProtocol::Openai,
+            Some(&body)
+        ));
+        assert!(!should_preserve_responses_response(
+            ProviderProtocol::Anthropic,
+            Some(&body)
+        ));
     }
 
     #[test]

--- a/src/router/dispatch.rs
+++ b/src/router/dispatch.rs
@@ -78,10 +78,7 @@ fn normalize_openai_response_body(body: bytes::Bytes) -> bytes::Bytes {
             .get("output")
             .and_then(serde_json::Value::as_array)
             .is_none()
-        && data
-            .get("error")
-            .and_then(serde_json::Value::as_object)
-            .is_none()
+        && !data.get("error").is_some_and(|error| !error.is_null())
     {
         return body;
     }
@@ -1446,6 +1443,7 @@ mod tests {
             bytes::Bytes::from_static(
                 br#"{"success":true,"data":{"error":{"message":"bad request"}}}"#,
             ),
+            bytes::Bytes::from_static(br#"{"success":true,"data":{"error":"rate limited"}}"#),
         ] {
             let normalized = normalize_openai_response_body(body);
             let payload: serde_json::Value = serde_json::from_slice(&normalized).unwrap();

--- a/src/router/dispatch.rs
+++ b/src/router/dispatch.rs
@@ -306,6 +306,8 @@ pub(super) struct TryRequestArgs<'a> {
     pub(super) debug_capture: Option<Arc<DebugCapture>>,
     /// Original OpenAI request body for passthrough to OpenAI-compatible backends.
     pub(super) openai_passthrough_body: Option<&'a serde_json::Value>,
+    /// Render refusal-only Responses results as text for native Anthropic clients.
+    pub(super) render_refusal_as_anthropic_text: bool,
 }
 
 pub(super) async fn try_request(args: TryRequestArgs<'_>) -> Result<Response, TryRequestError> {
@@ -321,6 +323,7 @@ pub(super) async fn try_request(args: TryRequestArgs<'_>) -> Result<Response, Tr
         ratelimit_tracker,
         debug_capture,
         openai_passthrough_body,
+        render_refusal_as_anthropic_text,
     } = args;
     let provider = config.resolve_provider(tier).ok_or_else(|| {
         TryRequestError::Other(anyhow::anyhow!("Provider not found for tier: {}", tier))
@@ -367,6 +370,7 @@ pub(super) async fn try_request(args: TryRequestArgs<'_>) -> Result<Response, Tr
                     chain,
                     debug_capture,
                     openai_passthrough_body: effective_passthrough,
+                    render_refusal_as_anthropic_text,
                 },
             )
             .await
@@ -386,6 +390,7 @@ pub(super) async fn try_request(args: TryRequestArgs<'_>) -> Result<Response, Tr
                     chain,
                     debug_capture,
                     openai_passthrough_body: None,
+                    render_refusal_as_anthropic_text,
                 },
             )
             .await
@@ -405,6 +410,7 @@ pub(super) struct TryRequestProtocolArgs<'a> {
     pub(super) debug_capture: Option<Arc<DebugCapture>>,
     /// Original OpenAI body for direct passthrough (skips Anthropic round-trip).
     pub(super) openai_passthrough_body: Option<serde_json::Value>,
+    pub(super) render_refusal_as_anthropic_text: bool,
 }
 
 pub(super) const DEFAULT_ANTHROPIC_VERSION: &str = "2023-06-01";
@@ -590,6 +596,7 @@ pub(super) async fn try_request_via_openai_protocol(
         chain,
         debug_capture,
         openai_passthrough_body,
+        render_refusal_as_anthropic_text,
     } = args;
 
     let url = if provider.protocol == ProviderProtocol::Responses {
@@ -891,7 +898,15 @@ pub(super) async fn try_request_via_openai_protocol(
             }
 
             // Translate to Anthropic format.
-            let anthropic_resp = translate_response_openai_to_anthropic(openai_resp, model_name);
+            let mut anthropic_resp =
+                translate_response_openai_to_anthropic(openai_resp, model_name);
+            if render_refusal_as_anthropic_text && anthropic_resp.content.is_empty() {
+                if let Some(refusal) = anthropic_resp.refusal.as_deref() {
+                    anthropic_resp.content.push(AnthropicContentBlock::Text {
+                        text: refusal.to_string(),
+                    });
+                }
+            }
 
             // Apply response transformers if chain is not empty.
             let final_resp = if chain.is_empty() {
@@ -936,6 +951,7 @@ pub(super) async fn try_request_via_anthropic_protocol(
         chain,
         debug_capture,
         openai_passthrough_body: _, // not used for Anthropic protocol
+        render_refusal_as_anthropic_text: _,
     } = args;
 
     let url = provider_anthropic_messages_url(provider);

--- a/src/router/dispatch.rs
+++ b/src/router/dispatch.rs
@@ -869,11 +869,17 @@ pub(super) async fn try_request_via_openai_protocol(
         if let Ok(openai_resp) = serde_json::from_slice::<OpenAIResponse>(&body) {
             // Record usage from the response.
             if let Some(ref usage) = openai_resp.usage {
+                let cache_read_tokens = usage
+                    .prompt_tokens_details
+                    .as_ref()
+                    .and_then(|details| details.get("cached_tokens"))
+                    .and_then(serde_json::Value::as_u64)
+                    .unwrap_or_default();
                 record_usage(
                     tier_name,
                     usage.prompt_tokens,
                     usage.completion_tokens,
-                    0, // OpenAI doesn't have cache fields in the same way
+                    cache_read_tokens,
                     0,
                 );
                 verify_token_usage(tier_name, local_estimate, usage.prompt_tokens);

--- a/src/router/dispatch.rs
+++ b/src/router/dispatch.rs
@@ -1325,9 +1325,9 @@ mod tests {
     #[test]
     fn non_object_error_metadata_is_not_an_embedded_error() {
         for body in [
-            br#"{\"error\":\"none\",\"output\":[]} "#.as_slice(),
-            br#"{\"error\":[],\"output\":[]} "#.as_slice(),
-            br#"{\"error\":null,\"output\":[]} "#.as_slice(),
+            br#"{"error":"none","output":[]}"#.as_slice(),
+            br#"{"error":[],"output":[]}"#.as_slice(),
+            br#"{"error":null,"output":[]}"#.as_slice(),
         ] {
             assert!(check_body_for_embedded_error(body, "test-tier").is_ok());
             assert!(embedded_stream_error(std::str::from_utf8(body).unwrap()).is_none());

--- a/src/router/dispatch.rs
+++ b/src/router/dispatch.rs
@@ -5,6 +5,9 @@ use std::sync::Arc;
 use std::time::Duration;
 use tracing::{trace, warn};
 
+use super::responses_protocol::{
+    openai_chat_request_to_responses, responses_response_to_openai_chat,
+};
 use super::streaming::{
     stream_anthropic_response_with_tracking, stream_response_translated, BoxByteStream,
 };
@@ -50,6 +53,37 @@ fn sanitized_capture_headers(headers: &reqwest::header::HeaderMap) -> serde_json
         );
     }
     serde_json::Value::Object(values)
+}
+
+/// Normalize the success envelope used by some OpenAI-compatible gateways.
+///
+/// ClinePass returns non-streaming responses as
+/// `{"success":true,"data":{...OpenAI response...}}` while its streaming
+/// endpoint emits ordinary OpenAI SSE. Normalize only an unambiguous OpenAI
+/// response/error payload so unrelated provider metadata remains untouched.
+fn normalize_openai_response_body(body: bytes::Bytes) -> bytes::Bytes {
+    let Ok(value) = serde_json::from_slice::<serde_json::Value>(&body) else {
+        return body;
+    };
+    if value.get("success").and_then(serde_json::Value::as_bool) != Some(true) {
+        return body;
+    }
+    let Some(data) = value.get("data") else {
+        return body;
+    };
+    if data
+        .get("choices")
+        .and_then(serde_json::Value::as_array)
+        .is_none()
+        && data
+            .get("error")
+            .and_then(serde_json::Value::as_object)
+            .is_none()
+    {
+        return body;
+    }
+
+    serde_json::to_vec(data).map_or(body, bytes::Bytes::from)
 }
 
 async fn persist_debug_capture(
@@ -315,7 +349,7 @@ pub(super) async fn try_request(args: TryRequestArgs<'_>) -> Result<Response, Tr
     };
 
     match provider.protocol {
-        ProviderProtocol::Openai => {
+        ProviderProtocol::Openai | ProviderProtocol::Responses => {
             try_request_via_openai_protocol(
                 config,
                 provider,
@@ -555,7 +589,11 @@ pub(super) async fn try_request_via_openai_protocol(
         openai_passthrough_body,
     } = args;
 
-    let url = provider_openai_chat_completions_url(provider);
+    let url = if provider.protocol == ProviderProtocol::Responses {
+        provider_endpoint_url(provider, "responses")
+    } else {
+        provider_openai_chat_completions_url(provider)
+    };
     let headers = build_openai_headers(provider)?;
 
     // Fast path: when the inbound request was already OpenAI-formatted (Codex
@@ -591,6 +629,15 @@ pub(super) async fn try_request_via_openai_protocol(
             serde_json::to_value(&openai_request).map_err(|e| TryRequestError::Other(e.into()))?;
         (value, stream)
     };
+    let (request_value, stream_flag) = if provider.protocol == ProviderProtocol::Responses {
+        (
+            openai_chat_request_to_responses(&openai_request_value, model_name)
+                .map_err(TryRequestError::Other)?,
+            false,
+        )
+    } else {
+        (openai_request_value, stream_flag)
+    };
 
     // Set up capture if enabled for this provider
     let capture_builder = if let Some(ref capture) = debug_capture {
@@ -599,7 +646,7 @@ pub(super) async fn try_request_via_openai_protocol(
                 .builder(&provider.name, tier_name)
                 .model(model_name)
                 .url(&url)
-                .request_body(openai_request_value.clone())
+                .request_body(request_value.clone())
                 .streaming(stream_flag);
             if capture.headers_enabled() {
                 builder = builder.request_headers(sanitized_capture_headers(&headers));
@@ -616,7 +663,7 @@ pub(super) async fn try_request_via_openai_protocol(
         .http_client()
         .post(&url)
         .headers(headers)
-        .json(&openai_request_value)
+        .json(&request_value)
         .send()
         .await;
 
@@ -781,6 +828,20 @@ pub(super) async fn try_request_via_openai_protocol(
                 warn!("Failed to record debug capture: {}", capture_err);
             }
         }
+
+        let body = normalize_openai_response_body(body);
+        let body = if provider.protocol == ProviderProtocol::Responses {
+            let response_value = serde_json::from_slice::<serde_json::Value>(&body)
+                .map_err(|error| TryRequestError::Other(error.into()))?;
+            let openai_value = responses_response_to_openai_chat(&response_value, model_name)
+                .map_err(TryRequestError::Other)?;
+            bytes::Bytes::from(
+                serde_json::to_vec(&openai_value)
+                    .map_err(|error| TryRequestError::Other(error.into()))?,
+            )
+        } else {
+            body
+        };
 
         // Try to parse as OpenAI response and translate.
         if let Ok(openai_resp) = serde_json::from_slice::<OpenAIResponse>(&body) {
@@ -1209,5 +1270,33 @@ mod tests {
         assert_eq!(captured["authorization"], "[REDACTED]");
         assert_eq!(captured["x-api-key"], "[REDACTED]");
         assert_eq!(captured["x-request-id"], "request-123");
+    }
+
+    #[test]
+    fn openai_success_envelope_is_unwrapped() {
+        let body = bytes::Bytes::from(
+            serde_json::to_vec(&serde_json::json!({
+                "success": true,
+                "data": {
+                    "id": "chatcmpl-wrapped",
+                    "choices": [{"message": {"role": "assistant", "content": "ok"}}]
+                }
+            }))
+            .unwrap(),
+        );
+
+        let normalized = normalize_openai_response_body(body);
+        let payload: serde_json::Value = serde_json::from_slice(&normalized).unwrap();
+
+        assert_eq!(payload["id"], "chatcmpl-wrapped");
+        assert!(payload.get("success").is_none());
+        assert_eq!(payload["choices"][0]["message"]["content"], "ok");
+    }
+
+    #[test]
+    fn unrelated_success_envelope_is_preserved() {
+        let body = bytes::Bytes::from_static(br#"{"success":true,"data":{"value":1}}"#);
+
+        assert_eq!(normalize_openai_response_body(body.clone()), body);
     }
 }

--- a/src/router/dispatch.rs
+++ b/src/router/dispatch.rs
@@ -57,10 +57,9 @@ fn sanitized_capture_headers(headers: &reqwest::header::HeaderMap) -> serde_json
 
 /// Normalize the success envelope used by some OpenAI-compatible gateways.
 ///
-/// ClinePass returns non-streaming responses as
-/// `{"success":true,"data":{...OpenAI response...}}` while its streaming
-/// endpoint emits ordinary OpenAI SSE. Normalize only an unambiguous OpenAI
-/// response/error payload so unrelated provider metadata remains untouched.
+/// Some gateways return non-streaming OpenAI or Responses payloads inside
+/// `{"success":true,"data":{...}}`. Normalize only an unambiguous response or
+/// error payload so unrelated provider metadata remains untouched.
 fn normalize_openai_response_body(body: bytes::Bytes) -> bytes::Bytes {
     let Ok(value) = serde_json::from_slice::<serde_json::Value>(&body) else {
         return body;
@@ -75,6 +74,10 @@ fn normalize_openai_response_body(body: bytes::Bytes) -> bytes::Bytes {
         .get("choices")
         .and_then(serde_json::Value::as_array)
         .is_none()
+        && data
+            .get("output")
+            .and_then(serde_json::Value::as_array)
+            .is_none()
         && data
             .get("error")
             .and_then(serde_json::Value::as_object)
@@ -239,7 +242,7 @@ async fn check_stream_for_embedded_error(
 /// Check a non-streaming response body for an embedded error in a 200.
 fn check_body_for_embedded_error(body: &[u8], tier_name: &str) -> Result<(), TryRequestError> {
     if let Ok(json) = serde_json::from_slice::<serde_json::Value>(body) {
-        if json.get("error").is_some() {
+        if json.get("error").is_some_and(|error| !error.is_null()) {
             let msg = json["error"]["message"]
                 .as_str()
                 .unwrap_or("Unknown error in response body");
@@ -796,15 +799,16 @@ pub(super) async fn try_request_via_openai_protocol(
             .as_ref()
             .filter(|capture| capture.headers_enabled())
             .map(|_| sanitized_capture_headers(resp.headers()));
-        let body = resp
+        let raw_body = resp
             .bytes()
             .await
             .map_err(|e| TryRequestError::Other(e.into()))?;
+        let body = normalize_openai_response_body(raw_body.clone());
 
         // Check for embedded error in 200 body BEFORE recording success,
         // otherwise a failed request corrupts tier rate-limit state.
         if let Err(error) = check_body_for_embedded_error(&body, tier_name) {
-            let body_str = String::from_utf8_lossy(&body);
+            let body_str = String::from_utf8_lossy(&raw_body);
             persist_debug_capture(
                 debug_capture.as_ref(),
                 capture_builder,
@@ -817,11 +821,41 @@ pub(super) async fn try_request_via_openai_protocol(
             return Err(error);
         }
 
-        ratelimit_tracker.record_success(tier_name, rate_limit_info.0, rate_limit_info.1);
+        let body_result = if provider.protocol == ProviderProtocol::Responses {
+            serde_json::from_slice::<serde_json::Value>(&body)
+                .map_err(|error| TryRequestError::Other(error.into()))
+                .and_then(|response_value| {
+                    responses_response_to_openai_chat(&response_value, model_name)
+                        .map_err(TryRequestError::Other)
+                })
+                .and_then(|openai_value| {
+                    serde_json::to_vec(&openai_value)
+                        .map(bytes::Bytes::from)
+                        .map_err(|error| TryRequestError::Other(error.into()))
+                })
+        } else {
+            Ok(body)
+        };
+        let body = match body_result {
+            Ok(body) => body,
+            Err(error) => {
+                let body_str = String::from_utf8_lossy(&raw_body);
+                persist_debug_capture(
+                    debug_capture.as_ref(),
+                    capture_builder,
+                    resp_status,
+                    &body_str,
+                    captured_headers,
+                    Some(error.to_string()),
+                )
+                .await;
+                return Err(error);
+            }
+        };
 
-        let body_str = String::from_utf8_lossy(&body);
+        let body_str = String::from_utf8_lossy(&raw_body);
 
-        // Record capture for non-streaming response
+        // Record capture for the raw non-streaming response.
         if let (Some(builder), Some(capture)) = (capture_builder, debug_capture.clone()) {
             let interaction = builder.complete(resp_status, &body_str, captured_headers, None);
             if let Err(capture_err) = capture.record(interaction).await {
@@ -829,19 +863,7 @@ pub(super) async fn try_request_via_openai_protocol(
             }
         }
 
-        let body = normalize_openai_response_body(body);
-        let body = if provider.protocol == ProviderProtocol::Responses {
-            let response_value = serde_json::from_slice::<serde_json::Value>(&body)
-                .map_err(|error| TryRequestError::Other(error.into()))?;
-            let openai_value = responses_response_to_openai_chat(&response_value, model_name)
-                .map_err(TryRequestError::Other)?;
-            bytes::Bytes::from(
-                serde_json::to_vec(&openai_value)
-                    .map_err(|error| TryRequestError::Other(error.into()))?,
-            )
-        } else {
-            body
-        };
+        ratelimit_tracker.record_success(tier_name, rate_limit_info.0, rate_limit_info.1);
 
         // Try to parse as OpenAI response and translate.
         if let Ok(openai_resp) = serde_json::from_slice::<OpenAIResponse>(&body) {
@@ -1298,5 +1320,20 @@ mod tests {
         let body = bytes::Bytes::from_static(br#"{"success":true,"data":{"value":1}}"#);
 
         assert_eq!(normalize_openai_response_body(body.clone()), body);
+    }
+
+    #[test]
+    fn responses_success_and_error_envelopes_are_unwrapped() {
+        for body in [
+            bytes::Bytes::from_static(br#"{"success":true,"data":{"id":"resp_1","output":[]}}"#),
+            bytes::Bytes::from_static(
+                br#"{"success":true,"data":{"error":{"message":"bad request"}}}"#,
+            ),
+        ] {
+            let normalized = normalize_openai_response_body(body);
+            let payload: serde_json::Value = serde_json::from_slice(&normalized).unwrap();
+            assert!(payload.get("success").is_none());
+            assert!(payload.get("output").is_some() || payload.get("error").is_some());
+        }
     }
 }

--- a/src/router/dispatch.rs
+++ b/src/router/dispatch.rs
@@ -133,7 +133,7 @@ fn embedded_stream_error(payload: &str) -> Option<(String, String)> {
 
     let candidate = json_candidate?;
     let json = serde_json::from_str::<serde_json::Value>(&candidate).ok()?;
-    json.get("error")?;
+    json.get("error")?.as_object()?;
 
     let msg = json["error"]["message"]
         .as_str()
@@ -242,7 +242,7 @@ async fn check_stream_for_embedded_error(
 /// Check a non-streaming response body for an embedded error in a 200.
 fn check_body_for_embedded_error(body: &[u8], tier_name: &str) -> Result<(), TryRequestError> {
     if let Ok(json) = serde_json::from_slice::<serde_json::Value>(body) {
-        if json.get("error").is_some_and(|error| !error.is_null()) {
+        if json.get("error").is_some_and(serde_json::Value::is_object) {
             let msg = json["error"]["message"]
                 .as_str()
                 .unwrap_or("Unknown error in response body");
@@ -1320,6 +1320,18 @@ mod tests {
         let body = bytes::Bytes::from_static(br#"{"success":true,"data":{"value":1}}"#);
 
         assert_eq!(normalize_openai_response_body(body.clone()), body);
+    }
+
+    #[test]
+    fn non_object_error_metadata_is_not_an_embedded_error() {
+        for body in [
+            br#"{\"error\":\"none\",\"output\":[]} "#.as_slice(),
+            br#"{\"error\":[],\"output\":[]} "#.as_slice(),
+            br#"{\"error\":null,\"output\":[]} "#.as_slice(),
+        ] {
+            assert!(check_body_for_embedded_error(body, "test-tier").is_ok());
+            assert!(embedded_stream_error(std::str::from_utf8(body).unwrap()).is_none());
+        }
     }
 
     #[test]

--- a/src/router/dispatch.rs
+++ b/src/router/dispatch.rs
@@ -823,18 +823,20 @@ pub(super) async fn try_request_via_openai_protocol(
 
         // Check for embedded error in 200 body BEFORE recording success,
         // otherwise a failed request corrupts tier rate-limit state.
-        if let Err(error) = check_body_for_embedded_error(&body, tier_name) {
-            let body_str = String::from_utf8_lossy(&raw_body);
-            persist_debug_capture(
-                debug_capture.as_ref(),
-                capture_builder,
-                resp_status,
-                &body_str,
-                captured_headers,
-                Some(error.to_string()),
-            )
-            .await;
-            return Err(error);
+        if !preserve_responses_response {
+            if let Err(error) = check_body_for_embedded_error(&body, tier_name) {
+                let body_str = String::from_utf8_lossy(&raw_body);
+                persist_debug_capture(
+                    debug_capture.as_ref(),
+                    capture_builder,
+                    resp_status,
+                    &body_str,
+                    captured_headers,
+                    Some(error.to_string()),
+                )
+                .await;
+                return Err(error);
+            }
         }
 
         let mut trusted_responses_response = None;

--- a/src/router/dispatch.rs
+++ b/src/router/dispatch.rs
@@ -610,7 +610,7 @@ pub(super) async fn try_request_via_openai_protocol(
     // frontend) and no transformers need to modify it, reuse the original body
     // directly with only a model-name swap.  This eliminates the wasteful
     // OpenAI → Anthropic → deserialize → translate → OpenAI round-trip.
-    let (openai_request_value, stream_flag) = if let Some(mut body) = openai_passthrough_body {
+    let (mut openai_request_value, stream_flag) = if let Some(mut body) = openai_passthrough_body {
         // Swap model name to the backend's expected value.
         if let Some(obj) = body.as_object_mut() {
             obj.insert(
@@ -639,6 +639,11 @@ pub(super) async fn try_request_via_openai_protocol(
             serde_json::to_value(&openai_request).map_err(|e| TryRequestError::Other(e.into()))?;
         (value, stream)
     };
+    if provider.protocol != ProviderProtocol::Responses {
+        if let Some(object) = openai_request_value.as_object_mut() {
+            object.remove(super::RESPONSES_REASONING_PASSTHROUGH_KEY);
+        }
+    }
     let (request_value, stream_flag) = if provider.protocol == ProviderProtocol::Responses {
         (
             openai_chat_request_to_responses(&openai_request_value, model_name)
@@ -901,10 +906,10 @@ pub(super) async fn try_request_via_openai_protocol(
             let mut anthropic_resp =
                 translate_response_openai_to_anthropic(openai_resp, model_name);
             if render_refusal_as_anthropic_text && anthropic_resp.content.is_empty() {
-                if let Some(refusal) = anthropic_resp.refusal.as_deref() {
-                    anthropic_resp.content.push(AnthropicContentBlock::Text {
-                        text: refusal.to_string(),
-                    });
+                if let Some(refusal) = anthropic_resp.refusal.take() {
+                    anthropic_resp
+                        .content
+                        .push(AnthropicContentBlock::Text { text: refusal });
                 }
             }
 

--- a/src/router/dispatch.rs
+++ b/src/router/dispatch.rs
@@ -610,7 +610,7 @@ pub(super) async fn try_request_via_openai_protocol(
     // frontend) and no transformers need to modify it, reuse the original body
     // directly with only a model-name swap.  This eliminates the wasteful
     // OpenAI → Anthropic → deserialize → translate → OpenAI round-trip.
-    let preserve_responses_output = openai_passthrough_body
+    let preserve_responses_response = openai_passthrough_body
         .as_ref()
         .and_then(|body| body.get(super::RESPONSES_REQUEST_PASSTHROUGH_KEY))
         .is_some();
@@ -837,17 +837,15 @@ pub(super) async fn try_request_via_openai_protocol(
             return Err(error);
         }
 
+        let mut trusted_responses_response = None;
         let body_result = if provider.protocol == ProviderProtocol::Responses {
             serde_json::from_slice::<serde_json::Value>(&body)
                 .map_err(|error| TryRequestError::Other(error.into()))
                 .and_then(|response_value| {
-                    let mut converted =
-                        responses_response_to_openai_chat(&response_value, model_name)
-                            .map_err(TryRequestError::Other)?;
-                    if preserve_responses_output {
-                        if let Some(output) = response_value.get("output") {
-                            converted[super::RESPONSES_OUTPUT_PASSTHROUGH_KEY] = output.clone();
-                        }
+                    let converted = responses_response_to_openai_chat(&response_value, model_name)
+                        .map_err(TryRequestError::Other)?;
+                    if preserve_responses_response {
+                        trusted_responses_response = Some(response_value);
                     }
                     Ok(converted)
                 })
@@ -943,6 +941,11 @@ pub(super) async fn try_request_via_openai_protocol(
                 serde_json::to_vec(&final_resp).map_err(|e| TryRequestError::Other(e.into()))?;
 
             let mut response = (StatusCode::OK, response_body).into_response();
+            if let Some(trusted_response) = trusted_responses_response {
+                response
+                    .extensions_mut()
+                    .insert(super::TrustedResponsesResponse(trusted_response));
+            }
             insert_ccr_tier_header(&mut response, tier_name);
             return Ok(response);
         }

--- a/src/router/dispatch.rs
+++ b/src/router/dispatch.rs
@@ -842,8 +842,12 @@ pub(super) async fn try_request_via_openai_protocol(
             serde_json::from_slice::<serde_json::Value>(&body)
                 .map_err(|error| TryRequestError::Other(error.into()))
                 .and_then(|response_value| {
-                    let converted = responses_response_to_openai_chat(&response_value, model_name)
-                        .map_err(TryRequestError::Other)?;
+                    let converted = responses_response_to_openai_chat(
+                        &response_value,
+                        model_name,
+                        preserve_responses_response,
+                    )
+                    .map_err(TryRequestError::Other)?;
                     if preserve_responses_response {
                         trusted_responses_response = Some(response_value);
                     }

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -25,6 +25,8 @@ pub use responses_api::handle_responses;
 
 mod responses_protocol;
 
+const RESPONSES_REASONING_PASSTHROUGH_KEY: &str = "__ccr_responses_reasoning";
+
 use axum::{
     extract::{Path, State},
     http::{HeaderMap, StatusCode},

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -23,6 +23,8 @@ pub use openai_compat::handle_chat_completions;
 mod responses_api;
 pub use responses_api::handle_responses;
 
+mod responses_protocol;
+
 use axum::{
     extract::{Path, State},
     http::{HeaderMap, StatusCode},
@@ -238,12 +240,12 @@ pub async fn handle_messages(
         );
 
         // Per-provider streaming decision: allow_streaming bypasses forceNonStreaming
-        let provider_allows_streaming = config
-            .resolve_provider(tier)
-            .map(|p| p.allow_streaming)
-            .unwrap_or(false);
-        let forced_non_streaming =
-            config.router().force_non_streaming && !provider_allows_streaming;
+        let provider = config.resolve_provider(tier);
+        let provider_allows_streaming = provider.map(|p| p.allow_streaming).unwrap_or(false);
+        let provider_uses_responses =
+            provider.is_some_and(|p| p.protocol == crate::config::ProviderProtocol::Responses);
+        let forced_non_streaming = provider_uses_responses
+            || (config.router().force_non_streaming && !provider_allows_streaming);
         if client_wants_stream && forced_non_streaming {
             request.stream = Some(false);
         } else {

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -26,7 +26,10 @@ pub use responses_api::handle_responses;
 mod responses_protocol;
 
 const RESPONSES_REQUEST_PASSTHROUGH_KEY: &str = "__ccr_responses_request";
-const RESPONSES_OUTPUT_PASSTHROUGH_KEY: &str = "__ccr_responses_output";
+const RESPONSES_RESPONSE_PASSTHROUGH_KEY: &str = "__ccr_responses_response";
+
+#[derive(Clone, Debug)]
+struct TrustedResponsesResponse(serde_json::Value);
 
 use axum::{
     extract::{Path, State},
@@ -646,7 +649,6 @@ mod tests {
             }),
             response_status: None,
             incomplete_details: None,
-            responses_output: None,
         };
 
         let anthropic_resp =

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -282,6 +282,7 @@ pub async fn handle_messages(
                 ratelimit_tracker: state.ratelimit_tracker.clone(),
                 debug_capture: state.debug_capture.clone(),
                 openai_passthrough_body: request.openai_passthrough_body.as_ref(),
+                render_refusal_as_anthropic_text: frontend == FrontendType::ClaudeCode,
             })
             .await
             {

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -36,7 +36,7 @@ use std::collections::BTreeSet;
 use std::sync::atomic::Ordering;
 use tracing::{error, info, warn};
 
-use crate::frontend::detect_frontend;
+use crate::frontend::{detect_frontend, FrontendType};
 use crate::metrics::{
     increment_active_requests, record_failure, record_pre_request_tokens,
     record_rate_limit_backoff, record_rate_limit_hit, record_request_duration_with_frontend,
@@ -330,7 +330,11 @@ pub async fn handle_messages(
                     // If client wanted streaming but we forced non-streaming for this provider,
                     // wrap the JSON response as pseudo-SSE so Claude CLI can parse it.
                     if client_wants_stream && forced_non_streaming {
-                        return streaming::wrap_json_response_as_sse(response).await;
+                        return streaming::wrap_json_response_as_sse(
+                            response,
+                            frontend == FrontendType::Codex,
+                        )
+                        .await;
                     }
 
                     return response;

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -25,7 +25,8 @@ pub use responses_api::handle_responses;
 
 mod responses_protocol;
 
-const RESPONSES_REASONING_PASSTHROUGH_KEY: &str = "__ccr_responses_reasoning";
+const RESPONSES_REQUEST_PASSTHROUGH_KEY: &str = "__ccr_responses_request";
+const RESPONSES_OUTPUT_PASSTHROUGH_KEY: &str = "__ccr_responses_output";
 
 use axum::{
     extract::{Path, State},
@@ -645,6 +646,7 @@ mod tests {
             }),
             response_status: None,
             incomplete_details: None,
+            responses_output: None,
         };
 
         let anthropic_resp =

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -640,6 +640,8 @@ mod tests {
                 prompt_tokens_details: None,
                 completion_tokens_details: None,
             }),
+            response_status: None,
+            incomplete_details: None,
         };
 
         let anthropic_resp =

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -629,6 +629,7 @@ mod tests {
                     role: "assistant".to_string(),
                     content: Some(serde_json::Value::String("The answer is 42.".to_string())),
                     reasoning_content: Some("Let me think...".to_string()),
+                    refusal: None,
                     tool_calls: None,
                 },
                 finish_reason: Some("stop".to_string()),

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -633,6 +633,7 @@ mod tests {
                 prompt_tokens: 10,
                 completion_tokens: 20,
                 prompt_tokens_details: None,
+                completion_tokens_details: None,
             }),
         };
 

--- a/src/router/openai_compat.rs
+++ b/src/router/openai_compat.rs
@@ -97,6 +97,15 @@ pub(super) fn anthropic_response_to_internal(
     if let Some(refusal) = response.refusal {
         extra_data.insert("refusal".to_string(), serde_json::Value::String(refusal));
     }
+    if let Some(response_status) = response.response_status {
+        extra_data.insert(
+            "response_status".to_string(),
+            serde_json::Value::String(response_status),
+        );
+    }
+    if let Some(incomplete_details) = response.incomplete_details {
+        extra_data.insert("incomplete_details".to_string(), incomplete_details);
+    }
 
     crate::frontend::InternalResponse {
         id: response.id,

--- a/src/router/openai_compat.rs
+++ b/src/router/openai_compat.rs
@@ -96,7 +96,14 @@ pub(super) fn anthropic_response_to_internal(
         usage: Some(crate::frontend::Usage {
             input_tokens: response.usage.input_tokens,
             output_tokens: response.usage.output_tokens,
-            input_tokens_details: None,
+            input_tokens_details: response
+                .usage
+                .cache_read_input_tokens
+                .map(|cached_tokens| serde_json::json!({"cached_tokens": cached_tokens})),
+            output_tokens_details: response
+                .usage
+                .reasoning_tokens
+                .map(|reasoning_tokens| serde_json::json!({"reasoning_tokens": reasoning_tokens})),
         }),
         extra_data: response
             .reasoning_content
@@ -238,6 +245,8 @@ async fn convert_anthropic_stream_response_to_openai(response: Response) -> Resp
         let mut sent_done = false;
         let mut prompt_tokens = None;
         let mut completion_tokens = None;
+        let mut cached_tokens = None;
+        let mut reasoning_tokens = None;
 
         loop {
             tokio::select! {
@@ -282,39 +291,30 @@ async fn convert_anthropic_stream_response_to_openai(response: Response) -> Resp
                                     .get("type")
                                     .and_then(serde_json::Value::as_str)
                                     .map(str::to_string);
-                                match event_kind.as_deref() {
-                                    Some("message_start") => {
-                                        let usage = &event_json["message"]["usage"];
-                                        prompt_tokens = usage
-                                            .get("input_tokens")
-                                            .and_then(serde_json::Value::as_u64)
-                                            .or(prompt_tokens);
-                                        completion_tokens = usage
-                                            .get("output_tokens")
-                                            .and_then(serde_json::Value::as_u64)
-                                            .or(completion_tokens);
+                                let event_usage = match event_kind.as_deref() {
+                                    Some("message_start") => Some(&event_json["message"]["usage"]),
+                                    Some("message_delta" | "message_stop") => {
+                                        Some(&event_json["usage"])
                                     }
-                                    Some("message_delta") => {
-                                        prompt_tokens = event_json["usage"]
-                                            .get("input_tokens")
-                                            .and_then(serde_json::Value::as_u64)
-                                            .or(prompt_tokens);
-                                        completion_tokens = event_json["usage"]
-                                            .get("output_tokens")
-                                            .and_then(serde_json::Value::as_u64)
-                                            .or(completion_tokens);
-                                    }
-                                    Some("message_stop") => {
-                                        prompt_tokens = event_json["usage"]
-                                            .get("input_tokens")
-                                            .and_then(serde_json::Value::as_u64)
-                                            .or(prompt_tokens);
-                                        completion_tokens = event_json["usage"]
-                                            .get("output_tokens")
-                                            .and_then(serde_json::Value::as_u64)
-                                            .or(completion_tokens);
-                                    }
-                                    _ => {}
+                                    _ => None,
+                                };
+                                if let Some(event_usage) = event_usage {
+                                    prompt_tokens = event_usage
+                                        .get("input_tokens")
+                                        .and_then(serde_json::Value::as_u64)
+                                        .or(prompt_tokens);
+                                    completion_tokens = event_usage
+                                        .get("output_tokens")
+                                        .and_then(serde_json::Value::as_u64)
+                                        .or(completion_tokens);
+                                    cached_tokens = event_usage
+                                        .get("cache_read_input_tokens")
+                                        .and_then(serde_json::Value::as_u64)
+                                        .or(cached_tokens);
+                                    reasoning_tokens = event_usage
+                                        .get("reasoning_tokens")
+                                        .and_then(serde_json::Value::as_u64)
+                                        .or(reasoning_tokens);
                                 }
 
                                 let mut transformed: serde_json::Value = match transformer.transform_response(event_json) {
@@ -330,11 +330,22 @@ async fn convert_anthropic_stream_response_to_openai(response: Response) -> Resp
                                     if let (Some(prompt), Some(completion)) =
                                         (prompt_tokens, completion_tokens)
                                     {
-                                        transformed["usage"] = serde_json::json!({
+                                        let mut usage = serde_json::json!({
                                             "prompt_tokens": prompt,
                                             "completion_tokens": completion,
                                             "total_tokens": prompt.saturating_add(completion)
                                         });
+                                        if let Some(cached) = cached_tokens {
+                                            usage["prompt_tokens_details"] = serde_json::json!({
+                                                "cached_tokens": cached
+                                            });
+                                        }
+                                        if let Some(reasoning) = reasoning_tokens {
+                                            usage["completion_tokens_details"] = serde_json::json!({
+                                                "reasoning_tokens": reasoning
+                                            });
+                                        }
+                                        transformed["usage"] = usage;
                                     }
                                 }
 

--- a/src/router/openai_compat.rs
+++ b/src/router/openai_compat.rs
@@ -106,6 +106,12 @@ pub(super) fn anthropic_response_to_internal(
     if let Some(incomplete_details) = response.incomplete_details {
         extra_data.insert("incomplete_details".to_string(), incomplete_details);
     }
+    if let Some(responses_output) = response.responses_output {
+        extra_data.insert(
+            super::RESPONSES_OUTPUT_PASSTHROUGH_KEY.to_string(),
+            responses_output,
+        );
+    }
 
     crate::frontend::InternalResponse {
         id: response.id,
@@ -469,14 +475,27 @@ async fn convert_anthropic_stream_response_to_openai(response: Response) -> Resp
 ///
 /// Converts to Anthropic format internally, processes the request,
 /// then converts the response back to OpenAI format.
-pub async fn handle_chat_completions(
+async fn handle_chat_completions_inner(
     State(state): State<AppState>,
     headers: HeaderMap,
-    Json(request_body): Json<serde_json::Value>,
+    Json(mut request_body): Json<serde_json::Value>,
+    native_responses_request: Option<serde_json::Value>,
 ) -> Response {
+    if let Some(object) = request_body.as_object_mut() {
+        object.remove(super::RESPONSES_REQUEST_PASSTHROUGH_KEY);
+        object.remove(super::RESPONSES_OUTPUT_PASSTHROUGH_KEY);
+    }
+
     // Preserve the original OpenAI-formatted body for potential passthrough
     // to OpenAI-compatible backends (avoids OpenAI→Anthropic→OpenAI round-trip).
-    let passthrough_body = request_body.clone();
+    let mut passthrough_body = request_body.clone();
+    if let Some(mut native_responses_request) = native_responses_request {
+        if let Some(object) = native_responses_request.as_object_mut() {
+            object.remove(super::RESPONSES_REQUEST_PASSTHROUGH_KEY);
+            object.remove(super::RESPONSES_OUTPUT_PASSTHROUGH_KEY);
+        }
+        passthrough_body[super::RESPONSES_REQUEST_PASSTHROUGH_KEY] = native_responses_request;
+    }
 
     let frontend = CodexFrontend::new();
     let internal_request = match frontend.parse_request(request_body) {
@@ -500,6 +519,23 @@ pub async fn handle_chat_completions(
     } else {
         convert_anthropic_json_response_to_openai(response).await
     }
+}
+
+pub async fn handle_chat_completions(
+    state: State<AppState>,
+    headers: HeaderMap,
+    request: Json<serde_json::Value>,
+) -> Response {
+    handle_chat_completions_inner(state, headers, request, None).await
+}
+
+pub(super) async fn handle_responses_chat_completions(
+    state: State<AppState>,
+    headers: HeaderMap,
+    request: Json<serde_json::Value>,
+    native_responses_request: serde_json::Value,
+) -> Response {
+    handle_chat_completions_inner(state, headers, request, Some(native_responses_request)).await
 }
 
 #[cfg(test)]

--- a/src/router/openai_compat.rs
+++ b/src/router/openai_compat.rs
@@ -106,13 +106,6 @@ pub(super) fn anthropic_response_to_internal(
     if let Some(incomplete_details) = response.incomplete_details {
         extra_data.insert("incomplete_details".to_string(), incomplete_details);
     }
-    if let Some(responses_output) = response.responses_output {
-        extra_data.insert(
-            super::RESPONSES_OUTPUT_PASSTHROUGH_KEY.to_string(),
-            responses_output,
-        );
-    }
-
     crate::frontend::InternalResponse {
         id: response.id,
         response_type: response.response_type,
@@ -483,7 +476,7 @@ async fn handle_chat_completions_inner(
 ) -> Response {
     if let Some(object) = request_body.as_object_mut() {
         object.remove(super::RESPONSES_REQUEST_PASSTHROUGH_KEY);
-        object.remove(super::RESPONSES_OUTPUT_PASSTHROUGH_KEY);
+        object.remove(super::RESPONSES_RESPONSE_PASSTHROUGH_KEY);
     }
 
     // Preserve the original OpenAI-formatted body for potential passthrough
@@ -492,7 +485,7 @@ async fn handle_chat_completions_inner(
     if let Some(mut native_responses_request) = native_responses_request {
         if let Some(object) = native_responses_request.as_object_mut() {
             object.remove(super::RESPONSES_REQUEST_PASSTHROUGH_KEY);
-            object.remove(super::RESPONSES_OUTPUT_PASSTHROUGH_KEY);
+            object.remove(super::RESPONSES_RESPONSE_PASSTHROUGH_KEY);
         }
         passthrough_body[super::RESPONSES_REQUEST_PASSTHROUGH_KEY] = native_responses_request;
     }

--- a/src/router/openai_compat.rs
+++ b/src/router/openai_compat.rs
@@ -13,6 +13,7 @@ use axum::{
 };
 use bytes::Bytes;
 use futures::StreamExt;
+use std::collections::HashMap;
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::error;
 
@@ -86,6 +87,17 @@ pub(super) fn anthropic_response_to_internal(
         })
         .collect();
 
+    let mut extra_data = serde_json::Map::new();
+    if let Some(reasoning_content) = response.reasoning_content {
+        extra_data.insert(
+            "reasoning_content".to_string(),
+            serde_json::Value::String(reasoning_content),
+        );
+    }
+    if let Some(refusal) = response.refusal {
+        extra_data.insert("refusal".to_string(), serde_json::Value::String(refusal));
+    }
+
     crate::frontend::InternalResponse {
         id: response.id,
         response_type: response.response_type,
@@ -105,9 +117,7 @@ pub(super) fn anthropic_response_to_internal(
                 .reasoning_tokens
                 .map(|reasoning_tokens| serde_json::json!({"reasoning_tokens": reasoning_tokens})),
         }),
-        extra_data: response
-            .reasoning_content
-            .map(|rc| serde_json::json!({ "reasoning_content": rc })),
+        extra_data: (!extra_data.is_empty()).then_some(serde_json::Value::Object(extra_data)),
     }
 }
 
@@ -184,6 +194,45 @@ async fn convert_anthropic_json_response_to_openai(response: Response) -> Respon
     Response::from_parts(parts, Body::from(serialized))
 }
 
+fn remap_anthropic_tool_call_index(
+    event: &mut serde_json::Value,
+    tool_indices: &mut HashMap<u64, u64>,
+    next_tool_index: &mut u64,
+) {
+    let event_type = event.get("type").and_then(serde_json::Value::as_str);
+    let block_index = event.get("index").and_then(serde_json::Value::as_u64);
+    let Some(block_index) = block_index else {
+        return;
+    };
+
+    let is_tool_start = event_type == Some("content_block_start")
+        && event
+            .get("content_block")
+            .and_then(|block| block.get("type"))
+            .and_then(serde_json::Value::as_str)
+            == Some("tool_use");
+    if is_tool_start {
+        let dense_index = *tool_indices.entry(block_index).or_insert_with(|| {
+            let index = *next_tool_index;
+            *next_tool_index += 1;
+            index
+        });
+        event["index"] = serde_json::json!(dense_index);
+        return;
+    }
+
+    let is_tool_delta = event_type == Some("content_block_delta")
+        && event
+            .get("delta")
+            .and_then(|delta| delta.get("partial_json"))
+            .is_some();
+    if is_tool_delta {
+        if let Some(dense_index) = tool_indices.get(&block_index) {
+            event["index"] = serde_json::json!(dense_index);
+        }
+    }
+}
+
 async fn convert_anthropic_stream_response_to_openai(response: Response) -> Response {
     let (mut parts, body) = response.into_parts();
 
@@ -247,6 +296,8 @@ async fn convert_anthropic_stream_response_to_openai(response: Response) -> Resp
         let mut completion_tokens = None;
         let mut cached_tokens = None;
         let mut reasoning_tokens = None;
+        let mut tool_indices = HashMap::new();
+        let mut next_tool_index = 0;
 
         loop {
             tokio::select! {
@@ -286,6 +337,12 @@ async fn convert_anthropic_stream_response_to_openai(response: Response) -> Resp
                                         event_json["type"] = serde_json::Value::String(t.to_string());
                                     }
                                 }
+
+                                remap_anthropic_tool_call_index(
+                                    &mut event_json,
+                                    &mut tool_indices,
+                                    &mut next_tool_index,
+                                );
 
                                 let event_kind = event_json
                                     .get("type")
@@ -464,5 +521,34 @@ mod tests {
         assert_eq!(output.matches("data: [DONE]").count(), 1);
         assert!(!output.contains("late"));
         assert!(output.ends_with("data: [DONE]\n\n"));
+    }
+
+    #[test]
+    fn anthropic_content_indices_map_to_dense_tool_indices() {
+        let mut tool_indices = HashMap::new();
+        let mut next_tool_index = 0;
+        let mut first_start = serde_json::json!({
+            "type": "content_block_start",
+            "index": 2,
+            "content_block": {"type": "tool_use", "id": "call_1"}
+        });
+        let mut first_delta = serde_json::json!({
+            "type": "content_block_delta",
+            "index": 2,
+            "delta": {"type": "input_json_delta", "partial_json": "{}"}
+        });
+        let mut second_start = serde_json::json!({
+            "type": "content_block_start",
+            "index": 4,
+            "content_block": {"type": "tool_use", "id": "call_2"}
+        });
+
+        remap_anthropic_tool_call_index(&mut first_start, &mut tool_indices, &mut next_tool_index);
+        remap_anthropic_tool_call_index(&mut first_delta, &mut tool_indices, &mut next_tool_index);
+        remap_anthropic_tool_call_index(&mut second_start, &mut tool_indices, &mut next_tool_index);
+
+        assert_eq!(first_start["index"], 0);
+        assert_eq!(first_delta["index"], 0);
+        assert_eq!(second_start["index"], 1);
     }
 }

--- a/src/router/openai_compat.rs
+++ b/src/router/openai_compat.rs
@@ -307,6 +307,8 @@ async fn convert_anthropic_stream_response_to_openai(response: Response) -> Resp
         let mut reasoning_tokens = None;
         let mut tool_indices = HashMap::new();
         let mut next_tool_index = 0;
+        let mut response_id = None;
+        let mut response_model = None;
 
         loop {
             tokio::select! {
@@ -357,6 +359,16 @@ async fn convert_anthropic_stream_response_to_openai(response: Response) -> Resp
                                     .get("type")
                                     .and_then(serde_json::Value::as_str)
                                     .map(str::to_string);
+                                if event_kind.as_deref() == Some("message_start") {
+                                    response_id = event_json["message"]
+                                        .get("id")
+                                        .and_then(serde_json::Value::as_str)
+                                        .map(str::to_string);
+                                    response_model = event_json["message"]
+                                        .get("model")
+                                        .and_then(serde_json::Value::as_str)
+                                        .map(str::to_string);
+                                }
                                 let event_usage = match event_kind.as_deref() {
                                     Some("message_start") => Some(&event_json["message"]["usage"]),
                                     Some("message_delta" | "message_stop") => {
@@ -391,6 +403,13 @@ async fn convert_anthropic_stream_response_to_openai(response: Response) -> Resp
                                         continue;
                                     }
                                 };
+
+                                if let Some(id) = response_id.as_deref() {
+                                    transformed["id"] = serde_json::Value::String(id.to_string());
+                                }
+                                if let Some(model) = response_model.as_deref() {
+                                    transformed["model"] = serde_json::Value::String(model.to_string());
+                                }
 
                                 if event_kind.as_deref() == Some("message_stop") && !sent_done {
                                     if let (Some(prompt), Some(completion)) =
@@ -509,6 +528,35 @@ mod tests {
         assert_eq!(output.matches("data: [DONE]").count(), 1);
         assert_eq!(output.matches("\"total_tokens\":3").count(), 1);
         assert!(output.ends_with("data: [DONE]\n\n"));
+    }
+
+    #[tokio::test]
+    async fn pseudo_stream_keeps_one_response_identity() {
+        let body = concat!(
+            "event: message_start\n",
+            "data: {\"type\":\"message_start\",\"message\":{\"id\":\"resp_original\",\"model\":\"muse\",\"usage\":{\"input_tokens\":1}}}\n\n",
+            "event: content_block_delta\n",
+            "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"ok\"}}\n\n",
+            "event: message_stop\n",
+            "data: {\"type\":\"message_stop\",\"usage\":{\"output_tokens\":1}}\n\n",
+        );
+        let response = Response::builder()
+            .status(StatusCode::OK)
+            .body(Body::from(body))
+            .unwrap();
+
+        let converted = convert_anthropic_stream_response_to_openai(response).await;
+        let bytes = to_bytes(converted.into_body(), usize::MAX).await.unwrap();
+        let payload = String::from_utf8(bytes.to_vec()).unwrap();
+        let ids: Vec<_> = payload
+            .lines()
+            .filter_map(|line| line.strip_prefix("data: "))
+            .filter(|data| *data != "[DONE]")
+            .map(|data| serde_json::from_str::<serde_json::Value>(data).unwrap()["id"].clone())
+            .collect();
+
+        assert!(!ids.is_empty());
+        assert!(ids.iter().all(|id| id == "resp_original"));
     }
 
     #[tokio::test]

--- a/src/router/openai_compat.rs
+++ b/src/router/openai_compat.rs
@@ -249,11 +249,16 @@ async fn convert_anthropic_stream_response_to_openai(response: Response) -> Resp
                                 let data = frame.data;
                                 let event_type = frame.event;
 
+                                // The first terminal marker closes the OpenAI stream. Ignore
+                                // duplicate or trailing Anthropic frames rather than emitting
+                                // data after [DONE].
+                                if sent_done {
+                                    continue;
+                                }
+
                                 if data.trim() == "[DONE]" {
-                                    if !sent_done {
-                                        let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n"))).await;
-                                        sent_done = true;
-                                    }
+                                    let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n"))).await;
+                                    sent_done = true;
                                     continue;
                                 }
 
@@ -321,7 +326,7 @@ async fn convert_anthropic_stream_response_to_openai(response: Response) -> Resp
                                     }
                                 };
 
-                                if event_kind.as_deref() == Some("message_stop") {
+                                if event_kind.as_deref() == Some("message_stop") && !sent_done {
                                     if let (Some(prompt), Some(completion)) =
                                         (prompt_tokens, completion_tokens)
                                     {
@@ -398,5 +403,34 @@ pub async fn handle_chat_completions(
         convert_anthropic_stream_response_to_openai(response).await
     } else {
         convert_anthropic_json_response_to_openai(response).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn duplicate_message_stop_does_not_emit_after_done() {
+        let body = concat!(
+            "event: message_start\n",
+            "data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":1}}}\n\n",
+            "event: message_stop\n",
+            "data: {\"type\":\"message_stop\",\"usage\":{\"output_tokens\":2}}\n\n",
+            "event: message_stop\n",
+            "data: {\"type\":\"message_stop\",\"usage\":{\"output_tokens\":2}}\n\n",
+        );
+        let response = Response::builder()
+            .status(StatusCode::OK)
+            .body(Body::from(body))
+            .unwrap();
+
+        let converted = convert_anthropic_stream_response_to_openai(response).await;
+        let bytes = to_bytes(converted.into_body(), usize::MAX).await.unwrap();
+        let output = String::from_utf8(bytes.to_vec()).unwrap();
+
+        assert_eq!(output.matches("data: [DONE]").count(), 1);
+        assert_eq!(output.matches("\"total_tokens\":3").count(), 1);
+        assert!(output.ends_with("data: [DONE]\n\n"));
     }
 }

--- a/src/router/openai_compat.rs
+++ b/src/router/openai_compat.rs
@@ -236,6 +236,8 @@ async fn convert_anthropic_stream_response_to_openai(response: Response) -> Resp
         let mut decoder = SseFrameDecoder::new();
         let transformer = AnthropicToOpenAiResponseTransformer;
         let mut sent_done = false;
+        let mut prompt_tokens = None;
+        let mut completion_tokens = None;
 
         loop {
             tokio::select! {
@@ -271,7 +273,46 @@ async fn convert_anthropic_stream_response_to_openai(response: Response) -> Resp
                                     }
                                 }
 
-                                let transformed: serde_json::Value = match transformer.transform_response(event_json) {
+                                let event_kind = event_json
+                                    .get("type")
+                                    .and_then(serde_json::Value::as_str)
+                                    .map(str::to_string);
+                                match event_kind.as_deref() {
+                                    Some("message_start") => {
+                                        let usage = &event_json["message"]["usage"];
+                                        prompt_tokens = usage
+                                            .get("input_tokens")
+                                            .and_then(serde_json::Value::as_u64)
+                                            .or(prompt_tokens);
+                                        completion_tokens = usage
+                                            .get("output_tokens")
+                                            .and_then(serde_json::Value::as_u64)
+                                            .or(completion_tokens);
+                                    }
+                                    Some("message_delta") => {
+                                        prompt_tokens = event_json["usage"]
+                                            .get("input_tokens")
+                                            .and_then(serde_json::Value::as_u64)
+                                            .or(prompt_tokens);
+                                        completion_tokens = event_json["usage"]
+                                            .get("output_tokens")
+                                            .and_then(serde_json::Value::as_u64)
+                                            .or(completion_tokens);
+                                    }
+                                    Some("message_stop") => {
+                                        prompt_tokens = event_json["usage"]
+                                            .get("input_tokens")
+                                            .and_then(serde_json::Value::as_u64)
+                                            .or(prompt_tokens);
+                                        completion_tokens = event_json["usage"]
+                                            .get("output_tokens")
+                                            .and_then(serde_json::Value::as_u64)
+                                            .or(completion_tokens);
+                                    }
+                                    _ => {}
+                                }
+
+                                let mut transformed: serde_json::Value = match transformer.transform_response(event_json) {
                                     Ok(value) => value,
                                     Err(_) => {
                                         let msg = format!("data: {}\n\n", data);
@@ -279,6 +320,18 @@ async fn convert_anthropic_stream_response_to_openai(response: Response) -> Resp
                                         continue;
                                     }
                                 };
+
+                                if event_kind.as_deref() == Some("message_stop") {
+                                    if let (Some(prompt), Some(completion)) =
+                                        (prompt_tokens, completion_tokens)
+                                    {
+                                        transformed["usage"] = serde_json::json!({
+                                            "prompt_tokens": prompt,
+                                            "completion_tokens": completion,
+                                            "total_tokens": prompt.saturating_add(completion)
+                                        });
+                                    }
+                                }
 
                                 let msg = format!("data: {}\n\n", serde_json::to_string(&transformed).unwrap_or_default());
                                 if tx.send(Ok(Bytes::from(msg))).await.is_err() {

--- a/src/router/openai_compat.rs
+++ b/src/router/openai_compat.rs
@@ -354,7 +354,7 @@ async fn convert_anthropic_stream_response_to_openai(response: Response) -> Resp
                                     return; // Receiver closed
                                 }
 
-                                if event_type.as_deref() == Some("message_stop") && !sent_done {
+                                if event_kind.as_deref() == Some("message_stop") && !sent_done {
                                     let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n"))).await;
                                     sent_done = true;
                                 }
@@ -442,6 +442,27 @@ mod tests {
 
         assert_eq!(output.matches("data: [DONE]").count(), 1);
         assert_eq!(output.matches("\"total_tokens\":3").count(), 1);
+        assert!(output.ends_with("data: [DONE]\n\n"));
+    }
+
+    #[tokio::test]
+    async fn json_only_message_stop_terminates_before_later_frames() {
+        let body = concat!(
+            "data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":1}}}\n\n",
+            "data: {\"type\":\"message_stop\",\"usage\":{\"output_tokens\":2}}\n\n",
+            "data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"late\"}}\n\n",
+        );
+        let response = Response::builder()
+            .status(StatusCode::OK)
+            .body(Body::from(body))
+            .unwrap();
+
+        let converted = convert_anthropic_stream_response_to_openai(response).await;
+        let bytes = to_bytes(converted.into_body(), usize::MAX).await.unwrap();
+        let output = String::from_utf8(bytes.to_vec()).unwrap();
+
+        assert_eq!(output.matches("data: [DONE]").count(), 1);
+        assert!(!output.contains("late"));
         assert!(output.ends_with("data: [DONE]\n\n"));
     }
 }

--- a/src/router/responses_api.rs
+++ b/src/router/responses_api.rs
@@ -583,6 +583,9 @@ pub(super) fn responses_request_to_openai_chat_request(
     if let Some(reasoning) = body.get("reasoning").cloned() {
         request["reasoning"] = reasoning;
     }
+    if let Some(previous_response_id) = body.get("previous_response_id").cloned() {
+        request["previous_response_id"] = previous_response_id;
+    }
 
     Ok(request)
 }

--- a/src/router/responses_api.rs
+++ b/src/router/responses_api.rs
@@ -544,15 +544,23 @@ pub(super) fn responses_request_to_openai_chat_request(
                         "content": content
                     }));
                 }
-                "function_call_output" | "custom_tool_call_output" | "computer_call_output" => {
+                "function_call_output"
+                | "custom_tool_call_output"
+                | "computer_call_output"
+                | "local_shell_call_output"
+                | "shell_call_output"
+                | "apply_patch_call_output"
+                | "mcp_approval_response" => {
                     let call_id = item
                         .get("call_id")
                         .and_then(|v| v.as_str())
+                        .or_else(|| item.get("id").and_then(|v| v.as_str()))
+                        .or_else(|| item.get("approval_request_id").and_then(|v| v.as_str()))
                         .unwrap_or("call_unknown");
                     let output = item
                         .get("output")
                         .map(normalize_tool_output)
-                        .unwrap_or_default();
+                        .unwrap_or_else(|| item.to_string());
                     messages.push(serde_json::json!({
                         "role": "tool",
                         "tool_call_id": call_id,
@@ -1685,33 +1693,86 @@ mod tests {
     }
 
     #[test]
-    fn accepts_native_computer_call_outputs_for_passthrough() {
-        let output = serde_json::json!({
-            "type": "computer_screenshot",
-            "image_url": "data:image/png;base64,c2NyZWVuc2hvdA=="
-        });
-        let request = serde_json::json!({
-            "model": "auto",
-            "previous_response_id": "resp_previous",
-            "input": [{
-                "type": "computer_call_output",
-                "call_id": "call_computer_1",
-                "output": output
-            }]
-        });
+    fn accepts_native_continuation_results_for_passthrough() {
+        let cases = [
+            (
+                "call_function",
+                serde_json::json!({
+                    "type": "function_call_output",
+                    "call_id": "call_function",
+                    "output": "function result"
+                }),
+            ),
+            (
+                "call_custom",
+                serde_json::json!({
+                    "type": "custom_tool_call_output",
+                    "call_id": "call_custom",
+                    "output": "custom result"
+                }),
+            ),
+            (
+                "call_computer",
+                serde_json::json!({
+                    "type": "computer_call_output",
+                    "call_id": "call_computer",
+                    "output": {
+                        "type": "computer_screenshot",
+                        "image_url": "data:image/png;base64,c2NyZWVuc2hvdA=="
+                    }
+                }),
+            ),
+            (
+                "call_local_shell",
+                serde_json::json!({
+                    "type": "local_shell_call_output",
+                    "id": "call_local_shell",
+                    "output": "{\"stdout\":\"done\"}"
+                }),
+            ),
+            (
+                "call_shell",
+                serde_json::json!({
+                    "type": "shell_call_output",
+                    "call_id": "call_shell",
+                    "output": [{"stdout": "done", "outcome": {"type": "exit", "exit_code": 0}}]
+                }),
+            ),
+            (
+                "call_patch",
+                serde_json::json!({
+                    "type": "apply_patch_call_output",
+                    "call_id": "call_patch",
+                    "status": "completed"
+                }),
+            ),
+            (
+                "approval_1",
+                serde_json::json!({
+                    "type": "mcp_approval_response",
+                    "approval_request_id": "approval_1",
+                    "approve": true
+                }),
+            ),
+        ];
 
-        let converted = responses_request_to_openai_chat_request(&request).unwrap();
+        for (call_id, input) in cases {
+            let request = serde_json::json!({
+                "model": "auto",
+                "previous_response_id": "resp_previous",
+                "input": [input]
+            });
 
-        assert_eq!(converted["messages"][0]["role"], "tool");
-        assert_eq!(converted["messages"][0]["tool_call_id"], "call_computer_1");
-        let normalized_output: serde_json::Value = serde_json::from_str(
-            converted["messages"][0]["content"]
+            let converted = responses_request_to_openai_chat_request(&request).unwrap();
+
+            assert_eq!(converted["messages"][0]["role"], "tool");
+            assert_eq!(converted["messages"][0]["tool_call_id"], call_id);
+            assert!(!converted["messages"][0]["content"]
                 .as_str()
-                .expect("computer output should have a Chat-compatible representation"),
-        )
-        .unwrap();
-        assert_eq!(normalized_output, output);
-        assert_eq!(converted["previous_response_id"], "resp_previous");
+                .expect("continuation result should have a Chat-compatible representation")
+                .is_empty());
+            assert_eq!(converted["previous_response_id"], "resp_previous");
+        }
     }
 
     #[test]

--- a/src/router/responses_api.rs
+++ b/src/router/responses_api.rs
@@ -872,6 +872,73 @@ fn initial_responses_output_item(item: &serde_json::Value) -> serde_json::Value 
     initial
 }
 
+#[derive(Clone)]
+struct ResponseOutputItemIdentity {
+    output_index: usize,
+    item_id: Option<String>,
+    content_index: Option<usize>,
+}
+
+fn response_output_item_identity(
+    response: &serde_json::Value,
+    item_type: &str,
+    occurrence: usize,
+    content_type: Option<&str>,
+) -> Option<ResponseOutputItemIdentity> {
+    let (output_index, item) = response
+        .get("output")?
+        .as_array()?
+        .iter()
+        .enumerate()
+        .filter(|(_, item)| item.get("type").and_then(|value| value.as_str()) == Some(item_type))
+        .nth(occurrence)?;
+    let content_index = content_type.map(|content_type| {
+        item.get("content")
+            .and_then(|content| content.as_array())
+            .and_then(|content| {
+                content.iter().position(|part| {
+                    part.get("type").and_then(|value| value.as_str()) == Some(content_type)
+                })
+            })
+            .unwrap_or(0)
+    });
+    Some(ResponseOutputItemIdentity {
+        output_index,
+        item_id: item
+            .get("id")
+            .and_then(|value| value.as_str())
+            .map(str::to_string),
+        content_index,
+    })
+}
+
+fn append_response_delta(
+    output: &mut String,
+    event_type: &str,
+    delta: &str,
+    identity: Option<ResponseOutputItemIdentity>,
+) {
+    let Some(identity) = identity else {
+        return;
+    };
+    let mut event = serde_json::json!({
+        "type": event_type,
+        "delta": delta,
+        "output_index": identity.output_index
+    });
+    if let Some(item_id) = identity.item_id {
+        event["item_id"] = serde_json::Value::String(item_id);
+    }
+    if let Some(content_index) = identity.content_index {
+        event["content_index"] = serde_json::json!(content_index);
+    }
+    output.push_str("event: ");
+    output.push_str(event_type);
+    output.push_str("\ndata: ");
+    output.push_str(&event.to_string());
+    output.push_str("\n\n");
+}
+
 fn add_reasoning_output_item(
     output: &mut String,
     response_id: &str,
@@ -908,8 +975,10 @@ fn convert_sse_payload_to_responses(
     #[derive(Default)]
     struct ToolAccum {
         id: String,
+        item_id: Option<String>,
         name: String,
         arguments: String,
+        emitted_arguments_len: usize,
         added: bool,
         output_index: Option<usize>,
     }
@@ -1072,13 +1141,19 @@ fn convert_sse_payload_to_responses(
                 }
 
                 message_text.push_str(text);
-                let delta_event = serde_json::json!({
-                    "type": "response.output_text.delta",
-                    "delta": text
-                });
-                output.push_str("event: response.output_text.delta\ndata: ");
-                output.push_str(&delta_event.to_string());
-                output.push_str("\n\n");
+                let identity = preserved_response
+                    .as_ref()
+                    .and_then(|response| {
+                        response_output_item_identity(response, "message", 0, Some("output_text"))
+                    })
+                    .or_else(|| {
+                        message_output_index.map(|output_index| ResponseOutputItemIdentity {
+                            output_index,
+                            item_id: Some(format!("msg_{}", response_id)),
+                            content_index: Some(0),
+                        })
+                    });
+                append_response_delta(&mut output, "response.output_text.delta", text, identity);
             }
 
             if let Some(reasoning) = delta
@@ -1098,14 +1173,29 @@ fn convert_sse_payload_to_responses(
                     reasoning_item_added = true;
                 }
                 reasoning_text.push_str(reasoning);
-                let delta_event = serde_json::json!({
-                    "type": "response.reasoning_text.delta",
-                    "delta": reasoning,
-                    "content_index": 0
-                });
-                output.push_str("event: response.reasoning_text.delta\ndata: ");
-                output.push_str(&delta_event.to_string());
-                output.push_str("\n\n");
+                let identity = preserved_response
+                    .as_ref()
+                    .and_then(|response| {
+                        response_output_item_identity(
+                            response,
+                            "reasoning",
+                            0,
+                            Some("reasoning_text"),
+                        )
+                    })
+                    .or_else(|| {
+                        reasoning_output_index.map(|output_index| ResponseOutputItemIdentity {
+                            output_index,
+                            item_id: Some(format!("rs_{}", response_id)),
+                            content_index: Some(0),
+                        })
+                    });
+                append_response_delta(
+                    &mut output,
+                    "response.reasoning_text.delta",
+                    reasoning,
+                    identity,
+                );
             }
 
             if let Some(refusal) = delta
@@ -1135,13 +1225,19 @@ fn convert_sse_payload_to_responses(
                     message_item_added = true;
                 }
                 refusal_text.push_str(refusal);
-                let delta_event = serde_json::json!({
-                    "type": "response.refusal.delta",
-                    "delta": refusal
-                });
-                output.push_str("event: response.refusal.delta\ndata: ");
-                output.push_str(&delta_event.to_string());
-                output.push_str("\n\n");
+                let identity = preserved_response
+                    .as_ref()
+                    .and_then(|response| {
+                        response_output_item_identity(response, "message", 0, Some("refusal"))
+                    })
+                    .or_else(|| {
+                        message_output_index.map(|output_index| ResponseOutputItemIdentity {
+                            output_index,
+                            item_id: Some(format!("msg_{}", response_id)),
+                            content_index: Some(0),
+                        })
+                    });
+                append_response_delta(&mut output, "response.refusal.delta", refusal, identity);
             }
 
             if let Some(tool_calls) = delta.get("tool_calls").and_then(|v| v.as_array()) {
@@ -1186,15 +1282,47 @@ fn convert_sse_payload_to_responses(
                                     "type": "function_call",
                                     "call_id": entry.id,
                                     "name": entry.name,
-                                    "arguments": entry.arguments
+                                    "arguments": ""
                                 }
                             });
                             output.push_str("event: response.output_item.added\ndata: ");
                             output.push_str(&added.to_string());
                             output.push_str("\n\n");
                             entry.output_index = Some(output_index);
+                            entry.item_id = Some(entry.id.clone());
+                        } else if let Some(identity) =
+                            preserved_response.as_ref().and_then(|response| {
+                                response_output_item_identity(
+                                    response,
+                                    "function_call",
+                                    index,
+                                    None,
+                                )
+                            })
+                        {
+                            entry.output_index = Some(identity.output_index);
+                            entry.item_id = identity.item_id;
                         }
                         entry.added = true;
+                    }
+
+                    if entry.added && entry.arguments.len() > entry.emitted_arguments_len {
+                        let delta = entry.arguments[entry.emitted_arguments_len..].to_string();
+                        entry.emitted_arguments_len = entry.arguments.len();
+                        let identity =
+                            entry
+                                .output_index
+                                .map(|output_index| ResponseOutputItemIdentity {
+                                    output_index,
+                                    item_id: entry.item_id.clone(),
+                                    content_index: None,
+                                });
+                        append_response_delta(
+                            &mut output,
+                            "response.function_call_arguments.delta",
+                            &delta,
+                            identity,
+                        );
                     }
                 }
             }
@@ -1235,13 +1363,31 @@ fn convert_sse_payload_to_responses(
                                 message_item_added = true;
                             }
                             message_text.push_str(text);
-                            let delta_event = serde_json::json!({
-                                "type": "response.output_text.delta",
-                                "delta": text
-                            });
-                            output.push_str("event: response.output_text.delta\ndata: ");
-                            output.push_str(&delta_event.to_string());
-                            output.push_str("\n\n");
+                            let identity = preserved_response
+                                .as_ref()
+                                .and_then(|response| {
+                                    response_output_item_identity(
+                                        response,
+                                        "message",
+                                        0,
+                                        Some("output_text"),
+                                    )
+                                })
+                                .or_else(|| {
+                                    message_output_index.map(|output_index| {
+                                        ResponseOutputItemIdentity {
+                                            output_index,
+                                            item_id: Some(format!("msg_{}", response_id)),
+                                            content_index: Some(0),
+                                        }
+                                    })
+                                });
+                            append_response_delta(
+                                &mut output,
+                                "response.output_text.delta",
+                                text,
+                                identity,
+                            );
                         }
                     }
                     if let Some(thinking) = delta.get("thinking").and_then(|v| v.as_str()) {
@@ -1258,14 +1404,31 @@ fn convert_sse_payload_to_responses(
                                 reasoning_item_added = true;
                             }
                             reasoning_text.push_str(thinking);
-                            let delta_event = serde_json::json!({
-                                "type": "response.reasoning_text.delta",
-                                "delta": thinking,
-                                "content_index": 0
-                            });
-                            output.push_str("event: response.reasoning_text.delta\ndata: ");
-                            output.push_str(&delta_event.to_string());
-                            output.push_str("\n\n");
+                            let identity = preserved_response
+                                .as_ref()
+                                .and_then(|response| {
+                                    response_output_item_identity(
+                                        response,
+                                        "reasoning",
+                                        0,
+                                        Some("reasoning_text"),
+                                    )
+                                })
+                                .or_else(|| {
+                                    reasoning_output_index.map(|output_index| {
+                                        ResponseOutputItemIdentity {
+                                            output_index,
+                                            item_id: Some(format!("rs_{}", response_id)),
+                                            content_index: Some(0),
+                                        }
+                                    })
+                                });
+                            append_response_delta(
+                                &mut output,
+                                "response.reasoning_text.delta",
+                                thinking,
+                                identity,
+                            );
                         }
                     }
                 }
@@ -1545,6 +1708,85 @@ mod tests {
                 "refusal": "I cannot help with that."
             })
         );
+    }
+
+    #[test]
+    fn preserved_pseudo_stream_deltas_identify_their_output_items() {
+        let preserved = serde_json::json!({
+            "id": "resp_native",
+            "object": "response",
+            "created_at": 42,
+            "status": "completed",
+            "model": "muse",
+            "output": [{
+                "id": "rs_native",
+                "type": "reasoning",
+                "content": [{"type": "reasoning_text", "text": "think"}],
+                "summary": []
+            }, {
+                "id": "fc_native",
+                "type": "function_call",
+                "call_id": "call_native",
+                "name": "lookup",
+                "arguments": "{\"q\":\"x\"}"
+            }, {
+                "id": "msg_native",
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "answer"}]
+            }]
+        });
+        let chunks = [
+            serde_json::json!({
+                "id": "resp_native",
+                "object": "chat.completion.chunk",
+                "created": 42,
+                "model": "muse",
+                "choices": [{"index": 0, "delta": {"reasoning_content": "think"}}]
+            }),
+            serde_json::json!({
+                "id": "resp_native",
+                "object": "chat.completion.chunk",
+                "created": 42,
+                "model": "muse",
+                "choices": [{"index": 0, "delta": {"tool_calls": [{
+                    "index": 0,
+                    "id": "call_native",
+                    "function": {"name": "lookup", "arguments": "{\"q\":\"x\"}"}
+                }]}}]
+            }),
+            serde_json::json!({
+                "id": "resp_native",
+                "object": "chat.completion.chunk",
+                "created": 42,
+                "model": "muse",
+                "choices": [{"index": 0, "delta": {"content": "answer"}}]
+            }),
+        ];
+        let mut payload = chunks
+            .iter()
+            .map(|chunk| format!("data: {chunk}\n\n"))
+            .collect::<String>();
+        payload.push_str("data: [DONE]\n\n");
+
+        let converted = convert_sse_payload_to_responses(&payload, Some(&preserved));
+        let events = parse_sse_frames(&converted)
+            .into_iter()
+            .filter_map(|(_, data)| serde_json::from_str::<serde_json::Value>(&data).ok())
+            .collect::<Vec<_>>();
+
+        for (event_type, output_index, item_id) in [
+            ("response.reasoning_text.delta", 0, "rs_native"),
+            ("response.function_call_arguments.delta", 1, "fc_native"),
+            ("response.output_text.delta", 2, "msg_native"),
+        ] {
+            let event = events
+                .iter()
+                .find(|event| event["type"] == event_type)
+                .unwrap_or_else(|| panic!("missing {event_type}"));
+            assert_eq!(event["output_index"], output_index);
+            assert_eq!(event["item_id"], item_id);
+        }
     }
 
     #[test]

--- a/src/router/responses_api.rs
+++ b/src/router/responses_api.rs
@@ -544,7 +544,7 @@ pub(super) fn responses_request_to_openai_chat_request(
                         "content": content
                     }));
                 }
-                "function_call_output" | "custom_tool_call_output" => {
+                "function_call_output" | "custom_tool_call_output" | "computer_call_output" => {
                     let call_id = item
                         .get("call_id")
                         .and_then(|v| v.as_str())
@@ -1682,6 +1682,36 @@ mod tests {
         let converted = responses_request_to_openai_chat_request(&request).unwrap();
 
         assert!(converted.get("previous_response_id").is_none());
+    }
+
+    #[test]
+    fn accepts_native_computer_call_outputs_for_passthrough() {
+        let output = serde_json::json!({
+            "type": "computer_screenshot",
+            "image_url": "data:image/png;base64,c2NyZWVuc2hvdA=="
+        });
+        let request = serde_json::json!({
+            "model": "auto",
+            "previous_response_id": "resp_previous",
+            "input": [{
+                "type": "computer_call_output",
+                "call_id": "call_computer_1",
+                "output": output
+            }]
+        });
+
+        let converted = responses_request_to_openai_chat_request(&request).unwrap();
+
+        assert_eq!(converted["messages"][0]["role"], "tool");
+        assert_eq!(converted["messages"][0]["tool_call_id"], "call_computer_1");
+        let normalized_output: serde_json::Value = serde_json::from_str(
+            converted["messages"][0]["content"]
+                .as_str()
+                .expect("computer output should have a Chat-compatible representation"),
+        )
+        .unwrap();
+        assert_eq!(normalized_output, output);
+        assert_eq!(converted["previous_response_id"], "resp_previous");
     }
 
     #[test]

--- a/src/router/responses_api.rs
+++ b/src/router/responses_api.rs
@@ -1209,17 +1209,29 @@ mod tests {
             "type": "message_start",
             "message": {"id": "resp_late", "model": "test-model"}
         });
+        let usage_only = serde_json::json!({
+            "id": "resp_original",
+            "object": "chat.completion.chunk",
+            "created": 42,
+            "model": "test-model",
+            "usage": {
+                "prompt_tokens": 15,
+                "completion_tokens": 4,
+                "total_tokens": 19
+            }
+        });
 
         converter.push_frame(None, &first.to_string());
         let empty_events = converter.push_frame(None, &empty.to_string());
         converter.push_frame(Some("message_start"), &late_message_start.to_string());
+        converter.push_frame(None, &usage_only.to_string());
         let terminal_events = converter.finish();
 
         assert!(!empty_events.contains("response.output_text.delta"));
         assert!(terminal_events.contains("\"id\":\"resp_original\""));
         assert!(!terminal_events.contains("resp_late"));
-        assert!(terminal_events.contains("\"input_tokens\":11"));
-        assert!(terminal_events.contains("\"output_tokens\":2"));
+        assert!(terminal_events.contains("\"input_tokens\":15"));
+        assert!(terminal_events.contains("\"output_tokens\":4"));
     }
 
     #[test]

--- a/src/router/responses_api.rs
+++ b/src/router/responses_api.rs
@@ -339,7 +339,14 @@ pub(super) fn responses_request_to_openai_chat_request(
         }
     }
 
-    if let Some(input_items) = body.get("input").and_then(|v| v.as_array()) {
+    if let Some(input) = body.get("input").and_then(|value| value.as_str()) {
+        messages.push(serde_json::json!({
+            "role": "user",
+            "content": input
+        }));
+    }
+
+    if let Some(input_items) = body.get("input").and_then(|value| value.as_array()) {
         for item in input_items {
             let item_type = item.get("type").and_then(|v| v.as_str()).unwrap_or("");
             match item_type {
@@ -432,6 +439,12 @@ pub(super) fn responses_request_to_openai_chat_request(
                 _ => {}
             }
         }
+    }
+    if body
+        .get("input")
+        .is_some_and(|input| !input.is_string() && !input.is_array())
+    {
+        return Err("responses request 'input' must be text or an array".to_string());
     }
 
     let mut request = serde_json::json!({

--- a/src/router/responses_api.rs
+++ b/src/router/responses_api.rs
@@ -432,6 +432,17 @@ fn normalize_tool_output(output: &serde_json::Value) -> String {
     }
 }
 
+fn normalize_continuation_output(item: &serde_json::Value) -> String {
+    if let Some(output) = item.get("output") {
+        return normalize_tool_output(output);
+    }
+    let mut payload = item.as_object().cloned().unwrap_or_default();
+    for identity_field in ["type", "call_id", "id", "approval_request_id"] {
+        payload.remove(identity_field);
+    }
+    serde_json::Value::Object(payload).to_string()
+}
+
 fn normalize_responses_message_role(role: &str) -> &str {
     match role {
         // OpenAI Responses API `developer` role should be treated as `system`
@@ -564,10 +575,7 @@ pub(super) fn responses_request_to_openai_chat_request(
                         .or_else(|| item.get("id").and_then(|v| v.as_str()))
                         .or_else(|| item.get("approval_request_id").and_then(|v| v.as_str()))
                         .unwrap_or("call_unknown");
-                    let output = item
-                        .get("output")
-                        .map(normalize_tool_output)
-                        .unwrap_or_else(|| item.to_string());
+                    let output = normalize_continuation_output(item);
                     messages.push(serde_json::json!({
                         "role": "tool",
                         "tool_call_id": call_id,
@@ -845,6 +853,25 @@ async fn convert_openai_stream_response_to_responses(response: Response) -> Resp
             axum::http::HeaderValue::from_static("text/event-stream"),
         );
         return Response::from_parts(parts, Body::from(output));
+    }
+
+    if let Some(content_encoding) = parts.headers.get(axum::http::header::CONTENT_ENCODING) {
+        let is_identity = content_encoding
+            .to_str()
+            .is_ok_and(|value| value.eq_ignore_ascii_case("identity"));
+        if !is_identity {
+            error!(
+                encoding = ?content_encoding,
+                "Responses stream adapter cannot translate an encoded upstream body"
+            );
+            return (
+                StatusCode::BAD_GATEWAY,
+                Json(serde_json::json!({
+                    "error": "Unsupported upstream stream content encoding"
+                })),
+            )
+                .into_response();
+        }
     }
 
     parts.headers.insert(
@@ -1147,6 +1174,107 @@ mod tests {
         assert!(terminal_events.contains("response.completed"));
     }
 
+    #[test]
+    fn incremental_stream_converter_keeps_identity_and_usage_stable() {
+        let mut converter = ResponsesStreamConverter::new(None);
+        let first = serde_json::json!({
+            "id": "resp_original",
+            "object": "chat.completion.chunk",
+            "created": 42,
+            "model": "test-model",
+            "choices": [{
+                "index": 0,
+                "delta": {"content": "answer"},
+                "finish_reason": null
+            }],
+            "usage": {
+                "prompt_tokens": 11,
+                "completion_tokens": 2,
+                "total_tokens": 13
+            }
+        });
+        let empty = serde_json::json!({
+            "id": "resp_original",
+            "object": "chat.completion.chunk",
+            "created": 42,
+            "model": "test-model",
+            "choices": [{
+                "index": 0,
+                "delta": {"content": ""},
+                "finish_reason": null
+            }],
+            "usage": null
+        });
+        let late_message_start = serde_json::json!({
+            "type": "message_start",
+            "message": {"id": "resp_late", "model": "test-model"}
+        });
+
+        converter.push_frame(None, &first.to_string());
+        let empty_events = converter.push_frame(None, &empty.to_string());
+        converter.push_frame(Some("message_start"), &late_message_start.to_string());
+        let terminal_events = converter.finish();
+
+        assert!(!empty_events.contains("response.output_text.delta"));
+        assert!(terminal_events.contains("\"id\":\"resp_original\""));
+        assert!(!terminal_events.contains("resp_late"));
+        assert!(terminal_events.contains("\"input_tokens\":11"));
+        assert!(terminal_events.contains("\"output_tokens\":2"));
+    }
+
+    #[test]
+    fn incremental_stream_converter_handles_anthropic_tool_use() {
+        let mut converter = ResponsesStreamConverter::new(None);
+        let message_start = serde_json::json!({
+            "type": "message_start",
+            "message": {
+                "id": "msg_tools",
+                "model": "test-model",
+                "usage": {"input_tokens": 3, "output_tokens": 0}
+            }
+        });
+        let tool_start = serde_json::json!({
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {
+                "type": "tool_use",
+                "id": "toolu_weather",
+                "name": "weather",
+                "input": {}
+            }
+        });
+        let first_arguments = serde_json::json!({
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "input_json_delta", "partial_json": "{\"city\":\""}
+        });
+        let second_arguments = serde_json::json!({
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "input_json_delta", "partial_json": "Paris\"}"}
+        });
+
+        converter.push_frame(Some("message_start"), &message_start.to_string());
+        let added = converter.push_frame(Some("content_block_start"), &tool_start.to_string());
+        let first_delta =
+            converter.push_frame(Some("content_block_delta"), &first_arguments.to_string());
+        let second_delta =
+            converter.push_frame(Some("content_block_delta"), &second_arguments.to_string());
+        let terminal = converter.finish();
+
+        assert!(added.contains("response.output_item.added"));
+        assert!(added.contains("\"name\":\"weather\""));
+        assert!(first_delta.contains("response.function_call_arguments.delta"));
+        assert!(second_delta.contains("response.function_call_arguments.delta"));
+        let done = parse_sse_frames(&terminal)
+            .into_iter()
+            .find(|(event, _)| event.as_deref() == Some("response.output_item.done"))
+            .expect("tool stream should finish its output item");
+        let done: serde_json::Value = serde_json::from_str(&done.1).unwrap();
+        assert_eq!(done["item"]["id"], "toolu_weather");
+        assert_eq!(done["item"]["arguments"], "{\"city\":\"Paris\"}");
+    }
+
     #[tokio::test]
     async fn incremental_stream_failure_retains_active_response_id() {
         let first = format!(
@@ -1183,6 +1311,37 @@ mod tests {
         assert!(payload.contains("event: response.failed"));
         assert!(payload.contains("\"id\":\"resp_active\""));
         assert!(!payload.contains("resp_failed"));
+    }
+
+    #[tokio::test]
+    async fn responses_stream_rejects_encoded_upstream_body() {
+        let upstream = Response::builder()
+            .status(StatusCode::OK)
+            .header(axum::http::header::CONTENT_TYPE, "text/event-stream")
+            .header(axum::http::header::CONTENT_ENCODING, "gzip")
+            .body(Body::from("encoded bytes"))
+            .unwrap();
+
+        let adapted = convert_openai_stream_response_to_responses(upstream).await;
+
+        assert_eq!(adapted.status(), StatusCode::BAD_GATEWAY);
+        let body = axum::body::to_bytes(adapted.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        assert!(
+            String::from_utf8_lossy(&body).contains("Unsupported upstream stream content encoding")
+        );
+    }
+
+    #[test]
+    fn continuation_fallback_omits_identity_metadata() {
+        let item = serde_json::json!({
+            "type": "mcp_approval_response",
+            "approval_request_id": "approval_1",
+            "approve": true
+        });
+
+        assert_eq!(normalize_continuation_output(&item), "{\"approve\":true}");
     }
 
     #[test]

--- a/src/router/responses_api.rs
+++ b/src/router/responses_api.rs
@@ -20,6 +20,33 @@ pub use handler::handle_responses;
 pub(super) const MAX_RESPONSES_BODY_BYTES: usize = 10 * 1024 * 1024;
 const MAX_RESPONSES_ZSTD_WINDOW_LOG: u32 = 24;
 
+#[derive(Debug)]
+pub(super) enum DecodeRequestBodyError {
+    PayloadTooLarge(String),
+    Invalid(String),
+}
+
+impl DecodeRequestBodyError {
+    #[cfg(test)]
+    fn contains(&self, needle: &str) -> bool {
+        self.to_string().contains(needle)
+    }
+
+    pub(super) fn is_payload_too_large(&self) -> bool {
+        matches!(self, Self::PayloadTooLarge(_))
+    }
+}
+
+impl std::fmt::Display for DecodeRequestBodyError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::PayloadTooLarge(message) | Self::Invalid(message) => formatter.write_str(message),
+        }
+    }
+}
+
+impl std::error::Error for DecodeRequestBodyError {}
+
 fn parse_sse_frames(payload: &str) -> Vec<(Option<String>, String)> {
     let mut frames = Vec::new();
     let normalized = payload.replace("\r\n", "\n");
@@ -53,7 +80,10 @@ fn looks_like_sse_payload(payload: &str) -> bool {
     trimmed.starts_with("event:") || trimmed.starts_with("data:")
 }
 
-pub(super) fn decode_request_body(bytes: &[u8], headers: &HeaderMap) -> Result<Vec<u8>, String> {
+pub(super) fn decode_request_body(
+    bytes: &[u8],
+    headers: &HeaderMap,
+) -> Result<Vec<u8>, DecodeRequestBodyError> {
     let content_encoding = headers
         .get(axum::http::header::CONTENT_ENCODING)
         .and_then(|v| v.to_str().ok())
@@ -66,29 +96,44 @@ pub(super) fn decode_request_body(bytes: &[u8], headers: &HeaderMap) -> Result<V
     }
 
     if content_encoding.contains("zstd") || content_encoding.contains("zst") {
-        let mut decoder = zstd::stream::read::Decoder::new(std::io::Cursor::new(bytes))
-            .map_err(|e| format!("Failed to decode zstd request body: {}", e))?;
+        let mut decoder =
+            zstd::stream::read::Decoder::new(std::io::Cursor::new(bytes)).map_err(|e| {
+                DecodeRequestBodyError::Invalid(format!(
+                    "Failed to decode zstd request body: {}",
+                    e
+                ))
+            })?;
         decoder
             .window_log_max(MAX_RESPONSES_ZSTD_WINDOW_LOG)
-            .map_err(|e| format!("Failed to bound zstd request window: {}", e))?;
+            .map_err(|e| {
+                DecodeRequestBodyError::Invalid(format!(
+                    "Failed to bound zstd request window: {}",
+                    e
+                ))
+            })?;
         let mut decoded = Vec::new();
         decoder
             .take((MAX_RESPONSES_BODY_BYTES + 1) as u64)
             .read_to_end(&mut decoded)
-            .map_err(|e| format!("Failed to decode zstd request body: {}", e))?;
+            .map_err(|e| {
+                DecodeRequestBodyError::Invalid(format!(
+                    "Failed to decode zstd request body: {}",
+                    e
+                ))
+            })?;
         if decoded.len() > MAX_RESPONSES_BODY_BYTES {
-            return Err(format!(
+            return Err(DecodeRequestBodyError::PayloadTooLarge(format!(
                 "Decoded request body exceeds {} bytes",
                 MAX_RESPONSES_BODY_BYTES
-            ));
+            )));
         }
         return Ok(decoded);
     }
 
-    Err(format!(
+    Err(DecodeRequestBodyError::Invalid(format!(
         "Unsupported content-encoding '{}'",
         content_encoding
-    ))
+    )))
 }
 
 pub(super) fn parse_json_payload(bytes: &[u8]) -> Result<serde_json::Value, String> {

--- a/src/router/responses_api.rs
+++ b/src/router/responses_api.rs
@@ -242,92 +242,99 @@ fn openai_chat_completion_to_responses_json(openai: &serde_json::Value) -> serde
         .and_then(|v| v.as_str())
         .unwrap_or("unknown");
 
+    let preserved_output = openai
+        .get(super::RESPONSES_OUTPUT_PASSTHROUGH_KEY)
+        .and_then(|output| output.as_array())
+        .cloned();
     let mut output_items = Vec::new();
-    if let Some(choice) = openai
-        .get("choices")
-        .and_then(|choices| choices.as_array())
-        .and_then(|choices| choices.first())
-    {
-        if let Some(message) = choice.get("message") {
-            let mut content_blocks = Vec::new();
-            if let Some(content) = message.get("content") {
-                match content {
-                    serde_json::Value::String(text) if !text.is_empty() => {
-                        content_blocks.push(serde_json::json!({
-                            "type": "output_text",
-                            "text": text
-                        }));
-                    }
-                    serde_json::Value::Array(items) => {
-                        for item in items {
-                            if item.get("type").and_then(|v| v.as_str()) == Some("text") {
-                                if let Some(text) = item.get("text").and_then(|v| v.as_str()) {
-                                    content_blocks.push(serde_json::json!({
-                                        "type": "output_text",
-                                        "text": text
-                                    }));
+    if preserved_output.is_none() {
+        if let Some(choice) = openai
+            .get("choices")
+            .and_then(|choices| choices.as_array())
+            .and_then(|choices| choices.first())
+        {
+            if let Some(message) = choice.get("message") {
+                let mut content_blocks = Vec::new();
+                if let Some(content) = message.get("content") {
+                    match content {
+                        serde_json::Value::String(text) if !text.is_empty() => {
+                            content_blocks.push(serde_json::json!({
+                                "type": "output_text",
+                                "text": text
+                            }));
+                        }
+                        serde_json::Value::Array(items) => {
+                            for item in items {
+                                if item.get("type").and_then(|v| v.as_str()) == Some("text") {
+                                    if let Some(text) = item.get("text").and_then(|v| v.as_str()) {
+                                        content_blocks.push(serde_json::json!({
+                                            "type": "output_text",
+                                            "text": text
+                                        }));
+                                    }
                                 }
                             }
                         }
+                        _ => {}
                     }
-                    _ => {}
                 }
-            }
 
-            if let Some(reasoning) = message
-                .get("reasoning_content")
-                .and_then(|v| v.as_str())
-                .filter(|reasoning| !reasoning.is_empty())
-            {
-                output_items.push(responses_reasoning_item(response_id, reasoning));
-            }
+                if let Some(reasoning) = message
+                    .get("reasoning_content")
+                    .and_then(|v| v.as_str())
+                    .filter(|reasoning| !reasoning.is_empty())
+                {
+                    output_items.push(responses_reasoning_item(response_id, reasoning));
+                }
 
-            if let Some(refusal) = message
-                .get("refusal")
-                .and_then(|v| v.as_str())
-                .filter(|refusal| !refusal.is_empty())
-            {
-                content_blocks.push(serde_json::json!({
-                    "type": "refusal",
-                    "refusal": refusal
-                }));
-            }
-
-            output_items.push(serde_json::json!({
-                "id": format!("msg_{}", response_id),
-                "type": "message",
-                "role": "assistant",
-                "content": content_blocks
-            }));
-
-            if let Some(tool_calls) = message.get("tool_calls").and_then(|v| v.as_array()) {
-                for tool_call in tool_calls {
-                    let call_id = tool_call
-                        .get("id")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("call_unknown");
-                    let name = tool_call
-                        .get("function")
-                        .and_then(|f| f.get("name"))
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("tool");
-                    let arguments = tool_call
-                        .get("function")
-                        .and_then(|f| f.get("arguments"))
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("{}");
-
-                    output_items.push(serde_json::json!({
-                        "id": call_id,
-                        "type": "function_call",
-                        "call_id": call_id,
-                        "name": name,
-                        "arguments": arguments
+                if let Some(refusal) = message
+                    .get("refusal")
+                    .and_then(|v| v.as_str())
+                    .filter(|refusal| !refusal.is_empty())
+                {
+                    content_blocks.push(serde_json::json!({
+                        "type": "refusal",
+                        "refusal": refusal
                     }));
+                }
+
+                output_items.push(serde_json::json!({
+                    "id": format!("msg_{}", response_id),
+                    "type": "message",
+                    "role": "assistant",
+                    "content": content_blocks
+                }));
+
+                if let Some(tool_calls) = message.get("tool_calls").and_then(|v| v.as_array()) {
+                    for tool_call in tool_calls {
+                        let call_id = tool_call
+                            .get("id")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("call_unknown");
+                        let name = tool_call
+                            .get("function")
+                            .and_then(|f| f.get("name"))
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("tool");
+                        let arguments = tool_call
+                            .get("function")
+                            .and_then(|f| f.get("arguments"))
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("{}");
+
+                        output_items.push(serde_json::json!({
+                            "id": call_id,
+                            "type": "function_call",
+                            "call_id": call_id,
+                            "name": name,
+                            "arguments": arguments
+                        }));
+                    }
                 }
             }
         }
     }
+    let output_items = preserved_output.unwrap_or(output_items);
 
     let usage = openai
         .get("usage")
@@ -346,7 +353,10 @@ fn openai_chat_completion_to_responses_json(openai: &serde_json::Value) -> serde
         "output": output_items,
         "usage": usage
     });
-    if let Some(incomplete_details) = openai.get("incomplete_details") {
+    if let Some(incomplete_details) = openai
+        .get("incomplete_details")
+        .filter(|value| !value.is_null())
+    {
         response["incomplete_details"] = incomplete_details.clone();
     }
     response
@@ -438,6 +448,66 @@ pub(super) fn responses_request_to_openai_chat_request(
         Some(input) if input.is_string() || input.is_array() => {}
         Some(_) => {
             return Err("responses request 'input' must be text or an array".to_string());
+        }
+    }
+
+    if let Some(tools) = body.get("tools") {
+        let tools = tools
+            .as_array()
+            .ok_or_else(|| "responses request 'tools' must be an array".to_string())?;
+        for tool in tools {
+            let tool_type = tool
+                .as_object()
+                .and_then(|object| object.get("type"))
+                .and_then(|value| value.as_str())
+                .filter(|tool_type| !tool_type.is_empty())
+                .ok_or_else(|| {
+                    "responses request tool entries require a non-empty string 'type'".to_string()
+                })?;
+            if tool_type == "function"
+                && tool
+                    .get("name")
+                    .and_then(|value| value.as_str())
+                    .filter(|name| !name.is_empty())
+                    .is_none()
+            {
+                return Err(
+                    "responses function tools require a non-empty string 'name'".to_string()
+                );
+            }
+        }
+    }
+    if let Some(tool_choice) = body.get("tool_choice").filter(|value| !value.is_null()) {
+        match tool_choice {
+            serde_json::Value::String(choice) if !choice.is_empty() => {}
+            serde_json::Value::Object(object) => {
+                let choice_type = object
+                    .get("type")
+                    .and_then(|value| value.as_str())
+                    .filter(|choice_type| !choice_type.is_empty())
+                    .ok_or_else(|| {
+                        "responses request 'tool_choice' must be a non-empty string or typed object"
+                            .to_string()
+                    })?;
+                if choice_type == "function"
+                    && object
+                        .get("name")
+                        .and_then(|value| value.as_str())
+                        .filter(|name| !name.is_empty())
+                        .is_none()
+                {
+                    return Err(
+                        "responses function tool choices require a non-empty string 'name'"
+                            .to_string(),
+                    );
+                }
+            }
+            _ => {
+                return Err(
+                    "responses request 'tool_choice' must be a non-empty string or typed object"
+                        .to_string(),
+                );
+            }
         }
     }
 
@@ -566,7 +636,11 @@ pub(super) fn responses_request_to_openai_chat_request(
     if let Some(tools) = body.get("tools").cloned() {
         request["tools"] = tools;
     }
-    if let Some(tool_choice) = body.get("tool_choice").cloned() {
+    if let Some(tool_choice) = body
+        .get("tool_choice")
+        .filter(|value| !value.is_null())
+        .cloned()
+    {
         request["tool_choice"] = tool_choice;
     }
     if let Some(temperature) = body.get("temperature").cloned() {
@@ -584,17 +658,17 @@ pub(super) fn responses_request_to_openai_chat_request(
         request["max_completion_tokens"] = max_tokens;
     }
     if let Some(reasoning) = body.get("reasoning").filter(|value| !value.is_null()) {
-        let effort = reasoning
-            .get("effort")
-            .and_then(|value| value.as_str())
-            .ok_or_else(|| "responses request 'reasoning.effort' must be a string".to_string())?;
+        let effort = match reasoning.get("effort").filter(|value| !value.is_null()) {
+            Some(effort) => effort.as_str().ok_or_else(|| {
+                "responses request 'reasoning.effort' must be a string".to_string()
+            })?,
+            None => "medium",
+        };
         request["reasoning_effort"] = serde_json::Value::String(effort.to_string());
-        request[super::RESPONSES_REASONING_PASSTHROUGH_KEY] = reasoning.clone();
     }
     if let Some(previous_response_id) = body.get("previous_response_id").cloned() {
         request["previous_response_id"] = previous_response_id;
     }
-
     Ok(request)
 }
 
@@ -807,6 +881,7 @@ fn convert_sse_payload_to_responses(payload: &str) -> String {
     let mut reasoning_text = String::new();
     let mut response_status = "completed".to_string();
     let mut incomplete_details = None;
+    let mut preserved_output = None;
     let mut tools: std::collections::BTreeMap<usize, ToolAccum> = std::collections::BTreeMap::new();
     let mut usage = map_openai_usage_to_responses_usage(&serde_json::json!({}));
 
@@ -840,6 +915,12 @@ fn convert_sse_payload_to_responses(payload: &str) -> String {
             .filter(|value| !value.is_null())
         {
             incomplete_details = Some(details.clone());
+        }
+        if let Some(output) = chunk
+            .get(super::RESPONSES_OUTPUT_PASSTHROUGH_KEY)
+            .and_then(|value| value.as_array())
+        {
+            preserved_output = Some(output.clone());
         }
 
         // Anthropic message_start metadata fallback
@@ -1160,6 +1241,10 @@ fn convert_sse_payload_to_responses(payload: &str) -> String {
         output.push_str("event: response.output_item.done\ndata: ");
         output.push_str(&done.to_string());
         output.push_str("\n\n");
+    }
+
+    if let Some(preserved_output) = preserved_output {
+        output_items = preserved_output;
     }
 
     let terminal_type = match response_status.as_str() {

--- a/src/router/responses_api.rs
+++ b/src/router/responses_api.rs
@@ -19,8 +19,10 @@ use tracing::error;
 use crate::sse::SseFrameDecoder;
 
 mod handler;
+mod incremental_stream;
 
 pub use handler::handle_responses;
+use incremental_stream::ResponsesStreamConverter;
 
 pub(super) const MAX_RESPONSES_BODY_BYTES: usize = 10 * 1024 * 1024;
 const MAX_RESPONSES_ZSTD_WINDOW_LOG: u32 = 24;
@@ -864,18 +866,18 @@ async fn convert_openai_stream_response_to_responses(response: Response) -> Resp
     tokio::spawn(async move {
         let mut stream = body.into_data_stream();
         let mut decoder = SseFrameDecoder::new();
-        let mut source = String::new();
-        let mut emitted = String::new();
+        let mut converter = ResponsesStreamConverter::new(preserved_response);
         let mut received_bytes = 0_usize;
-        let mut source_done = false;
 
         while let Some(chunk) = stream.next().await {
             let bytes = match chunk {
                 Ok(bytes) => bytes,
                 Err(err) => {
                     error!("Failed to read OpenAI stream chunk: {}", err);
-                    let failed =
-                        responses_stream_adapter_failed_event("Failed to read upstream stream");
+                    let failed = responses_stream_adapter_failed_event(
+                        converter.response_id(),
+                        "Failed to read upstream stream",
+                    );
                     let _ = tx.send(Ok(Bytes::from(failed))).await;
                     return;
                 }
@@ -883,85 +885,42 @@ async fn convert_openai_stream_response_to_responses(response: Response) -> Resp
             received_bytes = received_bytes.saturating_add(bytes.len());
             if received_bytes > MAX_RESPONSES_BODY_BYTES {
                 let failed = responses_stream_adapter_failed_event(
+                    converter.response_id(),
                     "Upstream stream exceeded the Responses adapter limit",
                 );
                 let _ = tx.send(Ok(Bytes::from(failed))).await;
                 return;
             }
 
-            let frames = decoder.push(&bytes);
-            if frames.is_empty() {
-                continue;
-            }
-            for frame in frames {
-                source_done |= frame.data.trim() == "[DONE]";
-                source.push_str(&frame.to_sse_string());
-            }
-
-            let converted = convert_sse_payload_to_responses(&source, preserved_response.as_ref());
-            let prefix_len = responses_stream_stable_prefix_len(&converted);
-            let stable_prefix = &converted[..prefix_len];
-            let Some(delta) = stable_prefix.strip_prefix(&emitted) else {
-                error!("Responses stream conversion prefix diverged");
-                let failed = responses_stream_adapter_failed_event(
-                    "Responses stream conversion became inconsistent",
-                );
-                let _ = tx.send(Ok(Bytes::from(failed))).await;
-                return;
-            };
-            if !delta.is_empty() {
-                if tx
-                    .send(Ok(Bytes::copy_from_slice(delta.as_bytes())))
-                    .await
-                    .is_err()
-                {
+            for frame in decoder.push(&bytes) {
+                let converted = if frame.data.trim() == "[DONE]" {
+                    converter.finish()
+                } else {
+                    converter.push_frame(frame.event.as_deref(), &frame.data)
+                };
+                if !converted.is_empty() && tx.send(Ok(Bytes::from(converted))).await.is_err() {
                     return;
                 }
-                emitted.push_str(delta);
-            }
-            if source_done {
-                break;
+                if frame.data.trim() == "[DONE]" {
+                    return;
+                }
             }
         }
 
-        let converted = convert_sse_payload_to_responses(&source, preserved_response.as_ref());
-        let Some(tail) = converted.strip_prefix(&emitted) else {
-            error!("Responses stream conversion tail diverged");
-            let failed = responses_stream_adapter_failed_event(
-                "Responses stream conversion became inconsistent",
-            );
-            let _ = tx.send(Ok(Bytes::from(failed))).await;
-            return;
-        };
+        let tail = converter.finish();
         if !tail.is_empty() {
-            let _ = tx.send(Ok(Bytes::copy_from_slice(tail.as_bytes()))).await;
+            let _ = tx.send(Ok(Bytes::from(tail))).await;
         }
     });
 
     Response::from_parts(parts, Body::from_stream(ReceiverStream::new(rx)))
 }
 
-fn responses_stream_stable_prefix_len(converted: &str) -> usize {
-    [
-        "event: response.output_item.done\n",
-        "event: response.queued\n",
-        "event: response.in_progress\n",
-        "event: response.completed\n",
-        "event: response.incomplete\n",
-        "event: response.failed\n",
-        "event: response.cancelled\n",
-    ]
-    .iter()
-    .filter_map(|marker| converted.find(marker))
-    .min()
-    .unwrap_or(converted.len())
-}
-
-fn responses_stream_adapter_failed_event(message: &str) -> String {
+fn responses_stream_adapter_failed_event(response_id: &str, message: &str) -> String {
     let failed = serde_json::json!({
         "type": "response.failed",
         "response": {
-            "id": "resp_failed",
+            "id": response_id,
             "object": "response",
             "status": "failed",
             "error": {
@@ -1132,648 +1091,99 @@ fn convert_sse_payload_to_responses(
     payload: &str,
     preserved_response: Option<&serde_json::Value>,
 ) -> String {
-    #[derive(Default)]
-    struct ToolAccum {
-        id: String,
-        item_id: Option<String>,
-        name: String,
-        arguments: String,
-        emitted_arguments_len: usize,
-        added: bool,
-        output_index: Option<usize>,
-    }
-
+    let mut converter = ResponsesStreamConverter::new(preserved_response.cloned());
     let mut output = String::new();
-    let mut response_id = "resp_stream".to_string();
-    let mut created_at = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs() as i64;
-    let mut model = "unknown".to_string();
-    let mut created_sent = false;
-    let mut reasoning_item_added = false;
-    let mut reasoning_output_index = None;
-    let mut message_item_added = false;
-    let mut message_output_index = None;
-    let mut next_output_index = 0;
-    let mut message_text = String::new();
-    let mut refusal_text = String::new();
-    let mut reasoning_text = String::new();
-    let mut response_status = "completed".to_string();
-    let mut incomplete_details = None;
-    let preserved_response = preserved_response.cloned();
-    let mut preserved_items_added = false;
-    let mut tools: std::collections::BTreeMap<usize, ToolAccum> = std::collections::BTreeMap::new();
-    let mut usage = map_openai_usage_to_responses_usage(&serde_json::json!({}));
-
-    if let Some(status) = preserved_response
-        .as_ref()
-        .and_then(|response| response.get("status"))
-        .and_then(|status| status.as_str())
-    {
-        response_status = status.to_string();
-    }
-
     for (event_type, data) in parse_sse_frames(payload) {
         if data.trim() == "[DONE]" {
             break;
         }
-
-        let chunk: serde_json::Value = match serde_json::from_str(&data) {
-            Ok(v) => v,
-            Err(_) => continue,
-        };
-
-        // OpenAI chunk metadata
-        if !created_sent {
-            if let Some(id) = chunk.get("id").and_then(|v| v.as_str()) {
-                response_id = id.to_string();
-            }
-        }
-        if let Some(ts) = chunk.get("created").and_then(|v| v.as_i64()) {
-            created_at = ts;
-        }
-        if let Some(m) = chunk.get("model").and_then(|v| v.as_str()) {
-            model = m.to_string();
-        }
-        if let Some(status) = chunk.get("response_status").and_then(|v| v.as_str()) {
-            response_status = status.to_string();
-        }
-        if let Some(details) = chunk
-            .get("incomplete_details")
-            .filter(|value| !value.is_null())
-        {
-            incomplete_details = Some(details.clone());
-        }
-        // Anthropic message_start metadata fallback
-        if event_type.as_deref() == Some("message_start")
-            || chunk.get("type").and_then(|v| v.as_str()) == Some("message_start")
-        {
-            if let Some(msg) = chunk.get("message") {
-                if let Some(id) = msg.get("id").and_then(|v| v.as_str()) {
-                    response_id = id.to_string();
-                }
-                if let Some(m) = msg.get("model").and_then(|v| v.as_str()) {
-                    model = m.to_string();
-                }
-                if let Some(u) = msg.get("usage") {
-                    usage = map_openai_usage_to_responses_usage(&serde_json::json!({
-                        "prompt_tokens": u.get("input_tokens").and_then(|v| v.as_u64()).unwrap_or(0),
-                        "completion_tokens": u.get("output_tokens").and_then(|v| v.as_u64()).unwrap_or(0),
-                        "total_tokens": u.get("input_tokens").and_then(|v| v.as_u64()).unwrap_or(0)
-                            + u.get("output_tokens").and_then(|v| v.as_u64()).unwrap_or(0)
-                    }));
-                }
-            }
-        }
-
-        if !created_sent {
-            let created_event = serde_json::json!({
-                "type": "response.created",
-                "response": {
-                    "id": response_id,
-                    "object": "response",
-                    "created_at": created_at,
-                    "status": "in_progress",
-                    "model": model
-                }
-            });
-            output.push_str("event: response.created\ndata: ");
-            output.push_str(&created_event.to_string());
-            output.push_str("\n\n");
-            created_sent = true;
-        }
-
-        if !preserved_items_added {
-            if let Some(items) = preserved_response
-                .as_ref()
-                .and_then(|response| response.get("output"))
-                .and_then(|value| value.as_array())
-            {
-                for (output_index, item) in items.iter().enumerate() {
-                    let added = serde_json::json!({
-                        "type": "response.output_item.added",
-                        "output_index": output_index,
-                        "item": initial_responses_output_item(item)
-                    });
-                    output.push_str("event: response.output_item.added\ndata: ");
-                    output.push_str(&added.to_string());
-                    output.push_str("\n\n");
-                }
-                preserved_items_added = true;
-            }
-        }
-
-        if let Some(u) = chunk.get("usage") {
-            usage = map_openai_usage_to_responses_usage(u);
-        }
-
-        // OpenAI chunk path
-        let choice = chunk
-            .get("choices")
-            .and_then(|v| v.as_array())
-            .and_then(|v| v.first());
-
-        if let Some(choice) = choice {
-            let delta = choice.get("delta").cloned().unwrap_or_default();
-
-            if let Some(text) = delta.get("content").and_then(|v| v.as_str()) {
-                if !message_item_added {
-                    if preserved_response.is_none() {
-                        let output_index = next_output_index;
-                        next_output_index += 1;
-                        let added = serde_json::json!({
-                            "type": "response.output_item.added",
-                            "output_index": output_index,
-                            "item": {
-                                "id": format!("msg_{}", response_id),
-                                "type": "message",
-                                "role": "assistant",
-                                "content": []
-                            }
-                        });
-                        output.push_str("event: response.output_item.added\ndata: ");
-                        output.push_str(&added.to_string());
-                        output.push_str("\n\n");
-                        message_output_index = Some(output_index);
-                    }
-                    message_item_added = true;
-                }
-
-                message_text.push_str(text);
-                let identity = preserved_response
-                    .as_ref()
-                    .and_then(|response| {
-                        unique_response_output_item_identity(
-                            response,
-                            "message",
-                            Some("output_text"),
-                        )
-                    })
-                    .or_else(|| {
-                        message_output_index.map(|output_index| ResponseOutputItemIdentity {
-                            output_index,
-                            item_id: Some(format!("msg_{}", response_id)),
-                            content_index: Some(0),
-                        })
-                    });
-                append_response_delta(&mut output, "response.output_text.delta", text, identity);
-            }
-
-            if let Some(reasoning) = delta
-                .get("reasoning_content")
-                .and_then(|v| v.as_str())
-                .filter(|reasoning| !reasoning.is_empty())
-            {
-                if preserved_response.is_none() {
-                    add_reasoning_output_item(
-                        &mut output,
-                        &response_id,
-                        &mut reasoning_item_added,
-                        &mut reasoning_output_index,
-                        &mut next_output_index,
-                    );
-                } else {
-                    reasoning_item_added = true;
-                }
-                reasoning_text.push_str(reasoning);
-                let identity = preserved_response
-                    .as_ref()
-                    .and_then(|response| {
-                        unique_response_output_item_identity(
-                            response,
-                            "reasoning",
-                            Some("reasoning_text"),
-                        )
-                    })
-                    .or_else(|| {
-                        reasoning_output_index.map(|output_index| ResponseOutputItemIdentity {
-                            output_index,
-                            item_id: Some(format!("rs_{}", response_id)),
-                            content_index: Some(0),
-                        })
-                    });
-                append_response_delta(
-                    &mut output,
-                    "response.reasoning_text.delta",
-                    reasoning,
-                    identity,
-                );
-            }
-
-            if let Some(refusal) = delta
-                .get("refusal")
-                .and_then(|v| v.as_str())
-                .filter(|refusal| !refusal.is_empty())
-            {
-                if !message_item_added {
-                    if preserved_response.is_none() {
-                        let output_index = next_output_index;
-                        next_output_index += 1;
-                        let added = serde_json::json!({
-                            "type": "response.output_item.added",
-                            "output_index": output_index,
-                            "item": {
-                                "id": format!("msg_{}", response_id),
-                                "type": "message",
-                                "role": "assistant",
-                                "content": []
-                            }
-                        });
-                        output.push_str("event: response.output_item.added\ndata: ");
-                        output.push_str(&added.to_string());
-                        output.push_str("\n\n");
-                        message_output_index = Some(output_index);
-                    }
-                    message_item_added = true;
-                }
-                refusal_text.push_str(refusal);
-                let identity = preserved_response
-                    .as_ref()
-                    .and_then(|response| {
-                        unique_response_output_item_identity(response, "message", Some("refusal"))
-                    })
-                    .or_else(|| {
-                        message_output_index.map(|output_index| ResponseOutputItemIdentity {
-                            output_index,
-                            item_id: Some(format!("msg_{}", response_id)),
-                            content_index: Some(0),
-                        })
-                    });
-                append_response_delta(&mut output, "response.refusal.delta", refusal, identity);
-            }
-
-            if let Some(tool_calls) = delta.get("tool_calls").and_then(|v| v.as_array()) {
-                for tool_call in tool_calls {
-                    let index =
-                        tool_call.get("index").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
-                    let entry = tools.entry(index).or_default();
-
-                    if let Some(id) = tool_call.get("id").and_then(|v| v.as_str()) {
-                        entry.id = id.to_string();
-                    }
-                    if let Some(name) = tool_call
-                        .get("function")
-                        .and_then(|f| f.get("name"))
-                        .and_then(|v| v.as_str())
-                    {
-                        entry.name = name.to_string();
-                    }
-                    if let Some(args) = tool_call
-                        .get("function")
-                        .and_then(|f| f.get("arguments"))
-                        .and_then(|v| v.as_str())
-                    {
-                        entry.arguments.push_str(args);
-                    }
-
-                    if !entry.added && (!entry.id.is_empty() || !entry.name.is_empty()) {
-                        if entry.id.is_empty() {
-                            entry.id = format!("call_{}", index);
-                        }
-                        if entry.name.is_empty() {
-                            entry.name = "tool".to_string();
-                        }
-                        if preserved_response.is_none() {
-                            let output_index = next_output_index;
-                            next_output_index += 1;
-                            let added = serde_json::json!({
-                                "type": "response.output_item.added",
-                                "output_index": output_index,
-                                "item": {
-                                    "id": entry.id,
-                                    "type": "function_call",
-                                    "call_id": entry.id,
-                                    "name": entry.name,
-                                    "arguments": ""
-                                }
-                            });
-                            output.push_str("event: response.output_item.added\ndata: ");
-                            output.push_str(&added.to_string());
-                            output.push_str("\n\n");
-                            entry.output_index = Some(output_index);
-                            entry.item_id = Some(entry.id.clone());
-                        } else if let Some(identity) =
-                            preserved_response.as_ref().and_then(|response| {
-                                response_output_item_identity(
-                                    response,
-                                    "function_call",
-                                    index,
-                                    None,
-                                )
-                            })
-                        {
-                            entry.output_index = Some(identity.output_index);
-                            entry.item_id = identity.item_id;
-                        }
-                        entry.added = true;
-                    }
-
-                    if entry.added && entry.arguments.len() > entry.emitted_arguments_len {
-                        let delta = entry.arguments[entry.emitted_arguments_len..].to_string();
-                        entry.emitted_arguments_len = entry.arguments.len();
-                        let identity =
-                            entry
-                                .output_index
-                                .map(|output_index| ResponseOutputItemIdentity {
-                                    output_index,
-                                    item_id: entry.item_id.clone(),
-                                    content_index: None,
-                                });
-                        append_response_delta(
-                            &mut output,
-                            "response.function_call_arguments.delta",
-                            &delta,
-                            identity,
-                        );
-                    }
-                }
-            }
-            continue;
-        }
-
-        // Anthropic event fallback path (when OpenAI conversion did not happen upstream)
-        let event_type = event_type.or_else(|| {
-            chunk
-                .get("type")
-                .and_then(|v| v.as_str())
-                .map(str::to_string)
-        });
-        match event_type.as_deref() {
-            Some("content_block_delta") => {
-                if let Some(delta) = chunk.get("delta") {
-                    if let Some(text) = delta.get("text").and_then(|v| v.as_str()) {
-                        if !text.is_empty() {
-                            if !message_item_added {
-                                if preserved_response.is_none() {
-                                    let output_index = next_output_index;
-                                    next_output_index += 1;
-                                    let added = serde_json::json!({
-                                        "type": "response.output_item.added",
-                                        "output_index": output_index,
-                                        "item": {
-                                            "id": format!("msg_{}", response_id),
-                                            "type": "message",
-                                            "role": "assistant",
-                                            "content": []
-                                        }
-                                    });
-                                    output.push_str("event: response.output_item.added\ndata: ");
-                                    output.push_str(&added.to_string());
-                                    output.push_str("\n\n");
-                                    message_output_index = Some(output_index);
-                                }
-                                message_item_added = true;
-                            }
-                            message_text.push_str(text);
-                            let identity = preserved_response
-                                .as_ref()
-                                .and_then(|response| {
-                                    unique_response_output_item_identity(
-                                        response,
-                                        "message",
-                                        Some("output_text"),
-                                    )
-                                })
-                                .or_else(|| {
-                                    message_output_index.map(|output_index| {
-                                        ResponseOutputItemIdentity {
-                                            output_index,
-                                            item_id: Some(format!("msg_{}", response_id)),
-                                            content_index: Some(0),
-                                        }
-                                    })
-                                });
-                            append_response_delta(
-                                &mut output,
-                                "response.output_text.delta",
-                                text,
-                                identity,
-                            );
-                        }
-                    }
-                    if let Some(thinking) = delta.get("thinking").and_then(|v| v.as_str()) {
-                        if !thinking.is_empty() {
-                            if preserved_response.is_none() {
-                                add_reasoning_output_item(
-                                    &mut output,
-                                    &response_id,
-                                    &mut reasoning_item_added,
-                                    &mut reasoning_output_index,
-                                    &mut next_output_index,
-                                );
-                            } else {
-                                reasoning_item_added = true;
-                            }
-                            reasoning_text.push_str(thinking);
-                            let identity = preserved_response
-                                .as_ref()
-                                .and_then(|response| {
-                                    unique_response_output_item_identity(
-                                        response,
-                                        "reasoning",
-                                        Some("reasoning_text"),
-                                    )
-                                })
-                                .or_else(|| {
-                                    reasoning_output_index.map(|output_index| {
-                                        ResponseOutputItemIdentity {
-                                            output_index,
-                                            item_id: Some(format!("rs_{}", response_id)),
-                                            content_index: Some(0),
-                                        }
-                                    })
-                                });
-                            append_response_delta(
-                                &mut output,
-                                "response.reasoning_text.delta",
-                                thinking,
-                                identity,
-                            );
-                        }
-                    }
-                }
-            }
-            Some("message_delta") => {
-                if let Some(u) = chunk.get("usage") {
-                    usage = map_openai_usage_to_responses_usage(&serde_json::json!({
-                        "prompt_tokens": u.get("input_tokens").and_then(|v| v.as_u64()).unwrap_or(0),
-                        "completion_tokens": u.get("output_tokens").and_then(|v| v.as_u64()).unwrap_or(0),
-                        "total_tokens": u.get("input_tokens").and_then(|v| v.as_u64()).unwrap_or(0)
-                            + u.get("output_tokens").and_then(|v| v.as_u64()).unwrap_or(0)
-                    }));
-                }
-            }
-            _ => {}
-        }
+        output.push_str(&converter.push_frame(event_type.as_deref(), &data));
     }
-
-    let mut indexed_output_items = Vec::new();
-
-    if preserved_response.is_none() && !reasoning_text.is_empty() {
-        let reasoning_item = responses_reasoning_item(&response_id, &reasoning_text);
-        let output_index =
-            reasoning_output_index.expect("generated reasoning output must have an added event");
-        indexed_output_items.push((output_index, reasoning_item.clone()));
-        let done = serde_json::json!({
-            "type": "response.output_item.done",
-            "output_index": output_index,
-            "item": reasoning_item
-        });
-        output.push_str("event: response.output_item.done\ndata: ");
-        output.push_str(&done.to_string());
-        output.push_str("\n\n");
-    }
-
-    if preserved_response.is_none() && message_item_added {
-        let mut message_content = Vec::new();
-        if !message_text.is_empty() {
-            message_content.push(serde_json::json!({
-                "type": "output_text",
-                "text": message_text
-            }));
-        }
-        if !refusal_text.is_empty() {
-            message_content.push(serde_json::json!({
-                "type": "refusal",
-                "refusal": refusal_text
-            }));
-        }
-        let message_item = serde_json::json!({
-            "id": format!("msg_{}", response_id),
-            "type": "message",
-            "role": "assistant",
-            "content": message_content
-        });
-        let output_index =
-            message_output_index.expect("generated message output must have an added event");
-        indexed_output_items.push((output_index, message_item.clone()));
-        let done = serde_json::json!({
-            "type": "response.output_item.done",
-            "output_index": output_index,
-            "item": message_item
-        });
-        output.push_str("event: response.output_item.done\ndata: ");
-        output.push_str(&done.to_string());
-        output.push_str("\n\n");
-    }
-
-    for tool in tools.values().filter(|_| preserved_response.is_none()) {
-        let call_id = if tool.id.is_empty() {
-            "call_unknown"
-        } else {
-            &tool.id
-        };
-        let name = if tool.name.is_empty() {
-            "tool"
-        } else {
-            &tool.name
-        };
-        let item = serde_json::json!({
-            "id": call_id,
-            "type": "function_call",
-            "call_id": call_id,
-            "name": name,
-            "arguments": tool.arguments
-        });
-        let output_index = if let Some(output_index) = tool.output_index {
-            output_index
-        } else {
-            let output_index = next_output_index;
-            next_output_index += 1;
-            let added = serde_json::json!({
-                "type": "response.output_item.added",
-                "output_index": output_index,
-                "item": {
-                    "id": call_id,
-                    "type": "function_call",
-                    "call_id": call_id,
-                    "name": name,
-                    "arguments": ""
-                }
-            });
-            output.push_str("event: response.output_item.added\ndata: ");
-            output.push_str(&added.to_string());
-            output.push_str("\n\n");
-            output_index
-        };
-        indexed_output_items.push((output_index, item.clone()));
-        let done = serde_json::json!({
-            "type": "response.output_item.done",
-            "output_index": output_index,
-            "item": item
-        });
-        output.push_str("event: response.output_item.done\ndata: ");
-        output.push_str(&done.to_string());
-        output.push_str("\n\n");
-    }
-
-    indexed_output_items.sort_by_key(|(output_index, _)| *output_index);
-    let mut output_items = indexed_output_items
-        .into_iter()
-        .map(|(_, item)| item)
-        .collect::<Vec<_>>();
-
-    if let Some(items) = preserved_response
-        .as_ref()
-        .and_then(|response| response.get("output"))
-        .and_then(|value| value.as_array())
-    {
-        for (output_index, item) in items.iter().enumerate() {
-            let done = serde_json::json!({
-                "type": "response.output_item.done",
-                "output_index": output_index,
-                "item": item
-            });
-            output.push_str("event: response.output_item.done\ndata: ");
-            output.push_str(&done.to_string());
-            output.push_str("\n\n");
-        }
-        output_items = items.clone();
-    }
-
-    let terminal_type = match response_status.as_str() {
-        "queued" => "response.queued",
-        "in_progress" => "response.in_progress",
-        "completed" => "response.completed",
-        "incomplete" => "response.incomplete",
-        "failed" => "response.failed",
-        "cancelled" => "response.cancelled",
-        _ => "response.incomplete",
-    };
-    let terminal_response = if let Some(preserved_response) = preserved_response {
-        preserved_response
-    } else {
-        let mut terminal_response = serde_json::json!({
-            "id": response_id,
-            "object": "response",
-            "created_at": created_at,
-            "status": response_status,
-            "model": model,
-            "output": output_items,
-            "usage": usage
-        });
-        if let Some(incomplete_details) = incomplete_details {
-            terminal_response["incomplete_details"] = incomplete_details;
-        }
-        terminal_response
-    };
-    let terminal = serde_json::json!({
-        "type": terminal_type,
-        "response": terminal_response
-    });
-    output.push_str("event: ");
-    output.push_str(terminal_type);
-    output.push_str("\ndata: ");
-    output.push_str(&terminal.to_string());
-    output.push_str("\n\n");
-
+    output.push_str(&converter.finish());
     output
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn incremental_stream_converter_emits_each_frame_once() {
+        let mut converter = ResponsesStreamConverter::new(None);
+        let first = serde_json::json!({
+            "id": "resp_incremental",
+            "object": "chat.completion.chunk",
+            "created": 42,
+            "model": "test-model",
+            "choices": [{
+                "index": 0,
+                "delta": {"content": "first"},
+                "finish_reason": null
+            }]
+        });
+        let second = serde_json::json!({
+            "id": "resp_incremental",
+            "object": "chat.completion.chunk",
+            "created": 42,
+            "model": "test-model",
+            "choices": [{
+                "index": 0,
+                "delta": {"content": " second"},
+                "finish_reason": "stop"
+            }]
+        });
+
+        let first_events = converter.push_frame(None, &first.to_string());
+        let second_events = converter.push_frame(None, &second.to_string());
+        let terminal_events = converter.finish();
+
+        assert!(first_events.contains("response.created"));
+        assert!(first_events.contains("\"delta\":\"first\""));
+        assert!(!second_events.contains("response.created"));
+        assert!(!second_events.contains("\"delta\":\"first\""));
+        assert!(second_events.contains("\"delta\":\" second\""));
+        assert!(!second_events.contains("response.completed"));
+        assert!(terminal_events.contains("response.output_item.done"));
+        assert!(terminal_events.contains("response.completed"));
+    }
+
+    #[tokio::test]
+    async fn incremental_stream_failure_retains_active_response_id() {
+        let first = format!(
+            "data: {}\n\n",
+            serde_json::json!({
+                "id": "resp_active",
+                "object": "chat.completion.chunk",
+                "created": 42,
+                "model": "test-model",
+                "choices": [{
+                    "index": 0,
+                    "delta": {"content": "first"},
+                    "finish_reason": null
+                }]
+            })
+        );
+        let body = Body::from_stream(futures::stream::iter([
+            Ok::<Bytes, std::io::Error>(Bytes::from(first)),
+            Ok(Bytes::from(vec![b'x'; MAX_RESPONSES_BODY_BYTES])),
+        ]));
+        let upstream = Response::builder()
+            .status(StatusCode::OK)
+            .header(axum::http::header::CONTENT_TYPE, "text/event-stream")
+            .body(body)
+            .unwrap();
+
+        let adapted = convert_openai_stream_response_to_responses(upstream).await;
+        let body = axum::body::to_bytes(adapted.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let payload = String::from_utf8(body.to_vec()).unwrap();
+
+        assert!(payload.contains("event: response.created"));
+        assert!(payload.contains("event: response.failed"));
+        assert!(payload.contains("\"id\":\"resp_active\""));
+        assert!(!payload.contains("resp_failed"));
+    }
 
     #[test]
     fn rejects_non_object_responses_reasoning() {

--- a/src/router/responses_api.rs
+++ b/src/router/responses_api.rs
@@ -223,7 +223,10 @@ fn responses_reasoning_item(response_id: &str, reasoning: &str) -> serde_json::V
     })
 }
 
-fn openai_chat_completion_to_responses_json(openai: &serde_json::Value) -> serde_json::Value {
+fn openai_chat_completion_to_responses_json(
+    openai: &serde_json::Value,
+    preserved_response: Option<&serde_json::Value>,
+) -> serde_json::Value {
     let response_id = openai
         .get("id")
         .and_then(|v| v.as_str())
@@ -242,99 +245,95 @@ fn openai_chat_completion_to_responses_json(openai: &serde_json::Value) -> serde
         .and_then(|v| v.as_str())
         .unwrap_or("unknown");
 
-    let preserved_output = openai
-        .get(super::RESPONSES_OUTPUT_PASSTHROUGH_KEY)
-        .and_then(|output| output.as_array())
-        .cloned();
+    if let Some(preserved_response) = preserved_response.filter(|response| response.is_object()) {
+        return preserved_response.clone();
+    }
     let mut output_items = Vec::new();
-    if preserved_output.is_none() {
-        if let Some(choice) = openai
-            .get("choices")
-            .and_then(|choices| choices.as_array())
-            .and_then(|choices| choices.first())
-        {
-            if let Some(message) = choice.get("message") {
-                let mut content_blocks = Vec::new();
-                if let Some(content) = message.get("content") {
-                    match content {
-                        serde_json::Value::String(text) if !text.is_empty() => {
-                            content_blocks.push(serde_json::json!({
-                                "type": "output_text",
-                                "text": text
-                            }));
-                        }
-                        serde_json::Value::Array(items) => {
-                            for item in items {
-                                if item.get("type").and_then(|v| v.as_str()) == Some("text") {
-                                    if let Some(text) = item.get("text").and_then(|v| v.as_str()) {
-                                        content_blocks.push(serde_json::json!({
-                                            "type": "output_text",
-                                            "text": text
-                                        }));
-                                    }
+    if let Some(choice) = openai
+        .get("choices")
+        .and_then(|choices| choices.as_array())
+        .and_then(|choices| choices.first())
+    {
+        if let Some(message) = choice.get("message") {
+            let mut content_blocks = Vec::new();
+            if let Some(content) = message.get("content") {
+                match content {
+                    serde_json::Value::String(text) if !text.is_empty() => {
+                        content_blocks.push(serde_json::json!({
+                            "type": "output_text",
+                            "text": text
+                        }));
+                    }
+                    serde_json::Value::Array(items) => {
+                        for item in items {
+                            if item.get("type").and_then(|v| v.as_str()) == Some("text") {
+                                if let Some(text) = item.get("text").and_then(|v| v.as_str()) {
+                                    content_blocks.push(serde_json::json!({
+                                        "type": "output_text",
+                                        "text": text
+                                    }));
                                 }
                             }
                         }
-                        _ => {}
                     }
+                    _ => {}
                 }
+            }
 
-                if let Some(reasoning) = message
-                    .get("reasoning_content")
-                    .and_then(|v| v.as_str())
-                    .filter(|reasoning| !reasoning.is_empty())
-                {
-                    output_items.push(responses_reasoning_item(response_id, reasoning));
-                }
+            if let Some(reasoning) = message
+                .get("reasoning_content")
+                .and_then(|v| v.as_str())
+                .filter(|reasoning| !reasoning.is_empty())
+            {
+                output_items.push(responses_reasoning_item(response_id, reasoning));
+            }
 
-                if let Some(refusal) = message
-                    .get("refusal")
-                    .and_then(|v| v.as_str())
-                    .filter(|refusal| !refusal.is_empty())
-                {
-                    content_blocks.push(serde_json::json!({
-                        "type": "refusal",
-                        "refusal": refusal
-                    }));
-                }
-
-                output_items.push(serde_json::json!({
-                    "id": format!("msg_{}", response_id),
-                    "type": "message",
-                    "role": "assistant",
-                    "content": content_blocks
+            if let Some(refusal) = message
+                .get("refusal")
+                .and_then(|v| v.as_str())
+                .filter(|refusal| !refusal.is_empty())
+            {
+                content_blocks.push(serde_json::json!({
+                    "type": "refusal",
+                    "refusal": refusal
                 }));
+            }
 
-                if let Some(tool_calls) = message.get("tool_calls").and_then(|v| v.as_array()) {
-                    for tool_call in tool_calls {
-                        let call_id = tool_call
-                            .get("id")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("call_unknown");
-                        let name = tool_call
-                            .get("function")
-                            .and_then(|f| f.get("name"))
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("tool");
-                        let arguments = tool_call
-                            .get("function")
-                            .and_then(|f| f.get("arguments"))
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("{}");
+            output_items.push(serde_json::json!({
+                "id": format!("msg_{}", response_id),
+                "type": "message",
+                "role": "assistant",
+                "content": content_blocks
+            }));
 
-                        output_items.push(serde_json::json!({
-                            "id": call_id,
-                            "type": "function_call",
-                            "call_id": call_id,
-                            "name": name,
-                            "arguments": arguments
-                        }));
-                    }
+            if let Some(tool_calls) = message.get("tool_calls").and_then(|v| v.as_array()) {
+                for tool_call in tool_calls {
+                    let call_id = tool_call
+                        .get("id")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("call_unknown");
+                    let name = tool_call
+                        .get("function")
+                        .and_then(|f| f.get("name"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("tool");
+                    let arguments = tool_call
+                        .get("function")
+                        .and_then(|f| f.get("arguments"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("{}");
+
+                    output_items.push(serde_json::json!({
+                        "id": call_id,
+                        "type": "function_call",
+                        "call_id": call_id,
+                        "name": name,
+                        "arguments": arguments
+                    }));
                 }
             }
         }
     }
-    let output_items = preserved_output.unwrap_or(output_items);
 
     let usage = openai
         .get("usage")
@@ -658,6 +657,9 @@ pub(super) fn responses_request_to_openai_chat_request(
         request["max_completion_tokens"] = max_tokens;
     }
     if let Some(reasoning) = body.get("reasoning").filter(|value| !value.is_null()) {
+        let reasoning = reasoning
+            .as_object()
+            .ok_or_else(|| "responses request 'reasoning' must be an object".to_string())?;
         let effort = match reasoning.get("effort").filter(|value| !value.is_null()) {
             Some(effort) => effort.as_str().ok_or_else(|| {
                 "responses request 'reasoning.effort' must be a string".to_string()
@@ -674,6 +676,10 @@ pub(super) fn responses_request_to_openai_chat_request(
 
 async fn convert_openai_json_response_to_responses(response: Response) -> Response {
     let (mut parts, body) = response.into_parts();
+    let preserved_response = parts
+        .extensions
+        .get::<super::TrustedResponsesResponse>()
+        .map(|response| response.0.clone());
     let body_bytes = match to_bytes(body, usize::MAX).await {
         Ok(bytes) => bytes,
         Err(err) => {
@@ -701,7 +707,10 @@ async fn convert_openai_json_response_to_responses(response: Response) -> Respon
                 parts.status = StatusCode::OK;
                 return Response::from_parts(
                     parts,
-                    Body::from(convert_sse_payload_to_responses(&payload)),
+                    Body::from(convert_sse_payload_to_responses(
+                        &payload,
+                        preserved_response.as_ref(),
+                    )),
                 );
             }
             return Response::from_parts(parts, Body::from(body_bytes));
@@ -759,7 +768,8 @@ async fn convert_openai_json_response_to_responses(response: Response) -> Respon
         return Response::from_parts(parts, Body::from(failed.to_string()));
     }
 
-    let responses_json = openai_chat_completion_to_responses_json(&openai_json);
+    let responses_json =
+        openai_chat_completion_to_responses_json(&openai_json, preserved_response.as_ref());
     parts.headers.insert(
         axum::http::header::CONTENT_TYPE,
         axum::http::HeaderValue::from_static("application/json"),
@@ -769,6 +779,10 @@ async fn convert_openai_json_response_to_responses(response: Response) -> Respon
 
 async fn convert_openai_stream_response_to_responses(response: Response) -> Response {
     let (mut parts, body) = response.into_parts();
+    let preserved_response = parts
+        .extensions
+        .get::<super::TrustedResponsesResponse>()
+        .map(|response| response.0.clone());
     let body_bytes = match to_bytes(body, usize::MAX).await {
         Ok(bytes) => bytes,
         Err(err) => {
@@ -828,7 +842,7 @@ async fn convert_openai_stream_response_to_responses(response: Response) -> Resp
         return Response::from_parts(parts, Body::from(output));
     }
 
-    let output = convert_sse_payload_to_responses(&payload);
+    let output = convert_sse_payload_to_responses(&payload, preserved_response.as_ref());
 
     parts.headers.insert(
         axum::http::header::CONTENT_TYPE,
@@ -857,7 +871,10 @@ fn add_reasoning_output_item(output: &mut String, response_id: &str, added: &mut
     *added = true;
 }
 
-fn convert_sse_payload_to_responses(payload: &str) -> String {
+fn convert_sse_payload_to_responses(
+    payload: &str,
+    preserved_response: Option<&serde_json::Value>,
+) -> String {
     #[derive(Default)]
     struct ToolAccum {
         id: String,
@@ -881,9 +898,18 @@ fn convert_sse_payload_to_responses(payload: &str) -> String {
     let mut reasoning_text = String::new();
     let mut response_status = "completed".to_string();
     let mut incomplete_details = None;
-    let mut preserved_output = None;
+    let preserved_response = preserved_response.cloned();
+    let mut preserved_items_added = false;
     let mut tools: std::collections::BTreeMap<usize, ToolAccum> = std::collections::BTreeMap::new();
     let mut usage = map_openai_usage_to_responses_usage(&serde_json::json!({}));
+
+    if let Some(status) = preserved_response
+        .as_ref()
+        .and_then(|response| response.get("status"))
+        .and_then(|status| status.as_str())
+    {
+        response_status = status.to_string();
+    }
 
     for (event_type, data) in parse_sse_frames(payload) {
         if data.trim() == "[DONE]" {
@@ -916,13 +942,6 @@ fn convert_sse_payload_to_responses(payload: &str) -> String {
         {
             incomplete_details = Some(details.clone());
         }
-        if let Some(output) = chunk
-            .get(super::RESPONSES_OUTPUT_PASSTHROUGH_KEY)
-            .and_then(|value| value.as_array())
-        {
-            preserved_output = Some(output.clone());
-        }
-
         // Anthropic message_start metadata fallback
         if event_type.as_deref() == Some("message_start")
             || chunk.get("type").and_then(|v| v.as_str()) == Some("message_start")
@@ -962,6 +981,26 @@ fn convert_sse_payload_to_responses(payload: &str) -> String {
             created_sent = true;
         }
 
+        if !preserved_items_added {
+            if let Some(items) = preserved_response
+                .as_ref()
+                .and_then(|response| response.get("output"))
+                .and_then(|value| value.as_array())
+            {
+                for (output_index, item) in items.iter().enumerate() {
+                    let added = serde_json::json!({
+                        "type": "response.output_item.added",
+                        "output_index": output_index,
+                        "item": item
+                    });
+                    output.push_str("event: response.output_item.added\ndata: ");
+                    output.push_str(&added.to_string());
+                    output.push_str("\n\n");
+                }
+                preserved_items_added = true;
+            }
+        }
+
         if let Some(u) = chunk.get("usage") {
             usage = map_openai_usage_to_responses_usage(u);
         }
@@ -977,18 +1016,20 @@ fn convert_sse_payload_to_responses(payload: &str) -> String {
 
             if let Some(text) = delta.get("content").and_then(|v| v.as_str()) {
                 if !message_item_added {
-                    let added = serde_json::json!({
-                        "type": "response.output_item.added",
-                        "item": {
-                            "id": format!("msg_{}", response_id),
-                            "type": "message",
-                            "role": "assistant",
-                            "content": []
-                        }
-                    });
-                    output.push_str("event: response.output_item.added\ndata: ");
-                    output.push_str(&added.to_string());
-                    output.push_str("\n\n");
+                    if preserved_response.is_none() {
+                        let added = serde_json::json!({
+                            "type": "response.output_item.added",
+                            "item": {
+                                "id": format!("msg_{}", response_id),
+                                "type": "message",
+                                "role": "assistant",
+                                "content": []
+                            }
+                        });
+                        output.push_str("event: response.output_item.added\ndata: ");
+                        output.push_str(&added.to_string());
+                        output.push_str("\n\n");
+                    }
                     message_item_added = true;
                 }
 
@@ -1007,7 +1048,11 @@ fn convert_sse_payload_to_responses(payload: &str) -> String {
                 .and_then(|v| v.as_str())
                 .filter(|reasoning| !reasoning.is_empty())
             {
-                add_reasoning_output_item(&mut output, &response_id, &mut reasoning_item_added);
+                if preserved_response.is_none() {
+                    add_reasoning_output_item(&mut output, &response_id, &mut reasoning_item_added);
+                } else {
+                    reasoning_item_added = true;
+                }
                 reasoning_text.push_str(reasoning);
                 let delta_event = serde_json::json!({
                     "type": "response.reasoning_text.delta",
@@ -1025,18 +1070,20 @@ fn convert_sse_payload_to_responses(payload: &str) -> String {
                 .filter(|refusal| !refusal.is_empty())
             {
                 if !message_item_added {
-                    let added = serde_json::json!({
-                        "type": "response.output_item.added",
-                        "item": {
-                            "id": format!("msg_{}", response_id),
-                            "type": "message",
-                            "role": "assistant",
-                            "content": []
-                        }
-                    });
-                    output.push_str("event: response.output_item.added\ndata: ");
-                    output.push_str(&added.to_string());
-                    output.push_str("\n\n");
+                    if preserved_response.is_none() {
+                        let added = serde_json::json!({
+                            "type": "response.output_item.added",
+                            "item": {
+                                "id": format!("msg_{}", response_id),
+                                "type": "message",
+                                "role": "assistant",
+                                "content": []
+                            }
+                        });
+                        output.push_str("event: response.output_item.added\ndata: ");
+                        output.push_str(&added.to_string());
+                        output.push_str("\n\n");
+                    }
                     message_item_added = true;
                 }
                 refusal_text.push_str(refusal);
@@ -1080,19 +1127,21 @@ fn convert_sse_payload_to_responses(payload: &str) -> String {
                         if entry.name.is_empty() {
                             entry.name = "tool".to_string();
                         }
-                        let added = serde_json::json!({
-                            "type": "response.output_item.added",
-                            "item": {
-                                "id": entry.id,
-                                "type": "function_call",
-                                "call_id": entry.id,
-                                "name": entry.name,
-                                "arguments": entry.arguments
-                            }
-                        });
-                        output.push_str("event: response.output_item.added\ndata: ");
-                        output.push_str(&added.to_string());
-                        output.push_str("\n\n");
+                        if preserved_response.is_none() {
+                            let added = serde_json::json!({
+                                "type": "response.output_item.added",
+                                "item": {
+                                    "id": entry.id,
+                                    "type": "function_call",
+                                    "call_id": entry.id,
+                                    "name": entry.name,
+                                    "arguments": entry.arguments
+                                }
+                            });
+                            output.push_str("event: response.output_item.added\ndata: ");
+                            output.push_str(&added.to_string());
+                            output.push_str("\n\n");
+                        }
                         entry.added = true;
                     }
                 }
@@ -1113,18 +1162,20 @@ fn convert_sse_payload_to_responses(payload: &str) -> String {
                     if let Some(text) = delta.get("text").and_then(|v| v.as_str()) {
                         if !text.is_empty() {
                             if !message_item_added {
-                                let added = serde_json::json!({
-                                    "type": "response.output_item.added",
-                                    "item": {
-                                        "id": format!("msg_{}", response_id),
-                                        "type": "message",
-                                        "role": "assistant",
-                                        "content": []
-                                    }
-                                });
-                                output.push_str("event: response.output_item.added\ndata: ");
-                                output.push_str(&added.to_string());
-                                output.push_str("\n\n");
+                                if preserved_response.is_none() {
+                                    let added = serde_json::json!({
+                                        "type": "response.output_item.added",
+                                        "item": {
+                                            "id": format!("msg_{}", response_id),
+                                            "type": "message",
+                                            "role": "assistant",
+                                            "content": []
+                                        }
+                                    });
+                                    output.push_str("event: response.output_item.added\ndata: ");
+                                    output.push_str(&added.to_string());
+                                    output.push_str("\n\n");
+                                }
                                 message_item_added = true;
                             }
                             message_text.push_str(text);
@@ -1139,11 +1190,15 @@ fn convert_sse_payload_to_responses(payload: &str) -> String {
                     }
                     if let Some(thinking) = delta.get("thinking").and_then(|v| v.as_str()) {
                         if !thinking.is_empty() {
-                            add_reasoning_output_item(
-                                &mut output,
-                                &response_id,
-                                &mut reasoning_item_added,
-                            );
+                            if preserved_response.is_none() {
+                                add_reasoning_output_item(
+                                    &mut output,
+                                    &response_id,
+                                    &mut reasoning_item_added,
+                                );
+                            } else {
+                                reasoning_item_added = true;
+                            }
                             reasoning_text.push_str(thinking);
                             let delta_event = serde_json::json!({
                                 "type": "response.reasoning_text.delta",
@@ -1173,7 +1228,7 @@ fn convert_sse_payload_to_responses(payload: &str) -> String {
 
     let mut output_items = Vec::new();
 
-    if !reasoning_text.is_empty() {
+    if preserved_response.is_none() && !reasoning_text.is_empty() {
         let reasoning_item = responses_reasoning_item(&response_id, &reasoning_text);
         output_items.push(reasoning_item.clone());
         let done = serde_json::json!({
@@ -1185,7 +1240,7 @@ fn convert_sse_payload_to_responses(payload: &str) -> String {
         output.push_str("\n\n");
     }
 
-    if message_item_added {
+    if preserved_response.is_none() && message_item_added {
         let mut message_content = Vec::new();
         if !message_text.is_empty() {
             message_content.push(serde_json::json!({
@@ -1215,7 +1270,7 @@ fn convert_sse_payload_to_responses(payload: &str) -> String {
         output.push_str("\n\n");
     }
 
-    for tool in tools.values() {
+    for tool in tools.values().filter(|_| preserved_response.is_none()) {
         let call_id = if tool.id.is_empty() {
             "call_unknown"
         } else {
@@ -1243,8 +1298,22 @@ fn convert_sse_payload_to_responses(payload: &str) -> String {
         output.push_str("\n\n");
     }
 
-    if let Some(preserved_output) = preserved_output {
-        output_items = preserved_output;
+    if let Some(items) = preserved_response
+        .as_ref()
+        .and_then(|response| response.get("output"))
+        .and_then(|value| value.as_array())
+    {
+        for (output_index, item) in items.iter().enumerate() {
+            let done = serde_json::json!({
+                "type": "response.output_item.done",
+                "output_index": output_index,
+                "item": item
+            });
+            output.push_str("event: response.output_item.done\ndata: ");
+            output.push_str(&done.to_string());
+            output.push_str("\n\n");
+        }
+        output_items = items.clone();
     }
 
     let terminal_type = match response_status.as_str() {
@@ -1254,18 +1323,23 @@ fn convert_sse_payload_to_responses(payload: &str) -> String {
         "cancelled" => "response.cancelled",
         _ => "response.incomplete",
     };
-    let mut terminal_response = serde_json::json!({
-        "id": response_id,
-        "object": "response",
-        "created_at": created_at,
-        "status": response_status,
-        "model": model,
-        "output": output_items,
-        "usage": usage
-    });
-    if let Some(incomplete_details) = incomplete_details {
-        terminal_response["incomplete_details"] = incomplete_details;
-    }
+    let terminal_response = if let Some(preserved_response) = preserved_response {
+        preserved_response
+    } else {
+        let mut terminal_response = serde_json::json!({
+            "id": response_id,
+            "object": "response",
+            "created_at": created_at,
+            "status": response_status,
+            "model": model,
+            "output": output_items,
+            "usage": usage
+        });
+        if let Some(incomplete_details) = incomplete_details {
+            terminal_response["incomplete_details"] = incomplete_details;
+        }
+        terminal_response
+    };
     let terminal = serde_json::json!({
         "type": terminal_type,
         "response": terminal_response
@@ -1282,6 +1356,19 @@ fn convert_sse_payload_to_responses(payload: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn rejects_non_object_responses_reasoning() {
+        let request = serde_json::json!({
+            "model": "auto",
+            "input": "Think",
+            "reasoning": "high"
+        });
+
+        let error = responses_request_to_openai_chat_request(&request).unwrap_err();
+
+        assert_eq!(error, "responses request 'reasoning' must be an object");
+    }
 
     #[test]
     fn chat_refusal_serializes_as_responses_refusal_block() {
@@ -1303,7 +1390,7 @@ mod tests {
             }]
         });
 
-        let response = openai_chat_completion_to_responses_json(&openai);
+        let response = openai_chat_completion_to_responses_json(&openai, None);
 
         assert_eq!(
             response["output"][0]["content"].as_array().unwrap().len(),
@@ -1332,7 +1419,7 @@ mod tests {
             "data: [DONE]\n\n"
         );
 
-        let converted = convert_sse_payload_to_responses(payload);
+        let converted = convert_sse_payload_to_responses(payload, None);
         let terminal = parse_sse_frames(&converted)
             .into_iter()
             .find(|(event, _)| event.as_deref() == Some("response.incomplete"))
@@ -1373,7 +1460,7 @@ mod tests {
                 status
             );
 
-            let converted = convert_sse_payload_to_responses(&payload);
+            let converted = convert_sse_payload_to_responses(&payload, None);
             let frames = parse_sse_frames(&converted);
             let created: serde_json::Value = serde_json::from_str(&frames[0].1).unwrap();
             let terminal = frames

--- a/src/router/responses_api.rs
+++ b/src/router/responses_api.rs
@@ -18,6 +18,7 @@ use tracing::error;
 
 use crate::sse::SseFrameDecoder;
 
+mod content_part_events;
 mod handler;
 mod incremental_stream;
 
@@ -1164,14 +1165,47 @@ mod tests {
         let second_events = converter.push_frame(None, &second.to_string());
         let terminal_events = converter.finish();
 
-        assert!(first_events.contains("response.created"));
-        assert!(first_events.contains("\"delta\":\"first\""));
+        let first_event_types = parse_sse_frames(&first_events)
+            .into_iter()
+            .filter_map(|(_, data)| serde_json::from_str::<serde_json::Value>(&data).ok())
+            .filter_map(|event| event["type"].as_str().map(str::to_string))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            first_event_types,
+            vec![
+                "response.created",
+                "response.output_item.added",
+                "response.content_part.added",
+                "response.output_text.delta"
+            ]
+        );
+        let added_part = parse_sse_frames(&first_events)
+            .into_iter()
+            .filter_map(|(_, data)| serde_json::from_str::<serde_json::Value>(&data).ok())
+            .find(|event| event["type"] == "response.content_part.added")
+            .expect("content part must be announced before its first delta");
+        assert_eq!(
+            added_part["part"],
+            serde_json::json!({"type": "output_text", "text": "", "annotations": []})
+        );
         assert!(!second_events.contains("response.created"));
         assert!(!second_events.contains("\"delta\":\"first\""));
         assert!(second_events.contains("\"delta\":\" second\""));
         assert!(!second_events.contains("response.completed"));
-        assert!(terminal_events.contains("response.output_item.done"));
-        assert!(terminal_events.contains("response.completed"));
+        let terminal_event_types = parse_sse_frames(&terminal_events)
+            .into_iter()
+            .filter_map(|(_, data)| serde_json::from_str::<serde_json::Value>(&data).ok())
+            .filter_map(|event| event["type"].as_str().map(str::to_string))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            terminal_event_types,
+            vec![
+                "response.output_text.done",
+                "response.content_part.done",
+                "response.output_item.done",
+                "response.completed"
+            ]
+        );
     }
 
     #[test]
@@ -1558,7 +1592,11 @@ mod tests {
                 "id": "msg_native",
                 "type": "message",
                 "role": "assistant",
-                "content": [{"type": "output_text", "text": "answer"}]
+                "content": [{
+                    "type": "output_text",
+                    "text": "answer",
+                    "annotations": [{"type": "url_citation", "url": "https://example.com"}]
+                }]
             }]
         });
         let chunks = [
@@ -1612,6 +1650,13 @@ mod tests {
             assert_eq!(event["output_index"], output_index);
             assert_eq!(event["item_id"], item_id);
         }
+        let content_done = events
+            .iter()
+            .find(|event| {
+                event["type"] == "response.content_part.done" && event["output_index"] == 2
+            })
+            .expect("preserved message content should complete its part lifecycle");
+        assert_eq!(content_done["part"], preserved["output"][2]["content"][0]);
     }
 
     #[test]

--- a/src/router/responses_api.rs
+++ b/src/router/responses_api.rs
@@ -18,6 +18,7 @@ mod handler;
 pub use handler::handle_responses;
 
 pub(super) const MAX_RESPONSES_BODY_BYTES: usize = 10 * 1024 * 1024;
+const MAX_RESPONSES_ZSTD_WINDOW_LOG: u32 = 24;
 
 fn parse_sse_frames(payload: &str) -> Vec<(Option<String>, String)> {
     let mut frames = Vec::new();
@@ -65,8 +66,11 @@ pub(super) fn decode_request_body(bytes: &[u8], headers: &HeaderMap) -> Result<V
     }
 
     if content_encoding.contains("zstd") || content_encoding.contains("zst") {
-        let decoder = zstd::stream::read::Decoder::new(std::io::Cursor::new(bytes))
+        let mut decoder = zstd::stream::read::Decoder::new(std::io::Cursor::new(bytes))
             .map_err(|e| format!("Failed to decode zstd request body: {}", e))?;
+        decoder
+            .window_log_max(MAX_RESPONSES_ZSTD_WINDOW_LOG)
+            .map_err(|e| format!("Failed to bound zstd request window: {}", e))?;
         let mut decoded = Vec::new();
         decoder
             .take((MAX_RESPONSES_BODY_BYTES + 1) as u64)
@@ -228,6 +232,17 @@ fn openai_chat_completion_to_responses_json(openai: &serde_json::Value) -> serde
                 .filter(|reasoning| !reasoning.is_empty())
             {
                 output_items.push(responses_reasoning_item(response_id, reasoning));
+            }
+
+            if let Some(refusal) = message
+                .get("refusal")
+                .and_then(|v| v.as_str())
+                .filter(|refusal| !refusal.is_empty())
+            {
+                content_blocks.push(serde_json::json!({
+                    "type": "refusal",
+                    "refusal": refusal
+                }));
             }
 
             output_items.push(serde_json::json!({
@@ -1048,4 +1063,40 @@ fn convert_sse_payload_to_responses(payload: &str) -> String {
     output.push_str("\n\n");
 
     output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chat_refusal_serializes_as_responses_refusal_block() {
+        let openai = serde_json::json!({
+            "id": "resp_refusal",
+            "object": "chat.completion",
+            "created": 42,
+            "model": "muse",
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": null,
+                    "refusal": "I cannot help with that."
+                },
+                "finish_reason": "content_filter"
+            }]
+        });
+
+        let response = openai_chat_completion_to_responses_json(&openai);
+
+        assert_eq!(
+            response["output"][0]["content"].as_array().unwrap().len(),
+            1
+        );
+        assert_eq!(response["output"][0]["content"][0]["type"], "refusal");
+        assert_eq!(
+            response["output"][0]["content"][0]["refusal"],
+            "I cannot help with that."
+        );
+    }
 }

--- a/src/router/responses_api.rs
+++ b/src/router/responses_api.rs
@@ -23,6 +23,7 @@ const MAX_RESPONSES_ZSTD_WINDOW_LOG: u32 = 24;
 #[derive(Debug)]
 pub(super) enum DecodeRequestBodyError {
     PayloadTooLarge(String),
+    UnsupportedEncoding(String),
     Invalid(String),
 }
 
@@ -40,7 +41,9 @@ impl DecodeRequestBodyError {
 impl std::fmt::Display for DecodeRequestBodyError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::PayloadTooLarge(message) | Self::Invalid(message) => formatter.write_str(message),
+            Self::PayloadTooLarge(message)
+            | Self::UnsupportedEncoding(message)
+            | Self::Invalid(message) => formatter.write_str(message),
         }
     }
 }
@@ -130,7 +133,7 @@ pub(super) fn decode_request_body(
         return Ok(decoded);
     }
 
-    Err(DecodeRequestBodyError::Invalid(format!(
+    Err(DecodeRequestBodyError::UnsupportedEncoding(format!(
         "Unsupported content-encoding '{}'",
         content_encoding
     )))
@@ -580,8 +583,13 @@ pub(super) fn responses_request_to_openai_chat_request(
         // without breaking Anthropic-protocol providers.
         request["max_completion_tokens"] = max_tokens;
     }
-    if let Some(reasoning) = body.get("reasoning").cloned() {
-        request["reasoning"] = reasoning;
+    if let Some(reasoning) = body.get("reasoning").filter(|value| !value.is_null()) {
+        let effort = reasoning
+            .get("effort")
+            .and_then(|value| value.as_str())
+            .ok_or_else(|| "responses request 'reasoning.effort' must be a string".to_string())?;
+        request["reasoning_effort"] = serde_json::Value::String(effort.to_string());
+        request[super::RESPONSES_REASONING_PASSTHROUGH_KEY] = reasoning.clone();
     }
     if let Some(previous_response_id) = body.get("previous_response_id").cloned() {
         request["previous_response_id"] = previous_response_id;
@@ -813,8 +821,10 @@ fn convert_sse_payload_to_responses(payload: &str) -> String {
         };
 
         // OpenAI chunk metadata
-        if let Some(id) = chunk.get("id").and_then(|v| v.as_str()) {
-            response_id = id.to_string();
+        if !created_sent {
+            if let Some(id) = chunk.get("id").and_then(|v| v.as_str()) {
+                response_id = id.to_string();
+            }
         }
         if let Some(ts) = chunk.get("created").and_then(|v| v.as_i64()) {
             created_at = ts;
@@ -825,7 +835,10 @@ fn convert_sse_payload_to_responses(payload: &str) -> String {
         if let Some(status) = chunk.get("response_status").and_then(|v| v.as_str()) {
             response_status = status.to_string();
         }
-        if let Some(details) = chunk.get("incomplete_details") {
+        if let Some(details) = chunk
+            .get("incomplete_details")
+            .filter(|value| !value.is_null())
+        {
             incomplete_details = Some(details.clone());
         }
 
@@ -1149,10 +1162,12 @@ fn convert_sse_payload_to_responses(payload: &str) -> String {
         output.push_str("\n\n");
     }
 
-    let terminal_type = if response_status == "incomplete" {
-        "response.incomplete"
-    } else {
-        "response.completed"
+    let terminal_type = match response_status.as_str() {
+        "completed" => "response.completed",
+        "incomplete" => "response.incomplete",
+        "failed" => "response.failed",
+        "cancelled" => "response.cancelled",
+        _ => "response.incomplete",
     };
     let mut terminal_response = serde_json::json!({
         "id": response_id,
@@ -1251,5 +1266,41 @@ mod tests {
                 "refusal": "I cannot help with that."
             })
         );
+    }
+
+    #[test]
+    fn pseudo_stream_keeps_initial_response_id_and_terminal_status() {
+        for (status, terminal_type) in [
+            ("failed", "response.failed"),
+            ("cancelled", "response.cancelled"),
+        ] {
+            let payload = format!(
+                concat!(
+                    "data: {{\"id\":\"resp_original\",\"object\":\"chat.completion.chunk\",",
+                    "\"created\":42,\"model\":\"muse\",\"choices\":[{{\"index\":0,",
+                    "\"delta\":{{\"role\":\"assistant\"}},\"finish_reason\":null}}]}}\n\n",
+                    "data: {{\"id\":\"chatcmpl-stream\",\"object\":\"chat.completion.chunk\",",
+                    "\"created\":42,\"model\":\"muse\",\"response_status\":\"{}\",",
+                    "\"choices\":[{{\"index\":0,\"delta\":{{\"content\":\"done\"}},",
+                    "\"finish_reason\":\"stop\"}}]}}\n\n",
+                    "data: [DONE]\n\n"
+                ),
+                status
+            );
+
+            let converted = convert_sse_payload_to_responses(&payload);
+            let frames = parse_sse_frames(&converted);
+            let created: serde_json::Value = serde_json::from_str(&frames[0].1).unwrap();
+            let terminal = frames
+                .iter()
+                .find(|(event, _)| event.as_deref() == Some(terminal_type))
+                .unwrap();
+            let terminal: serde_json::Value = serde_json::from_str(&terminal.1).unwrap();
+
+            assert_eq!(created["response"]["id"], "resp_original");
+            assert_eq!(terminal["response"]["id"], "resp_original");
+            assert_eq!(terminal["response"]["status"], status);
+            assert_eq!(terminal["response"]["output"][0]["id"], "msg_resp_original");
+        }
     }
 }

--- a/src/router/responses_api.rs
+++ b/src/router/responses_api.rs
@@ -912,6 +912,49 @@ fn response_output_item_identity(
     })
 }
 
+fn unique_response_output_item_identity(
+    response: &serde_json::Value,
+    item_type: &str,
+    content_type: Option<&str>,
+) -> Option<ResponseOutputItemIdentity> {
+    let mut matching_items = response
+        .get("output")?
+        .as_array()?
+        .iter()
+        .enumerate()
+        .filter(|(_, item)| item.get("type").and_then(|value| value.as_str()) == Some(item_type));
+    let (output_index, item) = matching_items.next()?;
+    if matching_items.next().is_some() {
+        return None;
+    }
+    let content_index = if let Some(content_type) = content_type {
+        let mut matching_content = item
+            .get("content")
+            .and_then(|content| content.as_array())
+            .into_iter()
+            .flatten()
+            .enumerate()
+            .filter(|(_, part)| {
+                part.get("type").and_then(|value| value.as_str()) == Some(content_type)
+            });
+        let first = matching_content.next().map(|(index, _)| index).unwrap_or(0);
+        if matching_content.next().is_some() {
+            return None;
+        }
+        Some(first)
+    } else {
+        None
+    };
+    Some(ResponseOutputItemIdentity {
+        output_index,
+        item_id: item
+            .get("id")
+            .and_then(|value| value.as_str())
+            .map(str::to_string),
+        content_index,
+    })
+}
+
 fn append_response_delta(
     output: &mut String,
     event_type: &str,
@@ -1144,7 +1187,11 @@ fn convert_sse_payload_to_responses(
                 let identity = preserved_response
                     .as_ref()
                     .and_then(|response| {
-                        response_output_item_identity(response, "message", 0, Some("output_text"))
+                        unique_response_output_item_identity(
+                            response,
+                            "message",
+                            Some("output_text"),
+                        )
                     })
                     .or_else(|| {
                         message_output_index.map(|output_index| ResponseOutputItemIdentity {
@@ -1176,10 +1223,9 @@ fn convert_sse_payload_to_responses(
                 let identity = preserved_response
                     .as_ref()
                     .and_then(|response| {
-                        response_output_item_identity(
+                        unique_response_output_item_identity(
                             response,
                             "reasoning",
-                            0,
                             Some("reasoning_text"),
                         )
                     })
@@ -1228,7 +1274,7 @@ fn convert_sse_payload_to_responses(
                 let identity = preserved_response
                     .as_ref()
                     .and_then(|response| {
-                        response_output_item_identity(response, "message", 0, Some("refusal"))
+                        unique_response_output_item_identity(response, "message", Some("refusal"))
                     })
                     .or_else(|| {
                         message_output_index.map(|output_index| ResponseOutputItemIdentity {
@@ -1366,10 +1412,9 @@ fn convert_sse_payload_to_responses(
                             let identity = preserved_response
                                 .as_ref()
                                 .and_then(|response| {
-                                    response_output_item_identity(
+                                    unique_response_output_item_identity(
                                         response,
                                         "message",
-                                        0,
                                         Some("output_text"),
                                     )
                                 })
@@ -1407,10 +1452,9 @@ fn convert_sse_payload_to_responses(
                             let identity = preserved_response
                                 .as_ref()
                                 .and_then(|response| {
-                                    response_output_item_identity(
+                                    unique_response_output_item_identity(
                                         response,
                                         "reasoning",
-                                        0,
                                         Some("reasoning_text"),
                                     )
                                 })
@@ -1786,6 +1830,63 @@ mod tests {
                 .unwrap_or_else(|| panic!("missing {event_type}"));
             assert_eq!(event["output_index"], output_index);
             assert_eq!(event["item_id"], item_id);
+        }
+    }
+
+    #[test]
+    fn preserved_pseudo_stream_suppresses_ambiguous_flattened_text_deltas() {
+        let ambiguous_outputs = [
+            serde_json::json!([{
+                "id": "msg_first",
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "first"}]
+            }, {
+                "id": "msg_second",
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "second"}]
+            }]),
+            serde_json::json!([{
+                "id": "msg_multi_content",
+                "type": "message",
+                "role": "assistant",
+                "content": [
+                    {"type": "output_text", "text": "first"},
+                    {"type": "output_text", "text": "second"}
+                ]
+            }]),
+        ];
+        let payload = concat!(
+            "data: {\"id\":\"resp_native\",\"object\":\"chat.completion.chunk\",",
+            "\"created\":42,\"model\":\"muse\",\"choices\":[{\"index\":0,",
+            "\"delta\":{\"content\":\"first\\n\\nsecond\"}}]}\n\n",
+            "data: [DONE]\n\n"
+        );
+
+        for output in ambiguous_outputs {
+            let preserved = serde_json::json!({
+                "id": "resp_native",
+                "object": "response",
+                "created_at": 42,
+                "status": "completed",
+                "model": "muse",
+                "output": output
+            });
+            let converted = convert_sse_payload_to_responses(payload, Some(&preserved));
+            let events = parse_sse_frames(&converted)
+                .into_iter()
+                .filter_map(|(_, data)| serde_json::from_str::<serde_json::Value>(&data).ok())
+                .collect::<Vec<_>>();
+
+            assert!(!events
+                .iter()
+                .any(|event| event["type"] == "response.output_text.delta"));
+            let completed = events
+                .iter()
+                .find(|event| event["type"] == "response.completed")
+                .expect("exact preserved terminal event should remain");
+            assert_eq!(completed["response"], preserved);
         }
     }
 

--- a/src/router/responses_api.rs
+++ b/src/router/responses_api.rs
@@ -6,14 +6,15 @@
 
 use axum::{
     body::{to_bytes, Body},
-    extract::State,
     http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
     Json,
 };
 use tracing::error;
 
-use super::{openai_compat::handle_chat_completions, AppState};
+mod handler;
+
+pub use handler::handle_responses;
 
 fn parse_sse_frames(payload: &str) -> Vec<(Option<String>, String)> {
     let mut frames = Vec::new();
@@ -144,6 +145,17 @@ fn map_openai_usage_to_responses_usage(usage: &serde_json::Value) -> serde_json:
     })
 }
 
+fn responses_reasoning_item(response_id: &str, reasoning: &str) -> serde_json::Value {
+    serde_json::json!({
+        "id": format!("rs_{}", response_id),
+        "type": "reasoning",
+        "summary": [{
+            "type": "summary_text",
+            "text": reasoning
+        }]
+    })
+}
+
 fn openai_chat_completion_to_responses_json(openai: &serde_json::Value) -> serde_json::Value {
     let response_id = openai
         .get("id")
@@ -193,6 +205,14 @@ fn openai_chat_completion_to_responses_json(openai: &serde_json::Value) -> serde
                     }
                     _ => {}
                 }
+            }
+
+            if let Some(reasoning) = message
+                .get("reasoning_content")
+                .and_then(|v| v.as_str())
+                .filter(|reasoning| !reasoning.is_empty())
+            {
+                output_items.push(responses_reasoning_item(response_id, reasoning));
             }
 
             output_items.push(serde_json::json!({
@@ -643,6 +663,25 @@ async fn convert_openai_stream_response_to_responses(response: Response) -> Resp
     Response::from_parts(parts, Body::from(output))
 }
 
+fn add_reasoning_output_item(output: &mut String, response_id: &str, added: &mut bool) {
+    if *added {
+        return;
+    }
+
+    let event = serde_json::json!({
+        "type": "response.output_item.added",
+        "item": {
+            "id": format!("rs_{}", response_id),
+            "type": "reasoning",
+            "summary": []
+        }
+    });
+    output.push_str("event: response.output_item.added\ndata: ");
+    output.push_str(&event.to_string());
+    output.push_str("\n\n");
+    *added = true;
+}
+
 fn convert_sse_payload_to_responses(payload: &str) -> String {
     #[derive(Default)]
     struct ToolAccum {
@@ -660,6 +699,7 @@ fn convert_sse_payload_to_responses(payload: &str) -> String {
         .as_secs() as i64;
     let mut model = "unknown".to_string();
     let mut created_sent = false;
+    let mut reasoning_item_added = false;
     let mut message_item_added = false;
     let mut message_text = String::new();
     let mut reasoning_text = String::new();
@@ -739,27 +779,6 @@ fn convert_sse_payload_to_responses(payload: &str) -> String {
         if let Some(choice) = choice {
             let delta = choice.get("delta").cloned().unwrap_or_default();
 
-            if delta
-                .get("role")
-                .and_then(|v| v.as_str())
-                .is_some_and(|r| r == "assistant")
-                && !message_item_added
-            {
-                let added = serde_json::json!({
-                    "type": "response.output_item.added",
-                    "item": {
-                        "id": format!("msg_{}", response_id),
-                        "type": "message",
-                        "role": "assistant",
-                        "content": []
-                    }
-                });
-                output.push_str("event: response.output_item.added\ndata: ");
-                output.push_str(&added.to_string());
-                output.push_str("\n\n");
-                message_item_added = true;
-            }
-
             if let Some(text) = delta.get("content").and_then(|v| v.as_str()) {
                 if !message_item_added {
                     let added = serde_json::json!({
@@ -787,7 +806,12 @@ fn convert_sse_payload_to_responses(payload: &str) -> String {
                 output.push_str("\n\n");
             }
 
-            if let Some(reasoning) = delta.get("reasoning_content").and_then(|v| v.as_str()) {
+            if let Some(reasoning) = delta
+                .get("reasoning_content")
+                .and_then(|v| v.as_str())
+                .filter(|reasoning| !reasoning.is_empty())
+            {
+                add_reasoning_output_item(&mut output, &response_id, &mut reasoning_item_added);
                 reasoning_text.push_str(reasoning);
                 let delta_event = serde_json::json!({
                     "type": "response.reasoning_text.delta",
@@ -859,25 +883,24 @@ fn convert_sse_payload_to_responses(payload: &str) -> String {
         });
         match event_type.as_deref() {
             Some("content_block_delta") => {
-                if !message_item_added {
-                    let added = serde_json::json!({
-                        "type": "response.output_item.added",
-                        "item": {
-                            "id": format!("msg_{}", response_id),
-                            "type": "message",
-                            "role": "assistant",
-                            "content": []
-                        }
-                    });
-                    output.push_str("event: response.output_item.added\ndata: ");
-                    output.push_str(&added.to_string());
-                    output.push_str("\n\n");
-                    message_item_added = true;
-                }
-
                 if let Some(delta) = chunk.get("delta") {
                     if let Some(text) = delta.get("text").and_then(|v| v.as_str()) {
                         if !text.is_empty() {
+                            if !message_item_added {
+                                let added = serde_json::json!({
+                                    "type": "response.output_item.added",
+                                    "item": {
+                                        "id": format!("msg_{}", response_id),
+                                        "type": "message",
+                                        "role": "assistant",
+                                        "content": []
+                                    }
+                                });
+                                output.push_str("event: response.output_item.added\ndata: ");
+                                output.push_str(&added.to_string());
+                                output.push_str("\n\n");
+                                message_item_added = true;
+                            }
                             message_text.push_str(text);
                             let delta_event = serde_json::json!({
                                 "type": "response.output_text.delta",
@@ -890,6 +913,11 @@ fn convert_sse_payload_to_responses(payload: &str) -> String {
                     }
                     if let Some(thinking) = delta.get("thinking").and_then(|v| v.as_str()) {
                         if !thinking.is_empty() {
+                            add_reasoning_output_item(
+                                &mut output,
+                                &response_id,
+                                &mut reasoning_item_added,
+                            );
                             reasoning_text.push_str(thinking);
                             let delta_event = serde_json::json!({
                                 "type": "response.reasoning_text.delta",
@@ -919,14 +947,20 @@ fn convert_sse_payload_to_responses(payload: &str) -> String {
 
     let mut output_items = Vec::new();
 
+    if !reasoning_text.is_empty() {
+        let reasoning_item = responses_reasoning_item(&response_id, &reasoning_text);
+        output_items.push(reasoning_item.clone());
+        let done = serde_json::json!({
+            "type": "response.output_item.done",
+            "item": reasoning_item
+        });
+        output.push_str("event: response.output_item.done\ndata: ");
+        output.push_str(&done.to_string());
+        output.push_str("\n\n");
+    }
+
     if message_item_added {
         let mut message_content = Vec::new();
-        if !reasoning_text.is_empty() {
-            message_content.push(serde_json::json!({
-                "type": "output_text",
-                "text": reasoning_text
-            }));
-        }
         if !message_text.is_empty() {
             message_content.push(serde_json::json!({
                 "type": "output_text",
@@ -994,85 +1028,4 @@ fn convert_sse_payload_to_responses(payload: &str) -> String {
     output.push_str("\n\n");
 
     output
-}
-
-/// Handle OpenAI Responses API requests.
-pub async fn handle_responses(
-    State(state): State<AppState>,
-    headers: HeaderMap,
-    body: Body,
-) -> Response {
-    let body_bytes = match to_bytes(body, usize::MAX).await {
-        Ok(bytes) => bytes,
-        Err(err) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({
-                    "error": {
-                        "message": format!("Failed to read request body: {}", err)
-                    }
-                })),
-            )
-                .into_response();
-        }
-    };
-
-    let decoded = match decode_request_body(&body_bytes, &headers) {
-        Ok(bytes) => bytes,
-        Err(err) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({
-                    "error": {
-                        "message": err
-                    }
-                })),
-            )
-                .into_response();
-        }
-    };
-
-    let request_body = match parse_json_payload(&decoded) {
-        Ok(v) => v,
-        Err(err) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({
-                    "error": {
-                        "message": err
-                    }
-                })),
-            )
-                .into_response();
-        }
-    };
-
-    let stream_requested = request_body
-        .get("stream")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(true);
-
-    let openai_chat_request = match responses_request_to_openai_chat_request(&request_body) {
-        Ok(request) => request,
-        Err(err) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({
-                    "error": {
-                        "message": err
-                    }
-                })),
-            )
-                .into_response();
-        }
-    };
-
-    let openai_response =
-        handle_chat_completions(State(state), headers, Json(openai_chat_request)).await;
-
-    if stream_requested {
-        convert_openai_stream_response_to_responses(openai_response).await
-    } else {
-        convert_openai_json_response_to_responses(openai_response).await
-    }
 }

--- a/src/router/responses_api.rs
+++ b/src/router/responses_api.rs
@@ -10,8 +10,13 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
+use bytes::Bytes;
+use futures::StreamExt;
 use std::io::Read;
+use tokio_stream::wrappers::ReceiverStream;
 use tracing::error;
+
+use crate::sse::SseFrameDecoder;
 
 mod handler;
 
@@ -795,52 +800,38 @@ async fn convert_openai_stream_response_to_responses(response: Response) -> Resp
         .extensions
         .get::<super::TrustedResponsesResponse>()
         .map(|response| response.0.clone());
-    let body_bytes = match to_bytes(body, usize::MAX).await {
-        Ok(bytes) => bytes,
-        Err(err) => {
-            error!("Failed to read OpenAI stream: {}", err);
-            return (
-                StatusCode::BAD_GATEWAY,
-                Json(serde_json::json!({"error": "Failed to read upstream stream"})),
-            )
-                .into_response();
-        }
-    };
-
-    let payload = String::from_utf8_lossy(&body_bytes);
 
     if parts.status != StatusCode::OK {
-        let mut output = String::new();
-        // Check if this is a rate limit error (429)
-        let is_rate_limit = parts.status == StatusCode::TOO_MANY_REQUESTS;
-        let retry_after = parts
-            .headers
-            .get("retry-after")
-            .and_then(|v| v.to_str().ok())
-            .and_then(|v| v.parse::<u64>().ok());
-
-        let error_text = String::from_utf8_lossy(&body_bytes).to_string();
-
-        let mut error_obj = serde_json::json!({
-            "message": error_text
-        });
-
-        if is_rate_limit {
-            error_obj["code"] = serde_json::Value::String("rate_limited".to_string());
-            if let Some(retry_after_secs) = retry_after {
-                error_obj["retry_after"] = serde_json::json!(retry_after_secs);
-            }
-        } else {
-            error_obj["code"] = serde_json::Value::String("upstream_error".to_string());
+        // Exhausted-tier rate limits are an HTTP contract, not a successful SSE
+        // stream. Preserve the synthesized status, headers, and structured body
+        // so Responses clients can apply their normal retry policy.
+        if parts.status == StatusCode::TOO_MANY_REQUESTS {
+            return Response::from_parts(parts, body);
         }
 
+        let body_bytes = match to_bytes(body, MAX_RESPONSES_BODY_BYTES).await {
+            Ok(bytes) => bytes,
+            Err(err) => {
+                error!("Failed to read OpenAI stream error body: {}", err);
+                return (
+                    StatusCode::BAD_GATEWAY,
+                    Json(serde_json::json!({"error": "Failed to read upstream stream"})),
+                )
+                    .into_response();
+            }
+        };
+        let mut output = String::new();
+        let error_text = String::from_utf8_lossy(&body_bytes).to_string();
         let failed_event = serde_json::json!({
             "type": "response.failed",
             "response": {
                 "id": "resp_failed",
                 "object": "response",
                 "status": "failed",
-                "error": error_obj
+                "error": {
+                    "message": error_text,
+                    "code": "upstream_error"
+                }
             }
         });
         output.push_str("event: response.failed\ndata: ");
@@ -854,14 +845,132 @@ async fn convert_openai_stream_response_to_responses(response: Response) -> Resp
         return Response::from_parts(parts, Body::from(output));
     }
 
-    let output = convert_sse_payload_to_responses(&payload, preserved_response.as_ref());
-
     parts.headers.insert(
         axum::http::header::CONTENT_TYPE,
         axum::http::HeaderValue::from_static("text/event-stream"),
     );
+    parts.headers.insert(
+        axum::http::header::CACHE_CONTROL,
+        axum::http::HeaderValue::from_static("no-cache"),
+    );
+    parts.headers.remove(axum::http::header::CONTENT_LENGTH);
+    parts.headers.remove(axum::http::header::CONTENT_ENCODING);
+    parts.headers.remove(axum::http::header::TRANSFER_ENCODING);
+    parts.headers.remove(axum::http::header::ETAG);
+    parts.headers.remove(axum::http::header::LAST_MODIFIED);
     parts.status = StatusCode::OK;
-    Response::from_parts(parts, Body::from(output))
+
+    let (tx, rx) = tokio::sync::mpsc::channel::<Result<Bytes, std::io::Error>>(100);
+    tokio::spawn(async move {
+        let mut stream = body.into_data_stream();
+        let mut decoder = SseFrameDecoder::new();
+        let mut source = String::new();
+        let mut emitted = String::new();
+        let mut received_bytes = 0_usize;
+        let mut source_done = false;
+
+        while let Some(chunk) = stream.next().await {
+            let bytes = match chunk {
+                Ok(bytes) => bytes,
+                Err(err) => {
+                    error!("Failed to read OpenAI stream chunk: {}", err);
+                    let failed =
+                        responses_stream_adapter_failed_event("Failed to read upstream stream");
+                    let _ = tx.send(Ok(Bytes::from(failed))).await;
+                    return;
+                }
+            };
+            received_bytes = received_bytes.saturating_add(bytes.len());
+            if received_bytes > MAX_RESPONSES_BODY_BYTES {
+                let failed = responses_stream_adapter_failed_event(
+                    "Upstream stream exceeded the Responses adapter limit",
+                );
+                let _ = tx.send(Ok(Bytes::from(failed))).await;
+                return;
+            }
+
+            let frames = decoder.push(&bytes);
+            if frames.is_empty() {
+                continue;
+            }
+            for frame in frames {
+                source_done |= frame.data.trim() == "[DONE]";
+                source.push_str(&frame.to_sse_string());
+            }
+
+            let converted = convert_sse_payload_to_responses(&source, preserved_response.as_ref());
+            let prefix_len = responses_stream_stable_prefix_len(&converted);
+            let stable_prefix = &converted[..prefix_len];
+            let Some(delta) = stable_prefix.strip_prefix(&emitted) else {
+                error!("Responses stream conversion prefix diverged");
+                let failed = responses_stream_adapter_failed_event(
+                    "Responses stream conversion became inconsistent",
+                );
+                let _ = tx.send(Ok(Bytes::from(failed))).await;
+                return;
+            };
+            if !delta.is_empty() {
+                if tx
+                    .send(Ok(Bytes::copy_from_slice(delta.as_bytes())))
+                    .await
+                    .is_err()
+                {
+                    return;
+                }
+                emitted.push_str(delta);
+            }
+            if source_done {
+                break;
+            }
+        }
+
+        let converted = convert_sse_payload_to_responses(&source, preserved_response.as_ref());
+        let Some(tail) = converted.strip_prefix(&emitted) else {
+            error!("Responses stream conversion tail diverged");
+            let failed = responses_stream_adapter_failed_event(
+                "Responses stream conversion became inconsistent",
+            );
+            let _ = tx.send(Ok(Bytes::from(failed))).await;
+            return;
+        };
+        if !tail.is_empty() {
+            let _ = tx.send(Ok(Bytes::copy_from_slice(tail.as_bytes()))).await;
+        }
+    });
+
+    Response::from_parts(parts, Body::from_stream(ReceiverStream::new(rx)))
+}
+
+fn responses_stream_stable_prefix_len(converted: &str) -> usize {
+    [
+        "event: response.output_item.done\n",
+        "event: response.queued\n",
+        "event: response.in_progress\n",
+        "event: response.completed\n",
+        "event: response.incomplete\n",
+        "event: response.failed\n",
+        "event: response.cancelled\n",
+    ]
+    .iter()
+    .filter_map(|marker| converted.find(marker))
+    .min()
+    .unwrap_or(converted.len())
+}
+
+fn responses_stream_adapter_failed_event(message: &str) -> String {
+    let failed = serde_json::json!({
+        "type": "response.failed",
+        "response": {
+            "id": "resp_failed",
+            "object": "response",
+            "status": "failed",
+            "error": {
+                "message": message,
+                "code": "stream_adapter_error"
+            }
+        }
+    });
+    format!("event: response.failed\ndata: {failed}\n\n")
 }
 
 fn initial_responses_output_item(item: &serde_json::Value) -> serde_json::Value {

--- a/src/router/responses_api.rs
+++ b/src/router/responses_api.rs
@@ -10,11 +10,14 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
+use std::io::Read;
 use tracing::error;
 
 mod handler;
 
 pub use handler::handle_responses;
+
+pub(super) const MAX_RESPONSES_BODY_BYTES: usize = 10 * 1024 * 1024;
 
 fn parse_sse_frames(payload: &str) -> Vec<(Option<String>, String)> {
     let mut frames = Vec::new();
@@ -62,8 +65,20 @@ pub(super) fn decode_request_body(bytes: &[u8], headers: &HeaderMap) -> Result<V
     }
 
     if content_encoding.contains("zstd") || content_encoding.contains("zst") {
-        return zstd::stream::decode_all(std::io::Cursor::new(bytes))
-            .map_err(|e| format!("Failed to decode zstd request body: {}", e));
+        let decoder = zstd::stream::read::Decoder::new(std::io::Cursor::new(bytes))
+            .map_err(|e| format!("Failed to decode zstd request body: {}", e))?;
+        let mut decoded = Vec::new();
+        decoder
+            .take((MAX_RESPONSES_BODY_BYTES + 1) as u64)
+            .read_to_end(&mut decoded)
+            .map_err(|e| format!("Failed to decode zstd request body: {}", e))?;
+        if decoded.len() > MAX_RESPONSES_BODY_BYTES {
+            return Err(format!(
+                "Decoded request body exceeds {} bytes",
+                MAX_RESPONSES_BODY_BYTES
+            ));
+        }
+        return Ok(decoded);
     }
 
     Err(format!(
@@ -348,6 +363,14 @@ pub(super) fn responses_request_to_openai_chat_request(
         .and_then(|v| v.as_str())
         .ok_or_else(|| "responses request requires 'model'".to_string())?;
 
+    match body.get("input") {
+        None => {}
+        Some(input) if input.is_string() || input.is_array() => {}
+        Some(_) => {
+            return Err("responses request 'input' must be text or an array".to_string());
+        }
+    }
+
     let mut messages: Vec<serde_json::Value> = Vec::new();
 
     if let Some(instructions) = body.get("instructions").and_then(|v| v.as_str()) {
@@ -460,11 +483,8 @@ pub(super) fn responses_request_to_openai_chat_request(
             }
         }
     }
-    if body
-        .get("input")
-        .is_some_and(|input| !input.is_string() && !input.is_array())
-    {
-        return Err("responses request 'input' must be text or an array".to_string());
+    if messages.is_empty() {
+        return Err("responses request requires 'input' or 'instructions'".to_string());
     }
 
     let mut request = serde_json::json!({

--- a/src/router/responses_api.rs
+++ b/src/router/responses_api.rs
@@ -286,15 +286,22 @@ fn openai_chat_completion_to_responses_json(openai: &serde_json::Value) -> serde
         .map(map_openai_usage_to_responses_usage)
         .unwrap_or_else(|| map_openai_usage_to_responses_usage(&serde_json::json!({})));
 
-    serde_json::json!({
+    let mut response = serde_json::json!({
         "id": response_id,
         "object": "response",
         "created_at": created_at,
-        "status": "completed",
+        "status": openai
+            .get("response_status")
+            .and_then(|value| value.as_str())
+            .unwrap_or("completed"),
         "model": model,
         "output": output_items,
         "usage": usage
-    })
+    });
+    if let Some(incomplete_details) = openai.get("incomplete_details") {
+        response["incomplete_details"] = incomplete_details.clone();
+    }
+    response
 }
 
 fn responses_content_to_openai_content(content: &serde_json::Value) -> serde_json::Value {
@@ -528,6 +535,9 @@ pub(super) fn responses_request_to_openai_chat_request(
         // without breaking Anthropic-protocol providers.
         request["max_completion_tokens"] = max_tokens;
     }
+    if let Some(reasoning) = body.get("reasoning").cloned() {
+        request["reasoning"] = reasoning;
+    }
 
     Ok(request)
 }
@@ -737,7 +747,10 @@ fn convert_sse_payload_to_responses(payload: &str) -> String {
     let mut reasoning_item_added = false;
     let mut message_item_added = false;
     let mut message_text = String::new();
+    let mut refusal_text = String::new();
     let mut reasoning_text = String::new();
+    let mut response_status = "completed".to_string();
+    let mut incomplete_details = None;
     let mut tools: std::collections::BTreeMap<usize, ToolAccum> = std::collections::BTreeMap::new();
     let mut usage = map_openai_usage_to_responses_usage(&serde_json::json!({}));
 
@@ -760,6 +773,12 @@ fn convert_sse_payload_to_responses(payload: &str) -> String {
         }
         if let Some(m) = chunk.get("model").and_then(|v| v.as_str()) {
             model = m.to_string();
+        }
+        if let Some(status) = chunk.get("response_status").and_then(|v| v.as_str()) {
+            response_status = status.to_string();
+        }
+        if let Some(details) = chunk.get("incomplete_details") {
+            incomplete_details = Some(details.clone());
         }
 
         // Anthropic message_start metadata fallback
@@ -854,6 +873,36 @@ fn convert_sse_payload_to_responses(payload: &str) -> String {
                     "content_index": 0
                 });
                 output.push_str("event: response.reasoning_text.delta\ndata: ");
+                output.push_str(&delta_event.to_string());
+                output.push_str("\n\n");
+            }
+
+            if let Some(refusal) = delta
+                .get("refusal")
+                .and_then(|v| v.as_str())
+                .filter(|refusal| !refusal.is_empty())
+            {
+                if !message_item_added {
+                    let added = serde_json::json!({
+                        "type": "response.output_item.added",
+                        "item": {
+                            "id": format!("msg_{}", response_id),
+                            "type": "message",
+                            "role": "assistant",
+                            "content": []
+                        }
+                    });
+                    output.push_str("event: response.output_item.added\ndata: ");
+                    output.push_str(&added.to_string());
+                    output.push_str("\n\n");
+                    message_item_added = true;
+                }
+                refusal_text.push_str(refusal);
+                let delta_event = serde_json::json!({
+                    "type": "response.refusal.delta",
+                    "delta": refusal
+                });
+                output.push_str("event: response.refusal.delta\ndata: ");
                 output.push_str(&delta_event.to_string());
                 output.push_str("\n\n");
             }
@@ -1002,6 +1051,12 @@ fn convert_sse_payload_to_responses(payload: &str) -> String {
                 "text": message_text
             }));
         }
+        if !refusal_text.is_empty() {
+            message_content.push(serde_json::json!({
+                "type": "refusal",
+                "refusal": refusal_text
+            }));
+        }
         let message_item = serde_json::json!({
             "id": format!("msg_{}", response_id),
             "type": "message",
@@ -1046,20 +1101,31 @@ fn convert_sse_payload_to_responses(payload: &str) -> String {
         output.push_str("\n\n");
     }
 
-    let completed = serde_json::json!({
-        "type": "response.completed",
-        "response": {
-            "id": response_id,
-            "object": "response",
-            "created_at": created_at,
-            "status": "completed",
-            "model": model,
-            "output": output_items,
-            "usage": usage
-        }
+    let terminal_type = if response_status == "incomplete" {
+        "response.incomplete"
+    } else {
+        "response.completed"
+    };
+    let mut terminal_response = serde_json::json!({
+        "id": response_id,
+        "object": "response",
+        "created_at": created_at,
+        "status": response_status,
+        "model": model,
+        "output": output_items,
+        "usage": usage
     });
-    output.push_str("event: response.completed\ndata: ");
-    output.push_str(&completed.to_string());
+    if let Some(incomplete_details) = incomplete_details {
+        terminal_response["incomplete_details"] = incomplete_details;
+    }
+    let terminal = serde_json::json!({
+        "type": terminal_type,
+        "response": terminal_response
+    });
+    output.push_str("event: ");
+    output.push_str(terminal_type);
+    output.push_str("\ndata: ");
+    output.push_str(&terminal.to_string());
     output.push_str("\n\n");
 
     output
@@ -1076,6 +1142,8 @@ mod tests {
             "object": "chat.completion",
             "created": 42,
             "model": "muse",
+            "response_status": "incomplete",
+            "incomplete_details": {"reason": "content_filter"},
             "choices": [{
                 "index": 0,
                 "message": {
@@ -1097,6 +1165,43 @@ mod tests {
         assert_eq!(
             response["output"][0]["content"][0]["refusal"],
             "I cannot help with that."
+        );
+        assert_eq!(response["status"], "incomplete");
+        assert_eq!(
+            response["incomplete_details"],
+            serde_json::json!({"reason": "content_filter"})
+        );
+    }
+
+    #[test]
+    fn pseudo_stream_preserves_refusal_and_incomplete_status() {
+        let payload = concat!(
+            "data: {\"id\":\"resp_refusal\",\"object\":\"chat.completion.chunk\",",
+            "\"created\":42,\"model\":\"muse\",\"response_status\":\"incomplete\",",
+            "\"incomplete_details\":{\"reason\":\"content_filter\"},",
+            "\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",",
+            "\"refusal\":\"I cannot help with that.\"},\"finish_reason\":\"content_filter\"}]}\n\n",
+            "data: [DONE]\n\n"
+        );
+
+        let converted = convert_sse_payload_to_responses(payload);
+        let terminal = parse_sse_frames(&converted)
+            .into_iter()
+            .find(|(event, _)| event.as_deref() == Some("response.incomplete"))
+            .expect("incomplete terminal event should be present");
+        let terminal: serde_json::Value = serde_json::from_str(&terminal.1).unwrap();
+
+        assert_eq!(terminal["response"]["status"], "incomplete");
+        assert_eq!(
+            terminal["response"]["incomplete_details"],
+            serde_json::json!({"reason": "content_filter"})
+        );
+        assert_eq!(
+            terminal["response"]["output"][0]["content"][0],
+            serde_json::json!({
+                "type": "refusal",
+                "refusal": "I cannot help with that."
+            })
         );
     }
 }

--- a/src/router/responses_api.rs
+++ b/src/router/responses_api.rs
@@ -937,7 +937,7 @@ fn unique_response_output_item_identity(
             .filter(|(_, part)| {
                 part.get("type").and_then(|value| value.as_str()) == Some(content_type)
             });
-        let first = matching_content.next().map(|(index, _)| index).unwrap_or(0);
+        let first = matching_content.next().map(|(index, _)| index)?;
         if matching_content.next().is_some() {
             return None;
         }
@@ -1888,6 +1888,46 @@ mod tests {
                 .expect("exact preserved terminal event should remain");
             assert_eq!(completed["response"], preserved);
         }
+    }
+
+    #[test]
+    fn preserved_pseudo_stream_suppresses_flattened_reasoning_summaries() {
+        let preserved = serde_json::json!({
+            "id": "resp_native",
+            "object": "response",
+            "created_at": 42,
+            "status": "completed",
+            "model": "muse",
+            "output": [{
+                "id": "rs_summaries",
+                "type": "reasoning",
+                "summary": [
+                    {"type": "summary_text", "text": "first"},
+                    {"type": "summary_text", "text": "second"}
+                ]
+            }]
+        });
+        let payload = concat!(
+            "data: {\"id\":\"resp_native\",\"object\":\"chat.completion.chunk\",",
+            "\"created\":42,\"model\":\"muse\",\"choices\":[{\"index\":0,",
+            "\"delta\":{\"reasoning_content\":\"first\\n\\nsecond\"}}]}\n\n",
+            "data: [DONE]\n\n"
+        );
+
+        let converted = convert_sse_payload_to_responses(payload, Some(&preserved));
+        let events = parse_sse_frames(&converted)
+            .into_iter()
+            .filter_map(|(_, data)| serde_json::from_str::<serde_json::Value>(&data).ok())
+            .collect::<Vec<_>>();
+
+        assert!(!events
+            .iter()
+            .any(|event| event["type"] == "response.reasoning_text.delta"));
+        let completed = events
+            .iter()
+            .find(|event| event["type"] == "response.completed")
+            .expect("exact preserved terminal event should remain");
+        assert_eq!(completed["response"], preserved);
     }
 
     #[test]

--- a/src/router/responses_api.rs
+++ b/src/router/responses_api.rs
@@ -668,7 +668,11 @@ pub(super) fn responses_request_to_openai_chat_request(
         };
         request["reasoning_effort"] = serde_json::Value::String(effort.to_string());
     }
-    if let Some(previous_response_id) = body.get("previous_response_id").cloned() {
+    if let Some(previous_response_id) = body
+        .get("previous_response_id")
+        .filter(|value| !value.is_null())
+        .cloned()
+    {
         request["previous_response_id"] = previous_response_id;
     }
     Ok(request)
@@ -852,13 +856,38 @@ async fn convert_openai_stream_response_to_responses(response: Response) -> Resp
     Response::from_parts(parts, Body::from(output))
 }
 
-fn add_reasoning_output_item(output: &mut String, response_id: &str, added: &mut bool) {
+fn initial_responses_output_item(item: &serde_json::Value) -> serde_json::Value {
+    let mut initial = item.clone();
+    match item.get("type").and_then(|value| value.as_str()) {
+        Some("message") => initial["content"] = serde_json::json!([]),
+        Some("reasoning") => {
+            initial["summary"] = serde_json::json!([]);
+            if initial.get("content").is_some() {
+                initial["content"] = serde_json::json!([]);
+            }
+        }
+        Some("function_call") => initial["arguments"] = serde_json::json!(""),
+        _ => {}
+    }
+    initial
+}
+
+fn add_reasoning_output_item(
+    output: &mut String,
+    response_id: &str,
+    added: &mut bool,
+    output_index: &mut Option<usize>,
+    next_output_index: &mut usize,
+) {
     if *added {
         return;
     }
 
+    let index = *next_output_index;
+    *next_output_index += 1;
     let event = serde_json::json!({
         "type": "response.output_item.added",
+        "output_index": index,
         "item": {
             "id": format!("rs_{}", response_id),
             "type": "reasoning",
@@ -869,6 +898,7 @@ fn add_reasoning_output_item(output: &mut String, response_id: &str, added: &mut
     output.push_str(&event.to_string());
     output.push_str("\n\n");
     *added = true;
+    *output_index = Some(index);
 }
 
 fn convert_sse_payload_to_responses(
@@ -881,6 +911,7 @@ fn convert_sse_payload_to_responses(
         name: String,
         arguments: String,
         added: bool,
+        output_index: Option<usize>,
     }
 
     let mut output = String::new();
@@ -892,7 +923,10 @@ fn convert_sse_payload_to_responses(
     let mut model = "unknown".to_string();
     let mut created_sent = false;
     let mut reasoning_item_added = false;
+    let mut reasoning_output_index = None;
     let mut message_item_added = false;
+    let mut message_output_index = None;
+    let mut next_output_index = 0;
     let mut message_text = String::new();
     let mut refusal_text = String::new();
     let mut reasoning_text = String::new();
@@ -991,7 +1025,7 @@ fn convert_sse_payload_to_responses(
                     let added = serde_json::json!({
                         "type": "response.output_item.added",
                         "output_index": output_index,
-                        "item": item
+                        "item": initial_responses_output_item(item)
                     });
                     output.push_str("event: response.output_item.added\ndata: ");
                     output.push_str(&added.to_string());
@@ -1017,8 +1051,11 @@ fn convert_sse_payload_to_responses(
             if let Some(text) = delta.get("content").and_then(|v| v.as_str()) {
                 if !message_item_added {
                     if preserved_response.is_none() {
+                        let output_index = next_output_index;
+                        next_output_index += 1;
                         let added = serde_json::json!({
                             "type": "response.output_item.added",
+                            "output_index": output_index,
                             "item": {
                                 "id": format!("msg_{}", response_id),
                                 "type": "message",
@@ -1029,6 +1066,7 @@ fn convert_sse_payload_to_responses(
                         output.push_str("event: response.output_item.added\ndata: ");
                         output.push_str(&added.to_string());
                         output.push_str("\n\n");
+                        message_output_index = Some(output_index);
                     }
                     message_item_added = true;
                 }
@@ -1049,7 +1087,13 @@ fn convert_sse_payload_to_responses(
                 .filter(|reasoning| !reasoning.is_empty())
             {
                 if preserved_response.is_none() {
-                    add_reasoning_output_item(&mut output, &response_id, &mut reasoning_item_added);
+                    add_reasoning_output_item(
+                        &mut output,
+                        &response_id,
+                        &mut reasoning_item_added,
+                        &mut reasoning_output_index,
+                        &mut next_output_index,
+                    );
                 } else {
                     reasoning_item_added = true;
                 }
@@ -1071,8 +1115,11 @@ fn convert_sse_payload_to_responses(
             {
                 if !message_item_added {
                     if preserved_response.is_none() {
+                        let output_index = next_output_index;
+                        next_output_index += 1;
                         let added = serde_json::json!({
                             "type": "response.output_item.added",
+                            "output_index": output_index,
                             "item": {
                                 "id": format!("msg_{}", response_id),
                                 "type": "message",
@@ -1083,6 +1130,7 @@ fn convert_sse_payload_to_responses(
                         output.push_str("event: response.output_item.added\ndata: ");
                         output.push_str(&added.to_string());
                         output.push_str("\n\n");
+                        message_output_index = Some(output_index);
                     }
                     message_item_added = true;
                 }
@@ -1128,8 +1176,11 @@ fn convert_sse_payload_to_responses(
                             entry.name = "tool".to_string();
                         }
                         if preserved_response.is_none() {
+                            let output_index = next_output_index;
+                            next_output_index += 1;
                             let added = serde_json::json!({
                                 "type": "response.output_item.added",
+                                "output_index": output_index,
                                 "item": {
                                     "id": entry.id,
                                     "type": "function_call",
@@ -1141,6 +1192,7 @@ fn convert_sse_payload_to_responses(
                             output.push_str("event: response.output_item.added\ndata: ");
                             output.push_str(&added.to_string());
                             output.push_str("\n\n");
+                            entry.output_index = Some(output_index);
                         }
                         entry.added = true;
                     }
@@ -1163,8 +1215,11 @@ fn convert_sse_payload_to_responses(
                         if !text.is_empty() {
                             if !message_item_added {
                                 if preserved_response.is_none() {
+                                    let output_index = next_output_index;
+                                    next_output_index += 1;
                                     let added = serde_json::json!({
                                         "type": "response.output_item.added",
+                                        "output_index": output_index,
                                         "item": {
                                             "id": format!("msg_{}", response_id),
                                             "type": "message",
@@ -1175,6 +1230,7 @@ fn convert_sse_payload_to_responses(
                                     output.push_str("event: response.output_item.added\ndata: ");
                                     output.push_str(&added.to_string());
                                     output.push_str("\n\n");
+                                    message_output_index = Some(output_index);
                                 }
                                 message_item_added = true;
                             }
@@ -1195,6 +1251,8 @@ fn convert_sse_payload_to_responses(
                                     &mut output,
                                     &response_id,
                                     &mut reasoning_item_added,
+                                    &mut reasoning_output_index,
+                                    &mut next_output_index,
                                 );
                             } else {
                                 reasoning_item_added = true;
@@ -1226,13 +1284,16 @@ fn convert_sse_payload_to_responses(
         }
     }
 
-    let mut output_items = Vec::new();
+    let mut indexed_output_items = Vec::new();
 
     if preserved_response.is_none() && !reasoning_text.is_empty() {
         let reasoning_item = responses_reasoning_item(&response_id, &reasoning_text);
-        output_items.push(reasoning_item.clone());
+        let output_index =
+            reasoning_output_index.expect("generated reasoning output must have an added event");
+        indexed_output_items.push((output_index, reasoning_item.clone()));
         let done = serde_json::json!({
             "type": "response.output_item.done",
+            "output_index": output_index,
             "item": reasoning_item
         });
         output.push_str("event: response.output_item.done\ndata: ");
@@ -1260,9 +1321,12 @@ fn convert_sse_payload_to_responses(
             "role": "assistant",
             "content": message_content
         });
-        output_items.push(message_item.clone());
+        let output_index =
+            message_output_index.expect("generated message output must have an added event");
+        indexed_output_items.push((output_index, message_item.clone()));
         let done = serde_json::json!({
             "type": "response.output_item.done",
+            "output_index": output_index,
             "item": message_item
         });
         output.push_str("event: response.output_item.done\ndata: ");
@@ -1288,15 +1352,43 @@ fn convert_sse_payload_to_responses(
             "name": name,
             "arguments": tool.arguments
         });
-        output_items.push(item.clone());
+        let output_index = if let Some(output_index) = tool.output_index {
+            output_index
+        } else {
+            let output_index = next_output_index;
+            next_output_index += 1;
+            let added = serde_json::json!({
+                "type": "response.output_item.added",
+                "output_index": output_index,
+                "item": {
+                    "id": call_id,
+                    "type": "function_call",
+                    "call_id": call_id,
+                    "name": name,
+                    "arguments": ""
+                }
+            });
+            output.push_str("event: response.output_item.added\ndata: ");
+            output.push_str(&added.to_string());
+            output.push_str("\n\n");
+            output_index
+        };
+        indexed_output_items.push((output_index, item.clone()));
         let done = serde_json::json!({
             "type": "response.output_item.done",
+            "output_index": output_index,
             "item": item
         });
         output.push_str("event: response.output_item.done\ndata: ");
         output.push_str(&done.to_string());
         output.push_str("\n\n");
     }
+
+    indexed_output_items.sort_by_key(|(output_index, _)| *output_index);
+    let mut output_items = indexed_output_items
+        .into_iter()
+        .map(|(_, item)| item)
+        .collect::<Vec<_>>();
 
     if let Some(items) = preserved_response
         .as_ref()
@@ -1317,6 +1409,8 @@ fn convert_sse_payload_to_responses(
     }
 
     let terminal_type = match response_status.as_str() {
+        "queued" => "response.queued",
+        "in_progress" => "response.in_progress",
         "completed" => "response.completed",
         "incomplete" => "response.incomplete",
         "failed" => "response.failed",
@@ -1368,6 +1462,19 @@ mod tests {
         let error = responses_request_to_openai_chat_request(&request).unwrap_err();
 
         assert_eq!(error, "responses request 'reasoning' must be an object");
+    }
+
+    #[test]
+    fn drops_null_previous_response_id() {
+        let request = serde_json::json!({
+            "model": "auto",
+            "input": "Continue",
+            "previous_response_id": null
+        });
+
+        let converted = responses_request_to_openai_chat_request(&request).unwrap();
+
+        assert!(converted.get("previous_response_id").is_none());
     }
 
     #[test]

--- a/src/router/responses_api/content_part_events.rs
+++ b/src/router/responses_api/content_part_events.rs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use super::ResponseOutputItemIdentity;
+
+fn append_event(output: &mut String, event_type: &str, event: serde_json::Value) {
+    output.push_str("event: ");
+    output.push_str(event_type);
+    output.push_str("\ndata: ");
+    output.push_str(&event.to_string());
+    output.push_str("\n\n");
+}
+
+fn event_with_identity(
+    event_type: &str,
+    identity: &ResponseOutputItemIdentity,
+) -> Option<serde_json::Value> {
+    let content_index = identity.content_index?;
+    let mut event = serde_json::json!({
+        "type": event_type,
+        "output_index": identity.output_index,
+        "content_index": content_index
+    });
+    if let Some(item_id) = &identity.item_id {
+        event["item_id"] = serde_json::Value::String(item_id.clone());
+    }
+    Some(event)
+}
+
+fn content_part(content_type: &str, content: &str) -> serde_json::Value {
+    match content_type {
+        "refusal" => serde_json::json!({"type": "refusal", "refusal": content}),
+        _ => serde_json::json!({
+            "type": "output_text",
+            "text": content,
+            "annotations": []
+        }),
+    }
+}
+
+pub(super) fn append_content_part_added(
+    output: &mut String,
+    identity: &ResponseOutputItemIdentity,
+    content_type: &str,
+) {
+    let Some(mut event) = event_with_identity("response.content_part.added", identity) else {
+        return;
+    };
+    event["part"] = content_part(content_type, "");
+    append_event(output, "response.content_part.added", event);
+}
+
+pub(super) fn append_content_part_done(
+    output: &mut String,
+    identity: &ResponseOutputItemIdentity,
+    content_type: &str,
+    content: &str,
+    preserved_part: Option<&serde_json::Value>,
+) {
+    let (delta_done_type, value_key) = match content_type {
+        "refusal" => ("response.refusal.done", "refusal"),
+        _ => ("response.output_text.done", "text"),
+    };
+    let completed_content = preserved_part
+        .and_then(|part| part.get(value_key))
+        .and_then(|value| value.as_str())
+        .unwrap_or(content);
+    if let Some(mut event) = event_with_identity(delta_done_type, identity) {
+        event[value_key] = serde_json::Value::String(completed_content.to_string());
+        append_event(output, delta_done_type, event);
+    }
+
+    if let Some(mut event) = event_with_identity("response.content_part.done", identity) {
+        event["part"] = preserved_part
+            .cloned()
+            .unwrap_or_else(|| content_part(content_type, completed_content));
+        append_event(output, "response.content_part.done", event);
+    }
+}

--- a/src/router/responses_api/handler.rs
+++ b/src/router/responses_api/handler.rs
@@ -11,6 +11,7 @@ use axum::{
 use super::{
     convert_openai_json_response_to_responses, convert_openai_stream_response_to_responses,
     decode_request_body, parse_json_payload, responses_request_to_openai_chat_request,
+    MAX_RESPONSES_BODY_BYTES,
 };
 use crate::router::{openai_compat::handle_chat_completions, AppState};
 
@@ -20,7 +21,7 @@ pub async fn handle_responses(
     headers: HeaderMap,
     body: Body,
 ) -> Response {
-    let body_bytes = match to_bytes(body, usize::MAX).await {
+    let body_bytes = match to_bytes(body, MAX_RESPONSES_BODY_BYTES).await {
         Ok(bytes) => bytes,
         Err(err) => {
             return (
@@ -80,5 +81,46 @@ pub async fn handle_responses(
         convert_openai_stream_response_to_responses(openai_response).await
     } else {
         convert_openai_json_response_to_responses(openai_response).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn responses_requests_require_valid_input_or_instructions() {
+        let missing = responses_request_to_openai_chat_request(&json!({"model": "test"}));
+        assert_eq!(
+            missing.unwrap_err(),
+            "responses request requires 'input' or 'instructions'"
+        );
+
+        let invalid = responses_request_to_openai_chat_request(&json!({
+            "model": "test",
+            "input": {"unexpected": true}
+        }));
+        assert_eq!(
+            invalid.unwrap_err(),
+            "responses request 'input' must be text or an array"
+        );
+    }
+
+    #[test]
+    fn zstd_request_decompression_is_bounded() {
+        let encoded = zstd::stream::encode_all(
+            std::io::Cursor::new(vec![0_u8; MAX_RESPONSES_BODY_BYTES + 1]),
+            1,
+        )
+        .unwrap();
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            axum::http::header::CONTENT_ENCODING,
+            axum::http::HeaderValue::from_static("zstd"),
+        );
+
+        let error = decode_request_body(&encoded, &headers).unwrap_err();
+        assert!(error.contains("exceeds"));
     }
 }

--- a/src/router/responses_api/handler.rs
+++ b/src/router/responses_api/handler.rs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use axum::{
+    body::{to_bytes, Body},
+    extract::State,
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+    Json,
+};
+
+use super::{
+    convert_openai_json_response_to_responses, convert_openai_stream_response_to_responses,
+    decode_request_body, parse_json_payload, responses_request_to_openai_chat_request,
+};
+use crate::router::{openai_compat::handle_chat_completions, AppState};
+
+/// Handle OpenAI Responses API requests.
+pub async fn handle_responses(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    body: Body,
+) -> Response {
+    let body_bytes = match to_bytes(body, usize::MAX).await {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "error": {
+                        "message": format!("Failed to read request body: {}", err)
+                    }
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    let decoded = match decode_request_body(&body_bytes, &headers) {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": {"message": err}})),
+            )
+                .into_response();
+        }
+    };
+
+    let request_body = match parse_json_payload(&decoded) {
+        Ok(value) => value,
+        Err(err) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": {"message": err}})),
+            )
+                .into_response();
+        }
+    };
+
+    let stream_requested = request_body
+        .get("stream")
+        .and_then(|value| value.as_bool())
+        .unwrap_or(true);
+
+    let openai_chat_request = match responses_request_to_openai_chat_request(&request_body) {
+        Ok(request) => request,
+        Err(err) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": {"message": err}})),
+            )
+                .into_response();
+        }
+    };
+
+    let openai_response =
+        handle_chat_completions(State(state), headers, Json(openai_chat_request)).await;
+
+    if stream_requested {
+        convert_openai_stream_response_to_responses(openai_response).await
+    } else {
+        convert_openai_json_response_to_responses(openai_response).await
+    }
+}

--- a/src/router/responses_api/handler.rs
+++ b/src/router/responses_api/handler.rs
@@ -15,6 +15,17 @@ use super::{
 };
 use crate::router::{openai_compat::handle_chat_completions, AppState};
 
+fn body_read_error_status(error: &(dyn std::error::Error + 'static)) -> StatusCode {
+    if error
+        .source()
+        .is_some_and(|source| source.is::<http_body_util::LengthLimitError>())
+    {
+        StatusCode::PAYLOAD_TOO_LARGE
+    } else {
+        StatusCode::BAD_REQUEST
+    }
+}
+
 /// Handle OpenAI Responses API requests.
 pub async fn handle_responses(
     State(state): State<AppState>,
@@ -24,8 +35,9 @@ pub async fn handle_responses(
     let body_bytes = match to_bytes(body, MAX_RESPONSES_BODY_BYTES).await {
         Ok(bytes) => bytes,
         Err(err) => {
+            let status = body_read_error_status(&err);
             return (
-                StatusCode::BAD_REQUEST,
+                status,
                 Json(serde_json::json!({
                     "error": {
                         "message": format!("Failed to read request body: {}", err)
@@ -122,5 +134,44 @@ mod tests {
 
         let error = decode_request_body(&encoded, &headers).unwrap_err();
         assert!(error.contains("exceeds"));
+    }
+
+    #[test]
+    fn zstd_request_rejects_frames_above_window_limit() {
+        let mut encoder = zstd::stream::Encoder::new(Vec::new(), 1).unwrap();
+        encoder.include_contentsize(false).unwrap();
+        encoder.long_distance_matching(true).unwrap();
+        encoder
+            .window_log(super::super::MAX_RESPONSES_ZSTD_WINDOW_LOG + 1)
+            .unwrap();
+        std::io::Write::write_all(&mut encoder, b"small request").unwrap();
+        let encoded = encoder.finish().unwrap();
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            axum::http::header::CONTENT_ENCODING,
+            axum::http::HeaderValue::from_static("zstd"),
+        );
+
+        let error = decode_request_body(&encoded, &headers).unwrap_err();
+
+        assert!(
+            error.contains("requires too much memory"),
+            "unexpected zstd error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn oversized_request_body_maps_to_payload_too_large() {
+        let error = to_bytes(
+            Body::from(vec![0_u8; MAX_RESPONSES_BODY_BYTES + 1]),
+            MAX_RESPONSES_BODY_BYTES,
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(
+            body_read_error_status(&error),
+            StatusCode::PAYLOAD_TOO_LARGE
+        );
     }
 }

--- a/src/router/responses_api/handler.rs
+++ b/src/router/responses_api/handler.rs
@@ -117,6 +117,17 @@ mod tests {
             invalid.unwrap_err(),
             "responses request 'input' must be text or an array"
         );
+
+        let reasoning = responses_request_to_openai_chat_request(&json!({
+            "model": "test",
+            "input": "think carefully",
+            "reasoning": {"effort": "high", "summary": "detailed"}
+        }))
+        .unwrap();
+        assert_eq!(
+            reasoning["reasoning"],
+            json!({"effort": "high", "summary": "detailed"})
+        );
     }
 
     #[test]

--- a/src/router/responses_api/handler.rs
+++ b/src/router/responses_api/handler.rs
@@ -11,7 +11,7 @@ use axum::{
 use super::{
     convert_openai_json_response_to_responses, convert_openai_stream_response_to_responses,
     decode_request_body, parse_json_payload, responses_request_to_openai_chat_request,
-    MAX_RESPONSES_BODY_BYTES,
+    DecodeRequestBodyError, MAX_RESPONSES_BODY_BYTES,
 };
 use crate::router::{openai_compat::handle_chat_completions, AppState};
 
@@ -20,6 +20,14 @@ fn body_read_error_status(error: &(dyn std::error::Error + 'static)) -> StatusCo
         .source()
         .is_some_and(|source| source.is::<http_body_util::LengthLimitError>())
     {
+        StatusCode::PAYLOAD_TOO_LARGE
+    } else {
+        StatusCode::BAD_REQUEST
+    }
+}
+
+fn decode_error_status(error: &DecodeRequestBodyError) -> StatusCode {
+    if error.is_payload_too_large() {
         StatusCode::PAYLOAD_TOO_LARGE
     } else {
         StatusCode::BAD_REQUEST
@@ -52,8 +60,8 @@ pub async fn handle_responses(
         Ok(bytes) => bytes,
         Err(err) => {
             return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({"error": {"message": err}})),
+                decode_error_status(&err),
+                Json(serde_json::json!({"error": {"message": err.to_string()}})),
             )
                 .into_response();
         }
@@ -145,6 +153,7 @@ mod tests {
 
         let error = decode_request_body(&encoded, &headers).unwrap_err();
         assert!(error.contains("exceeds"));
+        assert_eq!(decode_error_status(&error), StatusCode::PAYLOAD_TOO_LARGE);
     }
 
     #[test]

--- a/src/router/responses_api/handler.rs
+++ b/src/router/responses_api/handler.rs
@@ -29,6 +29,8 @@ fn body_read_error_status(error: &(dyn std::error::Error + 'static)) -> StatusCo
 fn decode_error_status(error: &DecodeRequestBodyError) -> StatusCode {
     if error.is_payload_too_large() {
         StatusCode::PAYLOAD_TOO_LARGE
+    } else if matches!(error, DecodeRequestBodyError::UnsupportedEncoding(_)) {
+        StatusCode::UNSUPPORTED_MEDIA_TYPE
     } else {
         StatusCode::BAD_REQUEST
     }
@@ -132,9 +134,21 @@ mod tests {
             "reasoning": {"effort": "high", "summary": "detailed"}
         }))
         .unwrap();
+        assert_eq!(reasoning["reasoning_effort"], "high");
+        assert!(reasoning.get("reasoning").is_none());
         assert_eq!(
-            reasoning["reasoning"],
+            reasoning[super::super::super::RESPONSES_REASONING_PASSTHROUGH_KEY],
             json!({"effort": "high", "summary": "detailed"})
+        );
+
+        let invalid_reasoning = responses_request_to_openai_chat_request(&json!({
+            "model": "test",
+            "input": "think carefully",
+            "reasoning": {"effort": 7}
+        }));
+        assert_eq!(
+            invalid_reasoning.unwrap_err(),
+            "responses request 'reasoning.effort' must be a string"
         );
     }
 
@@ -177,6 +191,22 @@ mod tests {
         assert!(
             error.contains("requires too much memory"),
             "unexpected zstd error: {error}"
+        );
+    }
+
+    #[test]
+    fn unsupported_content_encoding_maps_to_unsupported_media_type() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            axum::http::header::CONTENT_ENCODING,
+            axum::http::HeaderValue::from_static("gzip"),
+        );
+
+        let error = decode_request_body(b"{}", &headers).unwrap_err();
+
+        assert_eq!(
+            decode_error_status(&error),
+            StatusCode::UNSUPPORTED_MEDIA_TYPE
         );
     }
 

--- a/src/router/responses_api/handler.rs
+++ b/src/router/responses_api/handler.rs
@@ -13,7 +13,7 @@ use super::{
     decode_request_body, parse_json_payload, responses_request_to_openai_chat_request,
     DecodeRequestBodyError, MAX_RESPONSES_BODY_BYTES,
 };
-use crate::router::{openai_compat::handle_chat_completions, AppState};
+use crate::router::{openai_compat::handle_responses_chat_completions, AppState};
 
 fn body_read_error_status(error: &(dyn std::error::Error + 'static)) -> StatusCode {
     if error
@@ -96,8 +96,13 @@ pub async fn handle_responses(
         }
     };
 
-    let openai_response =
-        handle_chat_completions(State(state), headers, Json(openai_chat_request)).await;
+    let openai_response = handle_responses_chat_completions(
+        State(state),
+        headers,
+        Json(openai_chat_request),
+        request_body,
+    )
+    .await;
 
     if stream_requested {
         convert_openai_stream_response_to_responses(openai_response).await
@@ -136,10 +141,13 @@ mod tests {
         .unwrap();
         assert_eq!(reasoning["reasoning_effort"], "high");
         assert!(reasoning.get("reasoning").is_none());
-        assert_eq!(
-            reasoning[super::super::super::RESPONSES_REASONING_PASSTHROUGH_KEY],
-            json!({"effort": "high", "summary": "detailed"})
-        );
+        let default_reasoning = responses_request_to_openai_chat_request(&json!({
+            "model": "test",
+            "input": "think carefully",
+            "reasoning": {"summary": "auto"}
+        }))
+        .unwrap();
+        assert_eq!(default_reasoning["reasoning_effort"], "medium");
 
         let invalid_reasoning = responses_request_to_openai_chat_request(&json!({
             "model": "test",
@@ -149,6 +157,47 @@ mod tests {
         assert_eq!(
             invalid_reasoning.unwrap_err(),
             "responses request 'reasoning.effort' must be a string"
+        );
+
+        for invalid_tools in [json!(null), json!({}), json!([null]), json!(["tool"])] {
+            let invalid = responses_request_to_openai_chat_request(&json!({
+                "model": "test",
+                "input": "use tools",
+                "tools": invalid_tools
+            }));
+            assert!(invalid.is_err());
+        }
+
+        for invalid_choice in [json!(""), json!(7), json!({}), json!({"type": ""})] {
+            let invalid = responses_request_to_openai_chat_request(&json!({
+                "model": "test",
+                "input": "use tools",
+                "tool_choice": invalid_choice
+            }));
+            assert_eq!(
+                invalid.unwrap_err(),
+                "responses request 'tool_choice' must be a non-empty string or typed object"
+            );
+        }
+
+        let invalid_function_tool = responses_request_to_openai_chat_request(&json!({
+            "model": "test",
+            "input": "use tools",
+            "tools": [{"type": "function", "name": ""}]
+        }));
+        assert_eq!(
+            invalid_function_tool.unwrap_err(),
+            "responses function tools require a non-empty string 'name'"
+        );
+
+        let invalid_function_choice = responses_request_to_openai_chat_request(&json!({
+            "model": "test",
+            "input": "use tools",
+            "tool_choice": {"type": "function"}
+        }));
+        assert_eq!(
+            invalid_function_choice.unwrap_err(),
+            "responses function tool choices require a non-empty string 'name'"
         );
     }
 

--- a/src/router/responses_api/incremental_stream.rs
+++ b/src/router/responses_api/incremental_stream.rs
@@ -139,10 +139,14 @@ impl ResponsesStreamConverter {
         self.ensure_created(&mut output);
         self.ensure_preserved_items(&mut output);
 
+        if let Some(usage) = chunk.get("usage").filter(|usage| {
+            !usage.is_null()
+                && (usage.get("prompt_tokens").is_some()
+                    || usage.get("completion_tokens").is_some())
+        }) {
+            self.usage = map_openai_usage_to_responses_usage(usage);
+        }
         if let Some(choices) = chunk.get("choices").and_then(|value| value.as_array()) {
-            if let Some(usage) = chunk.get("usage").filter(|value| !value.is_null()) {
-                self.usage = map_openai_usage_to_responses_usage(usage);
-            }
             if let Some(choice) = choices.first() {
                 self.push_openai_choice(choice, &mut output);
             }
@@ -194,6 +198,7 @@ impl ResponsesStreamConverter {
                 output.push_str(&added.to_string());
                 output.push_str("\n\n");
             }
+            self.next_output_index = self.next_output_index.max(items.len());
             self.preserved_items_added = true;
         }
     }
@@ -740,4 +745,29 @@ fn append_output_item_done(output: &mut String, output_index: usize, item: &serd
     output.push_str("event: response.output_item.done\ndata: ");
     output.push_str(&done.to_string());
     output.push_str("\n\n");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preserved_items_reserve_their_output_indices() {
+        let preserved = serde_json::json!({
+            "id": "resp_preserved",
+            "output": [
+                {"id": "item_0", "type": "reasoning", "summary": []},
+                {"id": "item_1", "type": "message", "role": "assistant", "content": []}
+            ]
+        });
+        let mut converter = ResponsesStreamConverter::new(Some(preserved));
+        let frame = serde_json::json!({
+            "id": "resp_preserved",
+            "choices": []
+        });
+
+        converter.push_frame(None, &frame.to_string());
+
+        assert_eq!(converter.next_output_index, 2);
+    }
 }

--- a/src/router/responses_api/incremental_stream.rs
+++ b/src/router/responses_api/incremental_stream.rs
@@ -122,8 +122,10 @@ impl ResponsesStreamConverter {
             || chunk.get("type").and_then(|value| value.as_str()) == Some("message_start")
         {
             if let Some(message) = chunk.get("message") {
-                if let Some(id) = message.get("id").and_then(|value| value.as_str()) {
-                    self.response_id = id.to_string();
+                if !self.created_sent {
+                    if let Some(id) = message.get("id").and_then(|value| value.as_str()) {
+                        self.response_id = id.to_string();
+                    }
                 }
                 if let Some(model) = message.get("model").and_then(|value| value.as_str()) {
                     self.model = model.to_string();
@@ -138,7 +140,7 @@ impl ResponsesStreamConverter {
         self.ensure_preserved_items(&mut output);
 
         if let Some(choices) = chunk.get("choices").and_then(|value| value.as_array()) {
-            if let Some(usage) = chunk.get("usage") {
+            if let Some(usage) = chunk.get("usage").filter(|value| !value.is_null()) {
                 self.usage = map_openai_usage_to_responses_usage(usage);
             }
             if let Some(choice) = choices.first() {
@@ -277,7 +279,11 @@ impl ResponsesStreamConverter {
     fn push_openai_choice(&mut self, choice: &serde_json::Value, output: &mut String) {
         let delta = choice.get("delta").cloned().unwrap_or_default();
 
-        if let Some(text) = delta.get("content").and_then(|value| value.as_str()) {
+        if let Some(text) = delta
+            .get("content")
+            .and_then(|value| value.as_str())
+            .filter(|text| !text.is_empty())
+        {
             self.ensure_message_item(output);
             self.message_text.push_str(text);
             append_response_delta(
@@ -319,81 +325,147 @@ impl ResponsesStreamConverter {
                 .get("index")
                 .and_then(|value| value.as_u64())
                 .unwrap_or(0) as usize;
-            let entry = self.tools.entry(index).or_default();
-
-            if let Some(id) = tool_call.get("id").and_then(|value| value.as_str()) {
-                entry.id = id.to_string();
-            }
-            if let Some(name) = tool_call
-                .get("function")
-                .and_then(|function| function.get("name"))
-                .and_then(|value| value.as_str())
-            {
-                entry.name = name.to_string();
-            }
-            if let Some(arguments) = tool_call
-                .get("function")
-                .and_then(|function| function.get("arguments"))
-                .and_then(|value| value.as_str())
-            {
-                entry.arguments.push_str(arguments);
-            }
-
-            if !entry.added && (!entry.id.is_empty() || !entry.name.is_empty()) {
-                if entry.id.is_empty() {
-                    entry.id = format!("call_{index}");
+            let should_add = {
+                let entry = self.tools.entry(index).or_default();
+                if let Some(id) = tool_call.get("id").and_then(|value| value.as_str()) {
+                    entry.id = id.to_string();
                 }
-                if entry.name.is_empty() {
-                    entry.name = "tool".to_string();
-                }
-                if self.preserved_response.is_none() {
-                    let output_index = self.next_output_index;
-                    self.next_output_index += 1;
-                    let added = serde_json::json!({
-                        "type": "response.output_item.added",
-                        "output_index": output_index,
-                        "item": {
-                            "id": entry.id,
-                            "type": "function_call",
-                            "call_id": entry.id,
-                            "name": entry.name,
-                            "arguments": ""
-                        }
-                    });
-                    output.push_str("event: response.output_item.added\ndata: ");
-                    output.push_str(&added.to_string());
-                    output.push_str("\n\n");
-                    entry.output_index = Some(output_index);
-                    entry.item_id = Some(entry.id.clone());
-                } else if let Some(identity) =
-                    self.preserved_response.as_ref().and_then(|response| {
-                        response_output_item_identity(response, "function_call", index, None)
-                    })
+                if let Some(name) = tool_call
+                    .get("function")
+                    .and_then(|function| function.get("name"))
+                    .and_then(|value| value.as_str())
                 {
-                    entry.output_index = Some(identity.output_index);
-                    entry.item_id = identity.item_id;
+                    entry.name = name.to_string();
                 }
-                entry.added = true;
+                if let Some(arguments) = tool_call
+                    .get("function")
+                    .and_then(|function| function.get("arguments"))
+                    .and_then(|value| value.as_str())
+                {
+                    entry.arguments.push_str(arguments);
+                }
+                !entry.added && (!entry.id.is_empty() || !entry.name.is_empty())
+            };
+            if should_add {
+                self.ensure_tool_item(index, output);
             }
-
-            if entry.added && entry.arguments.len() > entry.emitted_arguments_len {
-                let arguments = entry.arguments[entry.emitted_arguments_len..].to_string();
-                entry.emitted_arguments_len = entry.arguments.len();
-                let identity = entry
-                    .output_index
-                    .map(|output_index| ResponseOutputItemIdentity {
-                        output_index,
-                        item_id: entry.item_id.clone(),
-                        content_index: None,
-                    });
-                append_response_delta(
-                    output,
-                    "response.function_call_arguments.delta",
-                    &arguments,
-                    identity,
-                );
-            }
+            self.emit_pending_tool_arguments(index, output);
         }
+    }
+
+    fn ensure_tool_item(&mut self, index: usize, output: &mut String) {
+        let entry = self.tools.entry(index).or_default();
+        if entry.added {
+            return;
+        }
+        if entry.id.is_empty() {
+            entry.id = format!("call_{index}");
+        }
+        if entry.name.is_empty() {
+            entry.name = "tool".to_string();
+        }
+        if self.preserved_response.is_none() {
+            let output_index = self.next_output_index;
+            self.next_output_index += 1;
+            let added = serde_json::json!({
+                "type": "response.output_item.added",
+                "output_index": output_index,
+                "item": {
+                    "id": entry.id,
+                    "type": "function_call",
+                    "call_id": entry.id,
+                    "name": entry.name,
+                    "arguments": ""
+                }
+            });
+            output.push_str("event: response.output_item.added\ndata: ");
+            output.push_str(&added.to_string());
+            output.push_str("\n\n");
+            entry.output_index = Some(output_index);
+            entry.item_id = Some(entry.id.clone());
+        } else if let Some(identity) = self.preserved_response.as_ref().and_then(|response| {
+            response_output_item_identity(response, "function_call", index, None)
+        }) {
+            entry.output_index = Some(identity.output_index);
+            entry.item_id = identity.item_id;
+        }
+        entry.added = true;
+    }
+
+    fn emit_pending_tool_arguments(&mut self, index: usize, output: &mut String) {
+        let Some(entry) = self.tools.get_mut(&index) else {
+            return;
+        };
+        if !entry.added || entry.arguments.len() <= entry.emitted_arguments_len {
+            return;
+        }
+        let arguments = entry.arguments[entry.emitted_arguments_len..].to_string();
+        entry.emitted_arguments_len = entry.arguments.len();
+        let identity = entry
+            .output_index
+            .map(|output_index| ResponseOutputItemIdentity {
+                output_index,
+                item_id: entry.item_id.clone(),
+                content_index: None,
+            });
+        append_response_delta(
+            output,
+            "response.function_call_arguments.delta",
+            &arguments,
+            identity,
+        );
+    }
+
+    fn push_anthropic_tool_start(&mut self, chunk: &serde_json::Value, output: &mut String) {
+        let Some(block) = chunk.get("content_block") else {
+            return;
+        };
+        if block.get("type").and_then(|value| value.as_str()) != Some("tool_use") {
+            return;
+        }
+        let index = chunk
+            .get("index")
+            .and_then(|value| value.as_u64())
+            .unwrap_or(0) as usize;
+        let entry = self.tools.entry(index).or_default();
+        if let Some(id) = block.get("id").and_then(|value| value.as_str()) {
+            entry.id = id.to_string();
+        }
+        if let Some(name) = block.get("name").and_then(|value| value.as_str()) {
+            entry.name = name.to_string();
+        }
+        if let Some(input) = block.get("input").filter(|input| {
+            !input.is_null() && !input.as_object().is_some_and(serde_json::Map::is_empty)
+        }) {
+            entry.arguments.push_str(&input.to_string());
+        }
+        self.ensure_tool_item(index, output);
+        self.emit_pending_tool_arguments(index, output);
+    }
+
+    fn push_anthropic_tool_delta(
+        &mut self,
+        chunk: &serde_json::Value,
+        delta: &serde_json::Value,
+        output: &mut String,
+    ) {
+        let Some(arguments) = delta
+            .get("partial_json")
+            .and_then(|value| value.as_str())
+            .filter(|arguments| !arguments.is_empty())
+        else {
+            return;
+        };
+        let index = chunk
+            .get("index")
+            .and_then(|value| value.as_u64())
+            .unwrap_or(0) as usize;
+        {
+            let entry = self.tools.entry(index).or_default();
+            entry.arguments.push_str(arguments);
+        }
+        self.ensure_tool_item(index, output);
+        self.emit_pending_tool_arguments(index, output);
     }
 
     fn push_anthropic_event(
@@ -403,10 +475,15 @@ impl ResponsesStreamConverter {
         output: &mut String,
     ) {
         match event_type {
+            Some("content_block_start") => self.push_anthropic_tool_start(chunk, output),
             Some("content_block_delta") => {
                 let Some(delta) = chunk.get("delta") else {
                     return;
                 };
+                if delta.get("type").and_then(|value| value.as_str()) == Some("input_json_delta") {
+                    self.push_anthropic_tool_delta(chunk, delta, output);
+                    return;
+                }
                 if let Some(text) = delta
                     .get("text")
                     .and_then(|value| value.as_str())
@@ -529,7 +606,7 @@ impl ResponsesStreamConverter {
         }
 
         indexed_output_items.sort_by_key(|(output_index, _)| *output_index);
-        let mut output_items = indexed_output_items
+        let output_items = indexed_output_items
             .into_iter()
             .map(|(_, item)| item)
             .collect::<Vec<_>>();
@@ -543,7 +620,6 @@ impl ResponsesStreamConverter {
             for (output_index, item) in items.iter().enumerate() {
                 append_output_item_done(&mut output, output_index, item);
             }
-            output_items = items.clone();
         }
 
         let terminal_type = match self.response_status.as_str() {

--- a/src/router/responses_api/incremental_stream.rs
+++ b/src/router/responses_api/incremental_stream.rs
@@ -2,6 +2,7 @@
 
 use std::collections::BTreeMap;
 
+use super::content_part_events::{append_content_part_added, append_content_part_done};
 use super::{
     add_reasoning_output_item, append_response_delta, initial_responses_output_item,
     map_openai_usage_to_responses_usage, response_output_item_identity, responses_reasoning_item,
@@ -33,6 +34,11 @@ pub(super) struct ResponsesStreamConverter {
     reasoning_output_index: Option<usize>,
     message_item_added: bool,
     message_output_index: Option<usize>,
+    message_text_part_added: bool,
+    message_text_content_index: Option<usize>,
+    refusal_part_added: bool,
+    refusal_content_index: Option<usize>,
+    next_message_content_index: usize,
     next_output_index: usize,
     message_text: String,
     refusal_text: String,
@@ -66,6 +72,11 @@ impl ResponsesStreamConverter {
             reasoning_output_index: None,
             message_item_added: false,
             message_output_index: None,
+            message_text_part_added: false,
+            message_text_content_index: None,
+            refusal_part_added: false,
+            refusal_content_index: None,
+            next_message_content_index: 0,
             next_output_index: 0,
             message_text: String::new(),
             refusal_text: String::new(),
@@ -239,9 +250,98 @@ impl ResponsesStreamConverter {
                     .map(|output_index| ResponseOutputItemIdentity {
                         output_index,
                         item_id: Some(format!("msg_{}", self.response_id)),
-                        content_index: Some(0),
+                        content_index: match content_type {
+                            "output_text" => self.message_text_content_index,
+                            "refusal" => self.refusal_content_index,
+                            _ => None,
+                        },
                     })
             })
+    }
+
+    fn ensure_message_content_part(&mut self, content_type: &str, output: &mut String) {
+        self.ensure_message_item(output);
+        let already_added = match content_type {
+            "output_text" => self.message_text_part_added,
+            "refusal" => self.refusal_part_added,
+            _ => return,
+        };
+        if already_added {
+            return;
+        }
+
+        if self.preserved_response.is_none() {
+            let content_index = self.next_message_content_index;
+            self.next_message_content_index += 1;
+            match content_type {
+                "output_text" => self.message_text_content_index = Some(content_index),
+                "refusal" => self.refusal_content_index = Some(content_index),
+                _ => return,
+            }
+        }
+
+        let Some(identity) = self.message_identity(content_type) else {
+            return;
+        };
+        append_content_part_added(output, &identity, content_type);
+        match content_type {
+            "output_text" => self.message_text_part_added = true,
+            "refusal" => self.refusal_part_added = true,
+            _ => {}
+        }
+    }
+
+    fn finish_message_content_parts(&self, output: &mut String) {
+        let mut parts = Vec::new();
+        if self.message_text_part_added {
+            if let Some(identity) = self.message_identity("output_text") {
+                let preserved_part = self.preserved_content_part(&identity);
+                parts.push((
+                    identity.content_index.unwrap_or(0),
+                    identity,
+                    "output_text",
+                    self.message_text.as_str(),
+                    preserved_part,
+                ));
+            }
+        }
+        if self.refusal_part_added {
+            if let Some(identity) = self.message_identity("refusal") {
+                let preserved_part = self.preserved_content_part(&identity);
+                parts.push((
+                    identity.content_index.unwrap_or(0),
+                    identity,
+                    "refusal",
+                    self.refusal_text.as_str(),
+                    preserved_part,
+                ));
+            }
+        }
+        parts.sort_by_key(|(content_index, _, _, _, _)| *content_index);
+        for (_, identity, content_type, content, preserved_part) in parts {
+            append_content_part_done(
+                output,
+                &identity,
+                content_type,
+                content,
+                preserved_part.as_ref(),
+            );
+        }
+    }
+
+    fn preserved_content_part(
+        &self,
+        identity: &ResponseOutputItemIdentity,
+    ) -> Option<serde_json::Value> {
+        self.preserved_response
+            .as_ref()?
+            .get("output")?
+            .as_array()?
+            .get(identity.output_index)?
+            .get("content")?
+            .as_array()?
+            .get(identity.content_index?)
+            .cloned()
     }
 
     fn reasoning_identity(&self) -> Option<ResponseOutputItemIdentity> {
@@ -289,7 +389,7 @@ impl ResponsesStreamConverter {
             .and_then(|value| value.as_str())
             .filter(|text| !text.is_empty())
         {
-            self.ensure_message_item(output);
+            self.ensure_message_content_part("output_text", output);
             self.message_text.push_str(text);
             append_response_delta(
                 output,
@@ -312,7 +412,7 @@ impl ResponsesStreamConverter {
             .and_then(|value| value.as_str())
             .filter(|refusal| !refusal.is_empty())
         {
-            self.ensure_message_item(output);
+            self.ensure_message_content_part("refusal", output);
             self.refusal_text.push_str(refusal);
             append_response_delta(
                 output,
@@ -494,7 +594,7 @@ impl ResponsesStreamConverter {
                     .and_then(|value| value.as_str())
                     .filter(|text| !text.is_empty())
                 {
-                    self.ensure_message_item(output);
+                    self.ensure_message_content_part("output_text", output);
                     self.message_text.push_str(text);
                     append_response_delta(
                         output,
@@ -537,20 +637,33 @@ impl ResponsesStreamConverter {
             append_output_item_done(&mut output, output_index, &reasoning_item);
         }
 
+        self.finish_message_content_parts(&mut output);
+
         if self.preserved_response.is_none() && self.message_item_added {
-            let mut content = Vec::new();
+            let mut indexed_content = Vec::new();
             if !self.message_text.is_empty() {
-                content.push(serde_json::json!({
-                    "type": "output_text",
-                    "text": self.message_text
-                }));
+                indexed_content.push((
+                    self.message_text_content_index.unwrap_or(0),
+                    serde_json::json!({
+                        "type": "output_text",
+                        "text": self.message_text
+                    }),
+                ));
             }
             if !self.refusal_text.is_empty() {
-                content.push(serde_json::json!({
-                    "type": "refusal",
-                    "refusal": self.refusal_text
-                }));
+                indexed_content.push((
+                    self.refusal_content_index.unwrap_or(0),
+                    serde_json::json!({
+                        "type": "refusal",
+                        "refusal": self.refusal_text
+                    }),
+                ));
             }
+            indexed_content.sort_by_key(|(content_index, _)| *content_index);
+            let content = indexed_content
+                .into_iter()
+                .map(|(_, content)| content)
+                .collect::<Vec<_>>();
             let message_item = serde_json::json!({
                 "id": format!("msg_{}", self.response_id),
                 "type": "message",

--- a/src/router/responses_api/incremental_stream.rs
+++ b/src/router/responses_api/incremental_stream.rs
@@ -1,0 +1,667 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use std::collections::BTreeMap;
+
+use super::{
+    add_reasoning_output_item, append_response_delta, initial_responses_output_item,
+    map_openai_usage_to_responses_usage, response_output_item_identity, responses_reasoning_item,
+    unique_response_output_item_identity, ResponseOutputItemIdentity,
+};
+
+#[derive(Default)]
+struct ToolAccum {
+    id: String,
+    item_id: Option<String>,
+    name: String,
+    arguments: String,
+    emitted_arguments_len: usize,
+    added: bool,
+    output_index: Option<usize>,
+}
+
+/// Stateful OpenAI/Anthropic SSE to Responses SSE converter.
+///
+/// Each complete upstream frame is parsed exactly once. Delta events are
+/// returned immediately, while output-item and response terminal events are
+/// emitted by [`Self::finish`].
+pub(super) struct ResponsesStreamConverter {
+    response_id: String,
+    created_at: i64,
+    model: String,
+    created_sent: bool,
+    reasoning_item_added: bool,
+    reasoning_output_index: Option<usize>,
+    message_item_added: bool,
+    message_output_index: Option<usize>,
+    next_output_index: usize,
+    message_text: String,
+    refusal_text: String,
+    reasoning_text: String,
+    response_status: String,
+    incomplete_details: Option<serde_json::Value>,
+    preserved_response: Option<serde_json::Value>,
+    preserved_items_added: bool,
+    tools: BTreeMap<usize, ToolAccum>,
+    usage: serde_json::Value,
+    finished: bool,
+}
+
+impl ResponsesStreamConverter {
+    pub(super) fn new(preserved_response: Option<serde_json::Value>) -> Self {
+        let response_status = preserved_response
+            .as_ref()
+            .and_then(|response| response.get("status"))
+            .and_then(|status| status.as_str())
+            .unwrap_or("completed")
+            .to_string();
+        Self {
+            response_id: "resp_stream".to_string(),
+            created_at: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs() as i64,
+            model: "unknown".to_string(),
+            created_sent: false,
+            reasoning_item_added: false,
+            reasoning_output_index: None,
+            message_item_added: false,
+            message_output_index: None,
+            next_output_index: 0,
+            message_text: String::new(),
+            refusal_text: String::new(),
+            reasoning_text: String::new(),
+            response_status,
+            incomplete_details: None,
+            preserved_response,
+            preserved_items_added: false,
+            tools: BTreeMap::new(),
+            usage: map_openai_usage_to_responses_usage(&serde_json::json!({})),
+            finished: false,
+        }
+    }
+
+    pub(super) fn response_id(&self) -> &str {
+        &self.response_id
+    }
+
+    pub(super) fn push_frame(&mut self, event_type: Option<&str>, data: &str) -> String {
+        if self.finished {
+            return String::new();
+        }
+        let chunk: serde_json::Value = match serde_json::from_str(data) {
+            Ok(value) => value,
+            Err(_) => return String::new(),
+        };
+        let mut output = String::new();
+
+        if !self.created_sent {
+            if let Some(id) = chunk.get("id").and_then(|value| value.as_str()) {
+                self.response_id = id.to_string();
+            }
+        }
+        if let Some(created_at) = chunk.get("created").and_then(|value| value.as_i64()) {
+            self.created_at = created_at;
+        }
+        if let Some(model) = chunk.get("model").and_then(|value| value.as_str()) {
+            self.model = model.to_string();
+        }
+        if let Some(status) = chunk
+            .get("response_status")
+            .and_then(|value| value.as_str())
+        {
+            self.response_status = status.to_string();
+        }
+        if let Some(details) = chunk
+            .get("incomplete_details")
+            .filter(|value| !value.is_null())
+        {
+            self.incomplete_details = Some(details.clone());
+        }
+
+        if event_type == Some("message_start")
+            || chunk.get("type").and_then(|value| value.as_str()) == Some("message_start")
+        {
+            if let Some(message) = chunk.get("message") {
+                if let Some(id) = message.get("id").and_then(|value| value.as_str()) {
+                    self.response_id = id.to_string();
+                }
+                if let Some(model) = message.get("model").and_then(|value| value.as_str()) {
+                    self.model = model.to_string();
+                }
+                if let Some(usage) = message.get("usage") {
+                    self.usage = anthropic_usage_to_responses_usage(usage);
+                }
+            }
+        }
+
+        self.ensure_created(&mut output);
+        self.ensure_preserved_items(&mut output);
+
+        if let Some(choices) = chunk.get("choices").and_then(|value| value.as_array()) {
+            if let Some(usage) = chunk.get("usage") {
+                self.usage = map_openai_usage_to_responses_usage(usage);
+            }
+            if let Some(choice) = choices.first() {
+                self.push_openai_choice(choice, &mut output);
+            }
+            return output;
+        }
+
+        let event_type = event_type.or_else(|| chunk.get("type").and_then(|value| value.as_str()));
+        self.push_anthropic_event(event_type, &chunk, &mut output);
+        output
+    }
+
+    fn ensure_created(&mut self, output: &mut String) {
+        if self.created_sent {
+            return;
+        }
+        let created = serde_json::json!({
+            "type": "response.created",
+            "response": {
+                "id": self.response_id,
+                "object": "response",
+                "created_at": self.created_at,
+                "status": "in_progress",
+                "model": self.model
+            }
+        });
+        output.push_str("event: response.created\ndata: ");
+        output.push_str(&created.to_string());
+        output.push_str("\n\n");
+        self.created_sent = true;
+    }
+
+    fn ensure_preserved_items(&mut self, output: &mut String) {
+        if self.preserved_items_added {
+            return;
+        }
+        if let Some(items) = self
+            .preserved_response
+            .as_ref()
+            .and_then(|response| response.get("output"))
+            .and_then(|value| value.as_array())
+        {
+            for (output_index, item) in items.iter().enumerate() {
+                let added = serde_json::json!({
+                    "type": "response.output_item.added",
+                    "output_index": output_index,
+                    "item": initial_responses_output_item(item)
+                });
+                output.push_str("event: response.output_item.added\ndata: ");
+                output.push_str(&added.to_string());
+                output.push_str("\n\n");
+            }
+            self.preserved_items_added = true;
+        }
+    }
+
+    fn ensure_message_item(&mut self, output: &mut String) {
+        if self.message_item_added {
+            return;
+        }
+        if self.preserved_response.is_none() {
+            let output_index = self.next_output_index;
+            self.next_output_index += 1;
+            let added = serde_json::json!({
+                "type": "response.output_item.added",
+                "output_index": output_index,
+                "item": {
+                    "id": format!("msg_{}", self.response_id),
+                    "type": "message",
+                    "role": "assistant",
+                    "content": []
+                }
+            });
+            output.push_str("event: response.output_item.added\ndata: ");
+            output.push_str(&added.to_string());
+            output.push_str("\n\n");
+            self.message_output_index = Some(output_index);
+        }
+        self.message_item_added = true;
+    }
+
+    fn message_identity(&self, content_type: &str) -> Option<ResponseOutputItemIdentity> {
+        self.preserved_response
+            .as_ref()
+            .and_then(|response| {
+                unique_response_output_item_identity(response, "message", Some(content_type))
+            })
+            .or_else(|| {
+                self.message_output_index
+                    .map(|output_index| ResponseOutputItemIdentity {
+                        output_index,
+                        item_id: Some(format!("msg_{}", self.response_id)),
+                        content_index: Some(0),
+                    })
+            })
+    }
+
+    fn reasoning_identity(&self) -> Option<ResponseOutputItemIdentity> {
+        self.preserved_response
+            .as_ref()
+            .and_then(|response| {
+                unique_response_output_item_identity(response, "reasoning", Some("reasoning_text"))
+            })
+            .or_else(|| {
+                self.reasoning_output_index
+                    .map(|output_index| ResponseOutputItemIdentity {
+                        output_index,
+                        item_id: Some(format!("rs_{}", self.response_id)),
+                        content_index: Some(0),
+                    })
+            })
+    }
+
+    fn push_reasoning_delta(&mut self, reasoning: &str, output: &mut String) {
+        if self.preserved_response.is_none() {
+            add_reasoning_output_item(
+                output,
+                &self.response_id,
+                &mut self.reasoning_item_added,
+                &mut self.reasoning_output_index,
+                &mut self.next_output_index,
+            );
+        } else {
+            self.reasoning_item_added = true;
+        }
+        self.reasoning_text.push_str(reasoning);
+        append_response_delta(
+            output,
+            "response.reasoning_text.delta",
+            reasoning,
+            self.reasoning_identity(),
+        );
+    }
+
+    fn push_openai_choice(&mut self, choice: &serde_json::Value, output: &mut String) {
+        let delta = choice.get("delta").cloned().unwrap_or_default();
+
+        if let Some(text) = delta.get("content").and_then(|value| value.as_str()) {
+            self.ensure_message_item(output);
+            self.message_text.push_str(text);
+            append_response_delta(
+                output,
+                "response.output_text.delta",
+                text,
+                self.message_identity("output_text"),
+            );
+        }
+
+        if let Some(reasoning) = delta
+            .get("reasoning_content")
+            .and_then(|value| value.as_str())
+            .filter(|reasoning| !reasoning.is_empty())
+        {
+            self.push_reasoning_delta(reasoning, output);
+        }
+
+        if let Some(refusal) = delta
+            .get("refusal")
+            .and_then(|value| value.as_str())
+            .filter(|refusal| !refusal.is_empty())
+        {
+            self.ensure_message_item(output);
+            self.refusal_text.push_str(refusal);
+            append_response_delta(
+                output,
+                "response.refusal.delta",
+                refusal,
+                self.message_identity("refusal"),
+            );
+        }
+
+        let Some(tool_calls) = delta.get("tool_calls").and_then(|value| value.as_array()) else {
+            return;
+        };
+        for tool_call in tool_calls {
+            let index = tool_call
+                .get("index")
+                .and_then(|value| value.as_u64())
+                .unwrap_or(0) as usize;
+            let entry = self.tools.entry(index).or_default();
+
+            if let Some(id) = tool_call.get("id").and_then(|value| value.as_str()) {
+                entry.id = id.to_string();
+            }
+            if let Some(name) = tool_call
+                .get("function")
+                .and_then(|function| function.get("name"))
+                .and_then(|value| value.as_str())
+            {
+                entry.name = name.to_string();
+            }
+            if let Some(arguments) = tool_call
+                .get("function")
+                .and_then(|function| function.get("arguments"))
+                .and_then(|value| value.as_str())
+            {
+                entry.arguments.push_str(arguments);
+            }
+
+            if !entry.added && (!entry.id.is_empty() || !entry.name.is_empty()) {
+                if entry.id.is_empty() {
+                    entry.id = format!("call_{index}");
+                }
+                if entry.name.is_empty() {
+                    entry.name = "tool".to_string();
+                }
+                if self.preserved_response.is_none() {
+                    let output_index = self.next_output_index;
+                    self.next_output_index += 1;
+                    let added = serde_json::json!({
+                        "type": "response.output_item.added",
+                        "output_index": output_index,
+                        "item": {
+                            "id": entry.id,
+                            "type": "function_call",
+                            "call_id": entry.id,
+                            "name": entry.name,
+                            "arguments": ""
+                        }
+                    });
+                    output.push_str("event: response.output_item.added\ndata: ");
+                    output.push_str(&added.to_string());
+                    output.push_str("\n\n");
+                    entry.output_index = Some(output_index);
+                    entry.item_id = Some(entry.id.clone());
+                } else if let Some(identity) =
+                    self.preserved_response.as_ref().and_then(|response| {
+                        response_output_item_identity(response, "function_call", index, None)
+                    })
+                {
+                    entry.output_index = Some(identity.output_index);
+                    entry.item_id = identity.item_id;
+                }
+                entry.added = true;
+            }
+
+            if entry.added && entry.arguments.len() > entry.emitted_arguments_len {
+                let arguments = entry.arguments[entry.emitted_arguments_len..].to_string();
+                entry.emitted_arguments_len = entry.arguments.len();
+                let identity = entry
+                    .output_index
+                    .map(|output_index| ResponseOutputItemIdentity {
+                        output_index,
+                        item_id: entry.item_id.clone(),
+                        content_index: None,
+                    });
+                append_response_delta(
+                    output,
+                    "response.function_call_arguments.delta",
+                    &arguments,
+                    identity,
+                );
+            }
+        }
+    }
+
+    fn push_anthropic_event(
+        &mut self,
+        event_type: Option<&str>,
+        chunk: &serde_json::Value,
+        output: &mut String,
+    ) {
+        match event_type {
+            Some("content_block_delta") => {
+                let Some(delta) = chunk.get("delta") else {
+                    return;
+                };
+                if let Some(text) = delta
+                    .get("text")
+                    .and_then(|value| value.as_str())
+                    .filter(|text| !text.is_empty())
+                {
+                    self.ensure_message_item(output);
+                    self.message_text.push_str(text);
+                    append_response_delta(
+                        output,
+                        "response.output_text.delta",
+                        text,
+                        self.message_identity("output_text"),
+                    );
+                }
+                if let Some(thinking) = delta
+                    .get("thinking")
+                    .and_then(|value| value.as_str())
+                    .filter(|thinking| !thinking.is_empty())
+                {
+                    self.push_reasoning_delta(thinking, output);
+                }
+            }
+            Some("message_delta") => {
+                if let Some(usage) = chunk.get("usage") {
+                    self.usage = merge_anthropic_usage(&self.usage, usage);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    pub(super) fn finish(&mut self) -> String {
+        if self.finished {
+            return String::new();
+        }
+        self.finished = true;
+        let mut output = String::new();
+        let mut indexed_output_items = Vec::new();
+
+        if self.preserved_response.is_none() && !self.reasoning_text.is_empty() {
+            let reasoning_item = responses_reasoning_item(&self.response_id, &self.reasoning_text);
+            let output_index = self
+                .reasoning_output_index
+                .expect("generated reasoning output must have an added event");
+            indexed_output_items.push((output_index, reasoning_item.clone()));
+            append_output_item_done(&mut output, output_index, &reasoning_item);
+        }
+
+        if self.preserved_response.is_none() && self.message_item_added {
+            let mut content = Vec::new();
+            if !self.message_text.is_empty() {
+                content.push(serde_json::json!({
+                    "type": "output_text",
+                    "text": self.message_text
+                }));
+            }
+            if !self.refusal_text.is_empty() {
+                content.push(serde_json::json!({
+                    "type": "refusal",
+                    "refusal": self.refusal_text
+                }));
+            }
+            let message_item = serde_json::json!({
+                "id": format!("msg_{}", self.response_id),
+                "type": "message",
+                "role": "assistant",
+                "content": content
+            });
+            let output_index = self
+                .message_output_index
+                .expect("generated message output must have an added event");
+            indexed_output_items.push((output_index, message_item.clone()));
+            append_output_item_done(&mut output, output_index, &message_item);
+        }
+
+        let mut next_output_index = self.next_output_index;
+        for tool in self
+            .tools
+            .values()
+            .filter(|_| self.preserved_response.is_none())
+        {
+            let call_id = if tool.id.is_empty() {
+                "call_unknown"
+            } else {
+                &tool.id
+            };
+            let name = if tool.name.is_empty() {
+                "tool"
+            } else {
+                &tool.name
+            };
+            let item = serde_json::json!({
+                "id": call_id,
+                "type": "function_call",
+                "call_id": call_id,
+                "name": name,
+                "arguments": tool.arguments
+            });
+            let output_index = tool.output_index.unwrap_or_else(|| {
+                let output_index = next_output_index;
+                next_output_index += 1;
+                let added = serde_json::json!({
+                    "type": "response.output_item.added",
+                    "output_index": output_index,
+                    "item": {
+                        "id": call_id,
+                        "type": "function_call",
+                        "call_id": call_id,
+                        "name": name,
+                        "arguments": ""
+                    }
+                });
+                output.push_str("event: response.output_item.added\ndata: ");
+                output.push_str(&added.to_string());
+                output.push_str("\n\n");
+                output_index
+            });
+            indexed_output_items.push((output_index, item.clone()));
+            append_output_item_done(&mut output, output_index, &item);
+        }
+
+        indexed_output_items.sort_by_key(|(output_index, _)| *output_index);
+        let mut output_items = indexed_output_items
+            .into_iter()
+            .map(|(_, item)| item)
+            .collect::<Vec<_>>();
+
+        if let Some(items) = self
+            .preserved_response
+            .as_ref()
+            .and_then(|response| response.get("output"))
+            .and_then(|value| value.as_array())
+        {
+            for (output_index, item) in items.iter().enumerate() {
+                append_output_item_done(&mut output, output_index, item);
+            }
+            output_items = items.clone();
+        }
+
+        let terminal_type = match self.response_status.as_str() {
+            "queued" => "response.queued",
+            "in_progress" => "response.in_progress",
+            "completed" => "response.completed",
+            "incomplete" => "response.incomplete",
+            "failed" => "response.failed",
+            "cancelled" => "response.cancelled",
+            _ => "response.incomplete",
+        };
+        let terminal_response = self.preserved_response.clone().unwrap_or_else(|| {
+            let mut response = serde_json::json!({
+                "id": self.response_id,
+                "object": "response",
+                "created_at": self.created_at,
+                "status": self.response_status,
+                "model": self.model,
+                "output": output_items,
+                "usage": self.usage
+            });
+            if let Some(details) = &self.incomplete_details {
+                response["incomplete_details"] = details.clone();
+            }
+            response
+        });
+        let terminal = serde_json::json!({
+            "type": terminal_type,
+            "response": terminal_response
+        });
+        output.push_str("event: ");
+        output.push_str(terminal_type);
+        output.push_str("\ndata: ");
+        output.push_str(&terminal.to_string());
+        output.push_str("\n\n");
+        output
+    }
+}
+
+fn anthropic_usage_to_responses_usage(usage: &serde_json::Value) -> serde_json::Value {
+    let input_tokens = usage
+        .get("input_tokens")
+        .and_then(|value| value.as_u64())
+        .unwrap_or(0);
+    let output_tokens = usage
+        .get("output_tokens")
+        .and_then(|value| value.as_u64())
+        .unwrap_or(0);
+    let cached_tokens = usage
+        .get("cache_read_input_tokens")
+        .and_then(|value| value.as_u64())
+        .unwrap_or(0);
+    let reasoning_tokens = usage
+        .get("reasoning_tokens")
+        .and_then(|value| value.as_u64())
+        .unwrap_or(0);
+    map_openai_usage_to_responses_usage(&serde_json::json!({
+        "prompt_tokens": input_tokens,
+        "completion_tokens": output_tokens,
+        "total_tokens": input_tokens + output_tokens,
+        "prompt_tokens_details": {"cached_tokens": cached_tokens},
+        "completion_tokens_details": {"reasoning_tokens": reasoning_tokens}
+    }))
+}
+
+fn merge_anthropic_usage(
+    current: &serde_json::Value,
+    update: &serde_json::Value,
+) -> serde_json::Value {
+    let input_tokens = update
+        .get("input_tokens")
+        .and_then(|value| value.as_u64())
+        .or_else(|| current.get("input_tokens").and_then(|value| value.as_u64()))
+        .unwrap_or(0);
+    let output_tokens = update
+        .get("output_tokens")
+        .and_then(|value| value.as_u64())
+        .or_else(|| {
+            current
+                .get("output_tokens")
+                .and_then(|value| value.as_u64())
+        })
+        .unwrap_or(0);
+    let cached_tokens = update
+        .get("cache_read_input_tokens")
+        .and_then(|value| value.as_u64())
+        .or_else(|| {
+            current
+                .get("input_tokens_details")
+                .and_then(|details| details.get("cached_tokens"))
+                .and_then(|value| value.as_u64())
+        })
+        .unwrap_or(0);
+    let reasoning_tokens = update
+        .get("reasoning_tokens")
+        .and_then(|value| value.as_u64())
+        .or_else(|| {
+            current
+                .get("output_tokens_details")
+                .and_then(|details| details.get("reasoning_tokens"))
+                .and_then(|value| value.as_u64())
+        })
+        .unwrap_or(0);
+    anthropic_usage_to_responses_usage(&serde_json::json!({
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "cache_read_input_tokens": cached_tokens,
+        "reasoning_tokens": reasoning_tokens
+    }))
+}
+
+fn append_output_item_done(output: &mut String, output_index: usize, item: &serde_json::Value) {
+    let done = serde_json::json!({
+        "type": "response.output_item.done",
+        "output_index": output_index,
+        "item": item
+    });
+    output.push_str("event: response.output_item.done\ndata: ");
+    output.push_str(&done.to_string());
+    output.push_str("\n\n");
+}

--- a/src/router/responses_protocol.rs
+++ b/src/router/responses_protocol.rs
@@ -87,7 +87,12 @@ fn response_content_blocks(content: &Value, role: &str) -> Result<Vec<Value>> {
 }
 
 fn responses_tool(tool: &Value) -> Option<Value> {
-    if tool.get("type").and_then(Value::as_str) != Some("function") {
+    let object = tool.as_object()?;
+    let tool_type = object
+        .get("type")
+        .and_then(Value::as_str)
+        .filter(|tool_type| !tool_type.is_empty())?;
+    if tool_type != "function" {
         return Some(tool.clone());
     }
     if tool.get("name").and_then(Value::as_str).is_some() {
@@ -104,7 +109,12 @@ fn responses_tool_choice(choice: &Value) -> Option<Value> {
     if choice.is_string() {
         return Some(choice.clone());
     }
-    if choice.get("type").and_then(Value::as_str) != Some("function") {
+    let object = choice.as_object()?;
+    let choice_type = object
+        .get("type")
+        .and_then(Value::as_str)
+        .filter(|choice_type| !choice_type.is_empty())?;
+    if choice_type != "function" {
         return Some(choice.clone());
     }
     if choice.get("name").and_then(Value::as_str).is_some() {
@@ -120,6 +130,21 @@ fn responses_tool_choice(choice: &Value) -> Option<Value> {
 
 /// Convert an OpenAI Chat Completions request into an upstream Responses request.
 pub(super) fn openai_chat_request_to_responses(request: &Value, model: &str) -> Result<Value> {
+    if let Some(native_request) = request
+        .get(super::RESPONSES_REQUEST_PASSTHROUGH_KEY)
+        .and_then(Value::as_object)
+    {
+        let mut body = Value::Object(native_request.clone());
+        body["model"] = Value::String(model.to_string());
+        body["stream"] = Value::Bool(false);
+        if body.get("tool_choice").is_some_and(Value::is_null) {
+            body.as_object_mut()
+                .expect("native Responses request is an object")
+                .remove("tool_choice");
+        }
+        return Ok(body);
+    }
+
     let messages = request
         .get("messages")
         .and_then(Value::as_array)
@@ -184,11 +209,7 @@ pub(super) fn openai_chat_request_to_responses(request: &Value, model: &str) -> 
             body[key] = value.clone();
         }
     }
-    if let Some(reasoning) = request
-        .get(super::RESPONSES_REASONING_PASSTHROUGH_KEY)
-        .or_else(|| request.get("reasoning"))
-        .filter(|value| !value.is_null())
-    {
+    if let Some(reasoning) = request.get("reasoning").filter(|value| !value.is_null()) {
         body["reasoning"] = reasoning.clone();
     } else if let Some(reasoning_effort) = request
         .get("reasoning_effort")
@@ -507,23 +528,50 @@ mod tests {
     }
 
     #[test]
-    fn preserves_internal_responses_reasoning_object() {
+    fn preserves_internal_responses_request() {
         let mut request = json!({
             "messages": [{"role": "user", "content": "Think"}],
             "reasoning_effort": "high"
         });
-        request[super::super::RESPONSES_REASONING_PASSTHROUGH_KEY] =
-            json!({"effort": "high", "summary": "detailed"});
+        request[super::super::RESPONSES_REQUEST_PASSTHROUGH_KEY] = json!({
+            "model": "auto",
+            "input": [{"role": "user", "content": [{
+                "type": "input_file",
+                "file_id": "file_123"
+            }]}],
+            "reasoning": {"effort": "high", "summary": "detailed"},
+            "text": {"format": {"type": "json_schema", "name": "answer"}},
+            "stream": true
+        });
 
         let converted = openai_chat_request_to_responses(&request, "muse").unwrap();
 
+        assert_eq!(converted["model"], "muse");
+        assert_eq!(converted["stream"], false);
+        assert_eq!(converted["input"][0]["content"][0]["type"], "input_file");
+        assert_eq!(converted["input"][0]["content"][0]["file_id"], "file_123");
         assert_eq!(
             converted["reasoning"],
             json!({"effort": "high", "summary": "detailed"})
         );
+        assert_eq!(converted["text"]["format"]["type"], "json_schema");
         assert!(converted
-            .get(super::super::RESPONSES_REASONING_PASSTHROUGH_KEY)
+            .get(super::super::RESPONSES_REQUEST_PASSTHROUGH_KEY)
             .is_none());
+    }
+
+    #[test]
+    fn drops_invalid_direct_chat_tools_and_choices() {
+        let request = json!({
+            "messages": [{"role": "user", "content": "Think"}],
+            "tools": [null, 7, {}, {"type": ""}, {"type": "web_search"}],
+            "tool_choice": null
+        });
+
+        let converted = openai_chat_request_to_responses(&request, "muse").unwrap();
+
+        assert_eq!(converted["tools"], json!([{"type": "web_search"}]));
+        assert!(converted.get("tool_choice").is_none());
     }
 
     #[test]

--- a/src/router/responses_protocol.rs
+++ b/src/router/responses_protocol.rs
@@ -1,0 +1,352 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! OpenAI Chat Completions to Responses API upstream conversion.
+
+use anyhow::{anyhow, Result};
+use serde_json::{json, Map, Value};
+
+fn content_text(content: &Value) -> String {
+    match content {
+        Value::String(text) => text.clone(),
+        Value::Array(items) => items
+            .iter()
+            .filter_map(|item| item.get("text").and_then(Value::as_str))
+            .collect(),
+        Value::Null => String::new(),
+        other => other.to_string(),
+    }
+}
+
+fn response_content_blocks(content: &Value, role: &str) -> Vec<Value> {
+    let text_type = if role == "assistant" {
+        "output_text"
+    } else {
+        "input_text"
+    };
+    match content {
+        Value::String(text) => vec![json!({"type": text_type, "text": text})],
+        Value::Array(items) => items
+            .iter()
+            .filter_map(|item| {
+                let item_type = item.get("type").and_then(Value::as_str).unwrap_or("");
+                match item_type {
+                    "text" | "input_text" | "output_text" => item
+                        .get("text")
+                        .cloned()
+                        .map(|text| json!({"type": text_type, "text": text})),
+                    "image_url" => item
+                        .get("image_url")
+                        .and_then(|image| image.get("url").or(Some(image)))
+                        .cloned()
+                        .map(|image_url| json!({"type": "input_image", "image_url": image_url})),
+                    "input_image" => Some(item.clone()),
+                    _ => None,
+                }
+            })
+            .collect(),
+        Value::Null => Vec::new(),
+        other => vec![json!({"type": text_type, "text": other.to_string()})],
+    }
+}
+
+fn responses_tool(tool: &Value) -> Option<Value> {
+    if tool.get("type").and_then(Value::as_str) != Some("function") {
+        return Some(tool.clone());
+    }
+    let function = tool.get("function")?.as_object()?;
+    let mut converted = function.clone();
+    converted.insert("type".to_string(), Value::String("function".to_string()));
+    Some(Value::Object(converted))
+}
+
+fn responses_tool_choice(choice: &Value) -> Value {
+    let Some(function) = choice.get("function").and_then(Value::as_object) else {
+        return choice.clone();
+    };
+    let mut converted = Map::new();
+    converted.insert("type".to_string(), Value::String("function".to_string()));
+    if let Some(name) = function.get("name") {
+        converted.insert("name".to_string(), name.clone());
+    }
+    Value::Object(converted)
+}
+
+/// Convert an OpenAI Chat Completions request into an upstream Responses request.
+pub(super) fn openai_chat_request_to_responses(request: &Value, model: &str) -> Result<Value> {
+    let messages = request
+        .get("messages")
+        .and_then(Value::as_array)
+        .ok_or_else(|| anyhow!("OpenAI request requires a messages array"))?;
+    let mut input = Vec::new();
+
+    for message in messages {
+        let role = message
+            .get("role")
+            .and_then(Value::as_str)
+            .unwrap_or("user");
+        if role == "tool" {
+            input.push(json!({
+                "type": "function_call_output",
+                "call_id": message
+                    .get("tool_call_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("call_unknown"),
+                "output": message.get("content").map(content_text).unwrap_or_default()
+            }));
+            continue;
+        }
+
+        let content = message
+            .get("content")
+            .map(|value| response_content_blocks(value, role))
+            .unwrap_or_default();
+        if !content.is_empty() {
+            input.push(json!({"role": role, "content": content}));
+        }
+
+        if let Some(tool_calls) = message.get("tool_calls").and_then(Value::as_array) {
+            for tool_call in tool_calls {
+                let function = tool_call.get("function").unwrap_or(&Value::Null);
+                input.push(json!({
+                    "type": "function_call",
+                    "call_id": tool_call
+                        .get("id")
+                        .and_then(Value::as_str)
+                        .unwrap_or("call_unknown"),
+                    "name": function
+                        .get("name")
+                        .and_then(Value::as_str)
+                        .unwrap_or("function"),
+                    "arguments": function
+                        .get("arguments")
+                        .map(content_text)
+                        .unwrap_or_else(|| "{}".to_string())
+                }));
+            }
+        }
+    }
+
+    let mut body = json!({"model": model, "input": input, "stream": false});
+    if let Some(max_tokens) = request
+        .get("max_completion_tokens")
+        .or_else(|| request.get("max_tokens"))
+    {
+        body["max_output_tokens"] = max_tokens.clone();
+    }
+    for key in ["temperature", "top_p", "parallel_tool_calls"] {
+        if let Some(value) = request.get(key) {
+            body[key] = value.clone();
+        }
+    }
+    if let Some(tools) = request.get("tools").and_then(Value::as_array) {
+        body["tools"] = Value::Array(tools.iter().filter_map(responses_tool).collect());
+    }
+    if let Some(tool_choice) = request.get("tool_choice") {
+        body["tool_choice"] = responses_tool_choice(tool_choice);
+    }
+    Ok(body)
+}
+
+fn response_text(response: &Value) -> String {
+    let mut text = String::new();
+    if let Some(output) = response.get("output").and_then(Value::as_array) {
+        for item in output {
+            if item.get("type").and_then(Value::as_str) != Some("message") {
+                continue;
+            }
+            if let Some(content) = item.get("content").and_then(Value::as_array) {
+                for part in content {
+                    if matches!(
+                        part.get("type").and_then(Value::as_str),
+                        Some("output_text" | "text")
+                    ) {
+                        if let Some(value) = part.get("text").and_then(Value::as_str) {
+                            text.push_str(value);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    if text.is_empty() {
+        response
+            .get("output_text")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string()
+    } else {
+        text
+    }
+}
+
+fn response_tool_calls(response: &Value) -> Vec<Value> {
+    response
+        .get("output")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter(|item| item.get("type").and_then(Value::as_str) == Some("function_call"))
+        .map(|item| {
+            let arguments = item
+                .get("arguments")
+                .map(content_text)
+                .unwrap_or_else(|| "{}".to_string());
+            json!({
+                "id": item
+                    .get("call_id")
+                    .or_else(|| item.get("id"))
+                    .and_then(Value::as_str)
+                    .unwrap_or("call_unknown"),
+                "type": "function",
+                "function": {
+                    "name": item
+                        .get("name")
+                        .and_then(Value::as_str)
+                        .unwrap_or("function"),
+                    "arguments": arguments
+                }
+            })
+        })
+        .collect()
+}
+
+/// Convert a completed Responses API payload to OpenAI Chat Completions JSON.
+pub(super) fn responses_response_to_openai_chat(response: &Value, model: &str) -> Result<Value> {
+    if let Some(error) = response.get("error") {
+        return Err(anyhow!("Responses provider returned an error: {error}"));
+    }
+    let output = response
+        .get("output")
+        .and_then(Value::as_array)
+        .ok_or_else(|| anyhow!("Responses provider payload is missing output"))?;
+    let text = response_text(response);
+    let tool_calls = response_tool_calls(response);
+    if output.is_empty() && text.is_empty() && tool_calls.is_empty() {
+        return Err(anyhow!("Responses provider returned no output items"));
+    }
+
+    let mut message = json!({
+        "role": "assistant",
+        "content": if text.is_empty() { Value::Null } else { Value::String(text) }
+    });
+    if !tool_calls.is_empty() {
+        message["tool_calls"] = Value::Array(tool_calls.clone());
+    }
+    let incomplete_reason = response
+        .get("incomplete_details")
+        .and_then(|details| details.get("reason"))
+        .and_then(Value::as_str);
+    let finish_reason = if !tool_calls.is_empty() {
+        "tool_calls"
+    } else if incomplete_reason == Some("max_output_tokens") {
+        "length"
+    } else {
+        "stop"
+    };
+    let usage = response.get("usage").cloned().unwrap_or_else(|| json!({}));
+    let prompt_tokens = usage
+        .get("input_tokens")
+        .and_then(Value::as_u64)
+        .unwrap_or_default();
+    let completion_tokens = usage
+        .get("output_tokens")
+        .and_then(Value::as_u64)
+        .unwrap_or_default();
+
+    Ok(json!({
+        "id": response.get("id").and_then(Value::as_str).unwrap_or("resp_unknown"),
+        "object": "chat.completion",
+        "created": response.get("created_at").and_then(Value::as_i64).unwrap_or_default(),
+        "model": response.get("model").and_then(Value::as_str).unwrap_or(model),
+        "choices": [{
+            "index": 0,
+            "message": message,
+            "finish_reason": finish_reason
+        }],
+        "usage": {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": usage
+                .get("total_tokens")
+                .and_then(Value::as_u64)
+                .unwrap_or(prompt_tokens.saturating_add(completion_tokens))
+        }
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn converts_chat_request_to_meta_responses_shape() {
+        let request = json!({
+            "model": "meta-muse,muse-spark-1.1",
+            "messages": [{"role": "user", "content": "Write a haiku"}],
+            "max_completion_tokens": 64,
+            "stream": true
+        });
+
+        let converted = openai_chat_request_to_responses(&request, "muse-spark-1.1").unwrap();
+
+        assert_eq!(converted["model"], "muse-spark-1.1");
+        assert_eq!(converted["stream"], false);
+        assert_eq!(converted["max_output_tokens"], 64);
+        assert_eq!(converted["input"][0]["role"], "user");
+        assert_eq!(converted["input"][0]["content"][0]["type"], "input_text");
+        assert_eq!(converted["input"][0]["content"][0]["text"], "Write a haiku");
+        assert!(converted.get("messages").is_none());
+    }
+
+    #[test]
+    fn converts_responses_text_and_usage_to_chat_shape() {
+        let response = json!({
+            "id": "resp_meta_1",
+            "object": "response",
+            "created_at": 42,
+            "status": "completed",
+            "model": "muse-spark-1.1",
+            "output": [{
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "AlphaHENG ready"}]
+            }],
+            "usage": {"input_tokens": 11, "output_tokens": 3, "total_tokens": 14}
+        });
+
+        let converted = responses_response_to_openai_chat(&response, "muse-spark-1.1").unwrap();
+
+        assert_eq!(
+            converted["choices"][0]["message"]["content"],
+            "AlphaHENG ready"
+        );
+        assert_eq!(converted["choices"][0]["finish_reason"], "stop");
+        assert_eq!(converted["usage"]["prompt_tokens"], 11);
+        assert_eq!(converted["usage"]["completion_tokens"], 3);
+    }
+
+    #[test]
+    fn preserves_function_calls_across_responses_protocol() {
+        let response = json!({
+            "id": "resp_meta_tool",
+            "model": "muse-spark-1.1",
+            "output": [{
+                "type": "function_call",
+                "call_id": "call_7",
+                "name": "run_check",
+                "arguments": "{\"target\":\"tests\"}"
+            }]
+        });
+
+        let converted = responses_response_to_openai_chat(&response, "muse-spark-1.1").unwrap();
+
+        assert_eq!(converted["choices"][0]["finish_reason"], "tool_calls");
+        assert_eq!(
+            converted["choices"][0]["message"]["tool_calls"][0]["id"],
+            "call_7"
+        );
+        assert_eq!(
+            converted["choices"][0]["message"]["tool_calls"][0]["function"]["name"],
+            "run_check"
+        );
+    }
+}

--- a/src/router/responses_protocol.rs
+++ b/src/router/responses_protocol.rs
@@ -41,25 +41,29 @@ fn response_created_at(created_at: Option<&Value>) -> i64 {
         .unwrap_or_default()
 }
 
-fn response_content_blocks(content: &Value, role: &str) -> Vec<Value> {
+fn response_content_blocks(content: &Value, role: &str) -> Result<Vec<Value>> {
     let text_type = if role == "assistant" {
         "output_text"
     } else {
         "input_text"
     };
     match content {
-        Value::String(text) if text.is_empty() => Vec::new(),
-        Value::String(text) => vec![json!({"type": text_type, "text": text})],
-        Value::Array(items) => items
-            .iter()
-            .filter_map(|item| {
+        Value::String(text) if text.is_empty() => Ok(Vec::new()),
+        Value::String(text) => Ok(vec![json!({"type": text_type, "text": text})]),
+        Value::Array(items) => {
+            let mut blocks = Vec::new();
+            for item in items {
                 let item_type = item.get("type").and_then(Value::as_str).unwrap_or("");
-                match item_type {
-                    "text" | "input_text" | "output_text" => item
-                        .get("text")
-                        .and_then(Value::as_str)
-                        .filter(|text| !text.is_empty())
-                        .map(|text| json!({"type": text_type, "text": text})),
+                let block = match item_type {
+                    "text" | "input_text" | "output_text" => {
+                        let text = item.get("text").ok_or_else(|| {
+                            anyhow!("Responses text content block is missing 'text'")
+                        })?;
+                        let text = text.as_str().ok_or_else(|| {
+                            anyhow!("Responses text content block requires string 'text'")
+                        })?;
+                        (!text.is_empty()).then(|| json!({"type": text_type, "text": text}))
+                    }
                     "image_url" => item
                         .get("image_url")
                         .and_then(|image| {
@@ -70,11 +74,15 @@ fn response_content_blocks(content: &Value, role: &str) -> Vec<Value> {
                         .map(|image_url| json!({"type": "input_image", "image_url": image_url})),
                     "input_image" => Some(item.clone()),
                     _ => None,
+                };
+                if let Some(block) = block {
+                    blocks.push(block);
                 }
-            })
-            .collect(),
-        Value::Null => Vec::new(),
-        other => vec![json!({"type": text_type, "text": other.to_string()})],
+            }
+            Ok(blocks)
+        }
+        Value::Null => Ok(Vec::new()),
+        other => Ok(vec![json!({"type": text_type, "text": other.to_string()})]),
     }
 }
 
@@ -139,6 +147,7 @@ pub(super) fn openai_chat_request_to_responses(request: &Value, model: &str) -> 
         let content = message
             .get("content")
             .map(|value| response_content_blocks(value, role))
+            .transpose()?
             .unwrap_or_default();
         if !content.is_empty() {
             input.push(json!({"role": role, "content": content}));
@@ -190,16 +199,6 @@ fn response_text(response: &Value) -> String {
     let mut text = String::new();
     if let Some(output) = response.get("output").and_then(Value::as_array) {
         for item in output {
-            if item.get("type").and_then(Value::as_str) == Some("refusal") {
-                if let Some(value) = item
-                    .get("refusal")
-                    .or_else(|| item.get("text"))
-                    .and_then(Value::as_str)
-                {
-                    text.push_str(value);
-                }
-                continue;
-            }
             if item.get("type").and_then(Value::as_str) != Some("message") {
                 continue;
             }
@@ -207,13 +206,9 @@ fn response_text(response: &Value) -> String {
                 for part in content {
                     if matches!(
                         part.get("type").and_then(Value::as_str),
-                        Some("output_text" | "text" | "refusal")
+                        Some("output_text" | "text")
                     ) {
-                        if let Some(value) = part
-                            .get("text")
-                            .or_else(|| part.get("refusal"))
-                            .and_then(Value::as_str)
-                        {
+                        if let Some(value) = part.get("text").and_then(Value::as_str) {
                             text.push_str(value);
                         }
                     }
@@ -230,6 +225,41 @@ fn response_text(response: &Value) -> String {
     } else {
         text
     }
+}
+
+fn response_refusal_text(response: &Value) -> String {
+    let mut refusal = String::new();
+    if let Some(output) = response.get("output").and_then(Value::as_array) {
+        for item in output {
+            if item.get("type").and_then(Value::as_str) == Some("refusal") {
+                if let Some(value) = item
+                    .get("refusal")
+                    .or_else(|| item.get("text"))
+                    .and_then(Value::as_str)
+                {
+                    refusal.push_str(value);
+                }
+                continue;
+            }
+            if item.get("type").and_then(Value::as_str) != Some("message") {
+                continue;
+            }
+            if let Some(content) = item.get("content").and_then(Value::as_array) {
+                for part in content {
+                    if part.get("type").and_then(Value::as_str) == Some("refusal") {
+                        if let Some(value) = part
+                            .get("refusal")
+                            .or_else(|| part.get("text"))
+                            .and_then(Value::as_str)
+                        {
+                            refusal.push_str(value);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    refusal
 }
 
 fn response_reasoning_text(response: &Value) -> String {
@@ -291,9 +321,10 @@ pub(super) fn responses_response_to_openai_chat(response: &Value, model: &str) -
         .and_then(Value::as_array)
         .ok_or_else(|| anyhow!("Responses provider payload is missing output"))?;
     let text = response_text(response);
+    let refusal = response_refusal_text(response);
     let reasoning = response_reasoning_text(response);
     let tool_calls = response_tool_calls(response);
-    if output.is_empty() && text.is_empty() && tool_calls.is_empty() {
+    if output.is_empty() && text.is_empty() && refusal.is_empty() && tool_calls.is_empty() {
         return Err(anyhow!("Responses provider returned no output items"));
     }
 
@@ -306,6 +337,9 @@ pub(super) fn responses_response_to_openai_chat(response: &Value, model: &str) -
     }
     if !reasoning.is_empty() {
         message["reasoning_content"] = Value::String(reasoning);
+    }
+    if !refusal.is_empty() {
+        message["refusal"] = Value::String(refusal);
     }
     let incomplete_reason = response
         .get("incomplete_details")
@@ -429,6 +463,23 @@ mod tests {
     }
 
     #[test]
+    fn rejects_non_string_text_content_blocks() {
+        let request = json!({
+            "messages": [{
+                "role": "user",
+                "content": [{"type": "text", "text": {"unexpected": true}}]
+            }]
+        });
+
+        let error = openai_chat_request_to_responses(&request, "muse").unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "Responses text content block requires string 'text'"
+        );
+    }
+
+    #[test]
     fn converts_responses_text_and_usage_to_chat_shape() {
         let response = json!({
             "id": "resp_meta_1",
@@ -532,8 +583,9 @@ mod tests {
 
         assert_eq!(converted["created"], 42);
         assert_eq!(converted["choices"][0]["finish_reason"], "content_filter");
+        assert!(converted["choices"][0]["message"]["content"].is_null());
         assert_eq!(
-            converted["choices"][0]["message"]["content"],
+            converted["choices"][0]["message"]["refusal"],
             "I cannot help with that."
         );
     }

--- a/src/router/responses_protocol.rs
+++ b/src/router/responses_protocol.rs
@@ -16,6 +16,31 @@ fn content_text(content: &Value) -> String {
     }
 }
 
+fn function_arguments(arguments: Option<&Value>) -> String {
+    let rendered = arguments.map(content_text).unwrap_or_default();
+    if rendered.trim().is_empty() {
+        "{}".to_string()
+    } else {
+        rendered
+    }
+}
+
+fn response_created_at(created_at: Option<&Value>) -> i64 {
+    created_at
+        .and_then(|created| {
+            created.as_i64().or_else(|| {
+                created.as_str().and_then(|value| {
+                    value.parse().ok().or_else(|| {
+                        chrono::DateTime::parse_from_rfc3339(value)
+                            .ok()
+                            .map(|timestamp| timestamp.timestamp())
+                    })
+                })
+            })
+        })
+        .unwrap_or_default()
+}
+
 fn response_content_blocks(content: &Value, role: &str) -> Vec<Value> {
     let text_type = if role == "assistant" {
         "output_text"
@@ -130,11 +155,7 @@ pub(super) fn openai_chat_request_to_responses(request: &Value, model: &str) -> 
                         .get("name")
                         .and_then(Value::as_str)
                         .unwrap_or("function"),
-                    "arguments": function
-                        .get("arguments")
-                        .filter(|value| !value.is_null())
-                        .map(content_text)
-                        .unwrap_or_else(|| "{}".to_string())
+                    "arguments": function_arguments(function.get("arguments"))
                 }));
             }
         }
@@ -217,11 +238,7 @@ fn response_tool_calls(response: &Value) -> Vec<Value> {
         .flatten()
         .filter(|item| item.get("type").and_then(Value::as_str) == Some("function_call"))
         .map(|item| {
-            let arguments = item
-                .get("arguments")
-                .filter(|value| !value.is_null())
-                .map(content_text)
-                .unwrap_or_else(|| "{}".to_string());
+            let arguments = function_arguments(item.get("arguments"));
             json!({
                 "id": item
                     .get("call_id")
@@ -291,14 +308,7 @@ pub(super) fn responses_response_to_openai_chat(response: &Value, model: &str) -
     Ok(json!({
         "id": response.get("id").and_then(Value::as_str).unwrap_or("resp_unknown"),
         "object": "chat.completion",
-        "created": response
-            .get("created_at")
-            .and_then(|created| {
-                created
-                    .as_i64()
-                    .or_else(|| created.as_str().and_then(|value| value.parse().ok()))
-            })
-            .unwrap_or_default(),
+        "created": response_created_at(response.get("created_at")),
         "model": response.get("model").and_then(Value::as_str).unwrap_or(model),
         "choices": [{
             "index": 0,
@@ -352,7 +362,7 @@ mod tests {
                 {"role": "assistant", "tool_calls": [{
                     "id": "call_1",
                     "type": "function",
-                    "function": {"name": "flat", "arguments": null}
+                    "function": {"name": "flat", "arguments": ""}
                 }]}
             ],
             "tools": [
@@ -423,7 +433,7 @@ mod tests {
                 "call_id": null,
                 "id": "call_7",
                 "name": "run_check",
-                "arguments": null
+                "arguments": "   "
             }]
         });
 
@@ -465,5 +475,21 @@ mod tests {
             converted["choices"][0]["message"]["content"],
             "I cannot help with that."
         );
+    }
+
+    #[test]
+    fn parses_rfc3339_response_timestamp() {
+        let response = json!({
+            "id": "resp_timestamp",
+            "created_at": "2026-08-01T12:34:56Z",
+            "output": [{
+                "type": "message",
+                "content": [{"type": "output_text", "text": "ok"}]
+            }]
+        });
+
+        let converted = responses_response_to_openai_chat(&response, "muse").unwrap();
+
+        assert_eq!(converted["created"], 1_785_587_696_i64);
     }
 }

--- a/src/router/responses_protocol.rs
+++ b/src/router/responses_protocol.rs
@@ -184,6 +184,11 @@ pub(super) fn openai_chat_request_to_responses(request: &Value, model: &str) -> 
             body[key] = value.clone();
         }
     }
+    if let Some(reasoning) = request.get("reasoning") {
+        body["reasoning"] = reasoning.clone();
+    } else if let Some(reasoning_effort) = request.get("reasoning_effort") {
+        body["reasoning"] = json!({"effort": reasoning_effort});
+    }
     if let Some(tools) = request.get("tools").and_then(Value::as_array) {
         body["tools"] = Value::Array(tools.iter().filter_map(responses_tool).collect());
     }
@@ -380,7 +385,7 @@ pub(super) fn responses_response_to_openai_chat(response: &Value, model: &str) -
         openai_usage["completion_tokens_details"] = details.clone();
     }
 
-    Ok(json!({
+    let mut converted = json!({
         "id": response.get("id").and_then(Value::as_str).unwrap_or("resp_unknown"),
         "object": "chat.completion",
         "created": response_created_at(response.get("created_at")),
@@ -391,7 +396,14 @@ pub(super) fn responses_response_to_openai_chat(response: &Value, model: &str) -
             "finish_reason": finish_reason
         }],
         "usage": openai_usage
-    }))
+    });
+    if let Some(status) = response.get("status").and_then(Value::as_str) {
+        converted["response_status"] = Value::String(status.to_string());
+    }
+    if let Some(incomplete_details) = response.get("incomplete_details") {
+        converted["incomplete_details"] = incomplete_details.clone();
+    }
+    Ok(converted)
 }
 
 #[cfg(test)]
@@ -404,6 +416,7 @@ mod tests {
             "model": "meta-muse,muse-spark-1.1",
             "messages": [{"role": "user", "content": "Write a haiku"}],
             "max_completion_tokens": 64,
+            "reasoning_effort": "high",
             "stream": true
         });
 
@@ -412,6 +425,7 @@ mod tests {
         assert_eq!(converted["model"], "muse-spark-1.1");
         assert_eq!(converted["stream"], false);
         assert_eq!(converted["max_output_tokens"], 64);
+        assert_eq!(converted["reasoning"], json!({"effort": "high"}));
         assert_eq!(converted["input"][0]["role"], "user");
         assert_eq!(converted["input"][0]["content"][0]["type"], "input_text");
         assert_eq!(converted["input"][0]["content"][0]["text"], "Write a haiku");
@@ -583,6 +597,11 @@ mod tests {
 
         assert_eq!(converted["created"], 42);
         assert_eq!(converted["choices"][0]["finish_reason"], "content_filter");
+        assert_eq!(converted["response_status"], "incomplete");
+        assert_eq!(
+            converted["incomplete_details"],
+            json!({"reason": "content_filter"})
+        );
         assert!(converted["choices"][0]["message"]["content"].is_null());
         assert_eq!(
             converted["choices"][0]["message"]["refusal"],

--- a/src/router/responses_protocol.rs
+++ b/src/router/responses_protocol.rs
@@ -128,6 +128,19 @@ fn responses_tool_choice(choice: &Value) -> Option<Value> {
     Some(Value::Object(converted))
 }
 
+fn responses_text_from_chat_format(response_format: &Value) -> Option<Value> {
+    let object = response_format.as_object()?;
+    let format_type = object.get("type")?.as_str()?;
+    let format = if format_type == "json_schema" {
+        let mut format = object.get("json_schema")?.as_object()?.clone();
+        format.insert("type".to_string(), Value::String("json_schema".to_string()));
+        Value::Object(format)
+    } else {
+        response_format.clone()
+    };
+    Some(json!({"format": format}))
+}
+
 /// Convert an OpenAI Chat Completions request into an upstream Responses request.
 pub(super) fn openai_chat_request_to_responses(request: &Value, model: &str) -> Result<Value> {
     if let Some(native_request) = request
@@ -208,6 +221,12 @@ pub(super) fn openai_chat_request_to_responses(request: &Value, model: &str) -> 
         if let Some(value) = request.get(key) {
             body[key] = value.clone();
         }
+    }
+    if let Some(text) = request
+        .get("response_format")
+        .and_then(responses_text_from_chat_format)
+    {
+        body["text"] = text;
     }
     if let Some(reasoning) = request.get("reasoning").filter(|value| !value.is_null()) {
         body["reasoning"] = reasoning.clone();
@@ -525,6 +544,43 @@ mod tests {
         let converted = openai_chat_request_to_responses(&request, "muse").unwrap();
 
         assert_eq!(converted["reasoning"], json!({"effort": "medium"}));
+    }
+
+    #[test]
+    fn maps_chat_json_schema_to_responses_text_format() {
+        let request = json!({
+            "messages": [{"role": "user", "content": "Return JSON"}],
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "answer",
+                    "schema": {
+                        "type": "object",
+                        "properties": {"answer": {"type": "string"}},
+                        "required": ["answer"],
+                        "additionalProperties": false
+                    },
+                    "strict": true
+                }
+            }
+        });
+
+        let converted = openai_chat_request_to_responses(&request, "muse").unwrap();
+
+        assert_eq!(
+            converted["text"]["format"],
+            json!({
+                "type": "json_schema",
+                "name": "answer",
+                "schema": {
+                    "type": "object",
+                    "properties": {"answer": {"type": "string"}},
+                    "required": ["answer"],
+                    "additionalProperties": false
+                },
+                "strict": true
+            })
+        );
     }
 
     #[test]

--- a/src/router/responses_protocol.rs
+++ b/src/router/responses_protocol.rs
@@ -230,6 +230,27 @@ fn response_text(response: &Value) -> String {
     }
 }
 
+fn response_reasoning_text(response: &Value) -> String {
+    let mut reasoning = String::new();
+    if let Some(output) = response.get("output").and_then(Value::as_array) {
+        for item in output {
+            if item.get("type").and_then(Value::as_str) != Some("reasoning") {
+                continue;
+            }
+            for field in ["summary", "content"] {
+                if let Some(parts) = item.get(field).and_then(Value::as_array) {
+                    for part in parts {
+                        if let Some(text) = part.get("text").and_then(Value::as_str) {
+                            reasoning.push_str(text);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    reasoning
+}
+
 fn response_tool_calls(response: &Value) -> Vec<Value> {
     response
         .get("output")
@@ -268,6 +289,7 @@ pub(super) fn responses_response_to_openai_chat(response: &Value, model: &str) -
         .and_then(Value::as_array)
         .ok_or_else(|| anyhow!("Responses provider payload is missing output"))?;
     let text = response_text(response);
+    let reasoning = response_reasoning_text(response);
     let tool_calls = response_tool_calls(response);
     if output.is_empty() && text.is_empty() && tool_calls.is_empty() {
         return Err(anyhow!("Responses provider returned no output items"));
@@ -279,6 +301,9 @@ pub(super) fn responses_response_to_openai_chat(response: &Value, model: &str) -
     });
     if !tool_calls.is_empty() {
         message["tool_calls"] = Value::Array(tool_calls.clone());
+    }
+    if !reasoning.is_empty() {
+        message["reasoning_content"] = Value::String(reasoning);
     }
     let incomplete_reason = response
         .get("incomplete_details")
@@ -404,11 +429,17 @@ mod tests {
             "error": null,
             "incomplete_details": null,
             "model": "muse-spark-1.1",
-            "output": [{
-                "type": "message",
-                "role": "assistant",
-                "content": [{"type": "output_text", "text": "AlphaHENG ready"}]
-            }],
+            "output": [
+                {
+                    "type": "reasoning",
+                    "summary": [{"type": "summary_text", "text": "Checked the route."}]
+                },
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "AlphaHENG ready"}]
+                }
+            ],
             "usage": {"input_tokens": 11, "output_tokens": 3, "total_tokens": 14}
         });
 
@@ -419,6 +450,10 @@ mod tests {
             "AlphaHENG ready"
         );
         assert_eq!(converted["choices"][0]["finish_reason"], "stop");
+        assert_eq!(
+            converted["choices"][0]["message"]["reasoning_content"],
+            "Checked the route."
+        );
         assert_eq!(converted["usage"]["prompt_tokens"], 11);
         assert_eq!(converted["usage"]["completion_tokens"], 3);
     }

--- a/src/router/responses_protocol.rs
+++ b/src/router/responses_protocol.rs
@@ -239,7 +239,10 @@ pub(super) fn openai_chat_request_to_responses(request: &Value, model: &str) -> 
             .ok_or_else(|| anyhow!("OpenAI reasoning_effort must be a string"))?;
         body["reasoning"] = json!({"effort": reasoning_effort});
     }
-    if let Some(previous_response_id) = request.get("previous_response_id") {
+    if let Some(previous_response_id) = request
+        .get("previous_response_id")
+        .filter(|value| !value.is_null())
+    {
         body["previous_response_id"] = previous_response_id.clone();
     }
     if let Some(tools) = request.get("tools").and_then(Value::as_array) {
@@ -373,10 +376,12 @@ fn response_tool_calls(response: &Value) -> Vec<Value> {
 pub(super) fn responses_response_to_openai_chat(
     response: &Value,
     model: &str,
-    allow_empty_output: bool,
+    preserve_native_envelope: bool,
 ) -> Result<Value> {
-    if let Some(error) = response.get("error").filter(|error| !error.is_null()) {
-        return Err(anyhow!("Responses provider returned an error: {error}"));
+    if !preserve_native_envelope {
+        if let Some(error) = response.get("error").filter(|error| !error.is_null()) {
+            return Err(anyhow!("Responses provider returned an error: {error}"));
+        }
     }
     let output = response
         .get("output")
@@ -386,7 +391,7 @@ pub(super) fn responses_response_to_openai_chat(
     let refusal = response_refusal_text(response);
     let reasoning = response_reasoning_text(response);
     let tool_calls = response_tool_calls(response);
-    if !allow_empty_output
+    if !preserve_native_envelope
         && output.is_empty()
         && text.is_empty()
         && refusal.is_empty()
@@ -630,13 +635,15 @@ mod tests {
         let request = json!({
             "messages": [{"role": "user", "content": "Think"}],
             "tools": [null, 7, {}, {"type": ""}, {"type": "web_search"}],
-            "tool_choice": null
+            "tool_choice": null,
+            "previous_response_id": null
         });
 
         let converted = openai_chat_request_to_responses(&request, "muse").unwrap();
 
         assert_eq!(converted["tools"], json!([{"type": "web_search"}]));
         assert!(converted.get("tool_choice").is_none());
+        assert!(converted.get("previous_response_id").is_none());
     }
 
     #[test]
@@ -824,5 +831,25 @@ mod tests {
         let converted = responses_response_to_openai_chat(&response, "muse", true).unwrap();
         assert_eq!(converted["response_status"], "queued");
         assert!(converted["choices"][0]["message"]["content"].is_null());
+    }
+
+    #[test]
+    fn allows_failed_envelope_only_for_native_responses_passthrough() {
+        let response = json!({
+            "id": "resp_failed",
+            "object": "response",
+            "status": "failed",
+            "model": "muse",
+            "error": {"code": "upstream_error", "message": "failed"},
+            "output": []
+        });
+
+        let error = responses_response_to_openai_chat(&response, "muse", false).unwrap_err();
+        assert!(error
+            .to_string()
+            .starts_with("Responses provider returned an error:"));
+
+        let converted = responses_response_to_openai_chat(&response, "muse", true).unwrap();
+        assert_eq!(converted["response_status"], "failed");
     }
 }

--- a/src/router/responses_protocol.rs
+++ b/src/router/responses_protocol.rs
@@ -231,7 +231,7 @@ fn response_text(response: &Value) -> String {
 }
 
 fn response_reasoning_text(response: &Value) -> String {
-    let mut reasoning = String::new();
+    let mut reasoning = Vec::new();
     if let Some(output) = response.get("output").and_then(Value::as_array) {
         for item in output {
             if item.get("type").and_then(Value::as_str) != Some("reasoning") {
@@ -241,14 +241,14 @@ fn response_reasoning_text(response: &Value) -> String {
                 if let Some(parts) = item.get(field).and_then(Value::as_array) {
                     for part in parts {
                         if let Some(text) = part.get("text").and_then(Value::as_str) {
-                            reasoning.push_str(text);
+                            reasoning.push(text);
                         }
                     }
                 }
             }
         }
     }
-    reasoning
+    reasoning.join("\n\n")
 }
 
 fn response_tool_calls(response: &Value) -> Vec<Value> {
@@ -432,7 +432,10 @@ mod tests {
             "output": [
                 {
                     "type": "reasoning",
-                    "summary": [{"type": "summary_text", "text": "Checked the route."}]
+                    "summary": [
+                        {"type": "summary_text", "text": "Checked the route."},
+                        {"type": "summary_text", "text": "Selected Muse."}
+                    ]
                 },
                 {
                     "type": "message",
@@ -452,7 +455,7 @@ mod tests {
         assert_eq!(converted["choices"][0]["finish_reason"], "stop");
         assert_eq!(
             converted["choices"][0]["message"]["reasoning_content"],
-            "Checked the route."
+            "Checked the route.\n\nSelected Muse."
         );
         assert_eq!(converted["usage"]["prompt_tokens"], 11);
         assert_eq!(converted["usage"]["completion_tokens"], 3);

--- a/src/router/responses_protocol.rs
+++ b/src/router/responses_protocol.rs
@@ -370,7 +370,11 @@ fn response_tool_calls(response: &Value) -> Vec<Value> {
 }
 
 /// Convert a completed Responses API payload to OpenAI Chat Completions JSON.
-pub(super) fn responses_response_to_openai_chat(response: &Value, model: &str) -> Result<Value> {
+pub(super) fn responses_response_to_openai_chat(
+    response: &Value,
+    model: &str,
+    allow_empty_output: bool,
+) -> Result<Value> {
     if let Some(error) = response.get("error").filter(|error| !error.is_null()) {
         return Err(anyhow!("Responses provider returned an error: {error}"));
     }
@@ -382,7 +386,12 @@ pub(super) fn responses_response_to_openai_chat(response: &Value, model: &str) -
     let refusal = response_refusal_text(response);
     let reasoning = response_reasoning_text(response);
     let tool_calls = response_tool_calls(response);
-    if output.is_empty() && text.is_empty() && refusal.is_empty() && tool_calls.is_empty() {
+    if !allow_empty_output
+        && output.is_empty()
+        && text.is_empty()
+        && refusal.is_empty()
+        && tool_calls.is_empty()
+    {
         return Err(anyhow!("Responses provider returned no output items"));
     }
 
@@ -695,7 +704,8 @@ mod tests {
             }
         });
 
-        let converted = responses_response_to_openai_chat(&response, "muse-spark-1.1").unwrap();
+        let converted =
+            responses_response_to_openai_chat(&response, "muse-spark-1.1", false).unwrap();
 
         assert_eq!(
             converted["choices"][0]["message"]["content"],
@@ -732,7 +742,8 @@ mod tests {
             }]
         });
 
-        let converted = responses_response_to_openai_chat(&response, "muse-spark-1.1").unwrap();
+        let converted =
+            responses_response_to_openai_chat(&response, "muse-spark-1.1", false).unwrap();
 
         assert_eq!(converted["choices"][0]["finish_reason"], "tool_calls");
         assert_eq!(
@@ -762,7 +773,7 @@ mod tests {
             }]
         });
 
-        let converted = responses_response_to_openai_chat(&response, "muse").unwrap();
+        let converted = responses_response_to_openai_chat(&response, "muse", false).unwrap();
 
         assert_eq!(converted["created"], 42);
         assert_eq!(converted["choices"][0]["finish_reason"], "content_filter");
@@ -789,8 +800,29 @@ mod tests {
             }]
         });
 
-        let converted = responses_response_to_openai_chat(&response, "muse").unwrap();
+        let converted = responses_response_to_openai_chat(&response, "muse", false).unwrap();
 
         assert_eq!(converted["created"], 1_785_587_696_i64);
+    }
+
+    #[test]
+    fn allows_empty_output_only_for_native_responses_passthrough() {
+        let response = json!({
+            "id": "resp_background",
+            "object": "response",
+            "status": "queued",
+            "model": "muse",
+            "output": []
+        });
+
+        let error = responses_response_to_openai_chat(&response, "muse", false).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "Responses provider returned no output items"
+        );
+
+        let converted = responses_response_to_openai_chat(&response, "muse", true).unwrap();
+        assert_eq!(converted["response_status"], "queued");
+        assert!(converted["choices"][0]["message"]["content"].is_null());
     }
 }

--- a/src/router/responses_protocol.rs
+++ b/src/router/responses_protocol.rs
@@ -329,6 +329,20 @@ pub(super) fn responses_response_to_openai_chat(response: &Value, model: &str) -
         .get("output_tokens")
         .and_then(Value::as_u64)
         .unwrap_or_default();
+    let mut openai_usage = json!({
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "total_tokens": usage
+            .get("total_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(prompt_tokens.saturating_add(completion_tokens))
+    });
+    if let Some(details) = usage.get("input_tokens_details") {
+        openai_usage["prompt_tokens_details"] = details.clone();
+    }
+    if let Some(details) = usage.get("output_tokens_details") {
+        openai_usage["completion_tokens_details"] = details.clone();
+    }
 
     Ok(json!({
         "id": response.get("id").and_then(Value::as_str).unwrap_or("resp_unknown"),
@@ -340,14 +354,7 @@ pub(super) fn responses_response_to_openai_chat(response: &Value, model: &str) -
             "message": message,
             "finish_reason": finish_reason
         }],
-        "usage": {
-            "prompt_tokens": prompt_tokens,
-            "completion_tokens": completion_tokens,
-            "total_tokens": usage
-                .get("total_tokens")
-                .and_then(Value::as_u64)
-                .unwrap_or(prompt_tokens.saturating_add(completion_tokens))
-        }
+        "usage": openai_usage
     }))
 }
 
@@ -443,7 +450,13 @@ mod tests {
                     "content": [{"type": "output_text", "text": "AlphaHENG ready"}]
                 }
             ],
-            "usage": {"input_tokens": 11, "output_tokens": 3, "total_tokens": 14}
+            "usage": {
+                "input_tokens": 11,
+                "input_tokens_details": {"cached_tokens": 4},
+                "output_tokens": 3,
+                "output_tokens_details": {"reasoning_tokens": 2},
+                "total_tokens": 14
+            }
         });
 
         let converted = responses_response_to_openai_chat(&response, "muse-spark-1.1").unwrap();
@@ -459,6 +472,14 @@ mod tests {
         );
         assert_eq!(converted["usage"]["prompt_tokens"], 11);
         assert_eq!(converted["usage"]["completion_tokens"], 3);
+        assert_eq!(
+            converted["usage"]["prompt_tokens_details"]["cached_tokens"],
+            4
+        );
+        assert_eq!(
+            converted["usage"]["completion_tokens_details"]["reasoning_tokens"],
+            2
+        );
     }
 
     #[test]

--- a/src/router/responses_protocol.rs
+++ b/src/router/responses_protocol.rs
@@ -48,6 +48,7 @@ fn response_content_blocks(content: &Value, role: &str) -> Vec<Value> {
         "input_text"
     };
     match content {
+        Value::String(text) if text.is_empty() => Vec::new(),
         Value::String(text) => vec![json!({"type": text_type, "text": text})],
         Value::Array(items) => items
             .iter()
@@ -56,7 +57,8 @@ fn response_content_blocks(content: &Value, role: &str) -> Vec<Value> {
                 match item_type {
                     "text" | "input_text" | "output_text" => item
                         .get("text")
-                        .cloned()
+                        .and_then(Value::as_str)
+                        .filter(|text| !text.is_empty())
                         .map(|text| json!({"type": text_type, "text": text})),
                     "image_url" => item
                         .get("image_url")
@@ -391,7 +393,7 @@ mod tests {
                     {"type": "image_url", "image_url": {}},
                     {"type": "image_url", "image_url": {"url": "https://example.test/a.png"}}
                 ]},
-                {"role": "assistant", "tool_calls": [{
+                {"role": "assistant", "content": "", "tool_calls": [{
                     "id": "call_1",
                     "type": "function",
                     "function": {"name": "flat", "arguments": ""}

--- a/src/router/responses_protocol.rs
+++ b/src/router/responses_protocol.rs
@@ -64,14 +64,17 @@ fn response_content_blocks(content: &Value, role: &str) -> Result<Vec<Value>> {
                         })?;
                         (!text.is_empty()).then(|| json!({"type": text_type, "text": text}))
                     }
-                    "image_url" => item
-                        .get("image_url")
-                        .and_then(|image| {
-                            image
-                                .as_str()
-                                .or_else(|| image.get("url").and_then(Value::as_str))
-                        })
-                        .map(|image_url| json!({"type": "input_image", "image_url": image_url})),
+                    "image_url" => item.get("image_url").and_then(|image| {
+                        let image_url = image
+                            .as_str()
+                            .or_else(|| image.get("url").and_then(Value::as_str))?;
+                        let mut block = json!({"type": "input_image", "image_url": image_url});
+                        if let Some(detail) = image.get("detail").filter(|detail| !detail.is_null())
+                        {
+                            block["detail"] = detail.clone();
+                        }
+                        Some(block)
+                    }),
                     "input_image" => Some(item.clone()),
                     _ => None,
                 };
@@ -509,7 +512,10 @@ mod tests {
                 {"role": "system", "content": "Be concise"},
                 {"role": "user", "content": [
                     {"type": "image_url", "image_url": {}},
-                    {"type": "image_url", "image_url": {"url": "https://example.test/a.png"}}
+                    {"type": "image_url", "image_url": {
+                        "url": "https://example.test/a.png",
+                        "detail": "high"
+                    }}
                 ]},
                 {"role": "assistant", "content": "", "tool_calls": [{
                     "id": "call_1",
@@ -536,6 +542,7 @@ mod tests {
             converted["input"][1]["content"][0]["image_url"],
             "https://example.test/a.png"
         );
+        assert_eq!(converted["input"][1]["content"][0]["detail"], "high");
         assert_eq!(converted["tools"].as_array().unwrap().len(), 3);
         assert_eq!(converted["tools"][0]["name"], "flat");
         assert_eq!(converted["tools"][1]["name"], "nested");

--- a/src/router/responses_protocol.rs
+++ b/src/router/responses_protocol.rs
@@ -88,7 +88,7 @@ fn response_content_blocks(content: &Value, role: &str) -> Result<Vec<Value>> {
 
 fn responses_tool(tool: &Value) -> Option<Value> {
     if tool.get("type").and_then(Value::as_str) != Some("function") {
-        return None;
+        return Some(tool.clone());
     }
     if tool.get("name").and_then(Value::as_str).is_some() {
         return Some(tool.clone());
@@ -105,7 +105,7 @@ fn responses_tool_choice(choice: &Value) -> Option<Value> {
         return Some(choice.clone());
     }
     if choice.get("type").and_then(Value::as_str) != Some("function") {
-        return None;
+        return Some(choice.clone());
     }
     if choice.get("name").and_then(Value::as_str).is_some() {
         return Some(choice.clone());
@@ -184,9 +184,19 @@ pub(super) fn openai_chat_request_to_responses(request: &Value, model: &str) -> 
             body[key] = value.clone();
         }
     }
-    if let Some(reasoning) = request.get("reasoning") {
+    if let Some(reasoning) = request
+        .get(super::RESPONSES_REASONING_PASSTHROUGH_KEY)
+        .or_else(|| request.get("reasoning"))
+        .filter(|value| !value.is_null())
+    {
         body["reasoning"] = reasoning.clone();
-    } else if let Some(reasoning_effort) = request.get("reasoning_effort") {
+    } else if let Some(reasoning_effort) = request
+        .get("reasoning_effort")
+        .filter(|value| !value.is_null())
+    {
+        let reasoning_effort = reasoning_effort
+            .as_str()
+            .ok_or_else(|| anyhow!("OpenAI reasoning_effort must be a string"))?;
         body["reasoning"] = json!({"effort": reasoning_effort});
     }
     if let Some(previous_response_id) = request.get("previous_response_id") {
@@ -403,7 +413,10 @@ pub(super) fn responses_response_to_openai_chat(response: &Value, model: &str) -
     if let Some(status) = response.get("status").and_then(Value::as_str) {
         converted["response_status"] = Value::String(status.to_string());
     }
-    if let Some(incomplete_details) = response.get("incomplete_details") {
+    if let Some(incomplete_details) = response
+        .get("incomplete_details")
+        .filter(|value| !value.is_null())
+    {
         converted["incomplete_details"] = incomplete_details.clone();
     }
     Ok(converted)
@@ -469,14 +482,63 @@ mod tests {
             converted["input"][1]["content"][0]["image_url"],
             "https://example.test/a.png"
         );
-        assert_eq!(converted["tools"].as_array().unwrap().len(), 2);
+        assert_eq!(converted["tools"].as_array().unwrap().len(), 3);
         assert_eq!(converted["tools"][0]["name"], "flat");
         assert_eq!(converted["tools"][1]["name"], "nested");
+        assert_eq!(converted["tools"][2]["type"], "code_interpreter");
         assert_eq!(
             converted["tool_choice"],
             json!({"type": "function", "name": "nested"})
         );
         assert_eq!(converted["input"][2]["arguments"], "{}");
+    }
+
+    #[test]
+    fn reasoning_null_falls_back_to_valid_effort() {
+        let request = json!({
+            "messages": [{"role": "user", "content": "Think"}],
+            "reasoning": null,
+            "reasoning_effort": "medium"
+        });
+
+        let converted = openai_chat_request_to_responses(&request, "muse").unwrap();
+
+        assert_eq!(converted["reasoning"], json!({"effort": "medium"}));
+    }
+
+    #[test]
+    fn preserves_internal_responses_reasoning_object() {
+        let mut request = json!({
+            "messages": [{"role": "user", "content": "Think"}],
+            "reasoning_effort": "high"
+        });
+        request[super::super::RESPONSES_REASONING_PASSTHROUGH_KEY] =
+            json!({"effort": "high", "summary": "detailed"});
+
+        let converted = openai_chat_request_to_responses(&request, "muse").unwrap();
+
+        assert_eq!(
+            converted["reasoning"],
+            json!({"effort": "high", "summary": "detailed"})
+        );
+        assert!(converted
+            .get(super::super::RESPONSES_REASONING_PASSTHROUGH_KEY)
+            .is_none());
+    }
+
+    #[test]
+    fn rejects_non_string_reasoning_effort() {
+        let request = json!({
+            "messages": [{"role": "user", "content": "Think"}],
+            "reasoning_effort": {"unexpected": true}
+        });
+
+        let error = openai_chat_request_to_responses(&request, "muse").unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "OpenAI reasoning_effort must be a string"
+        );
     }
 
     #[test]

--- a/src/router/responses_protocol.rs
+++ b/src/router/responses_protocol.rs
@@ -189,6 +189,9 @@ pub(super) fn openai_chat_request_to_responses(request: &Value, model: &str) -> 
     } else if let Some(reasoning_effort) = request.get("reasoning_effort") {
         body["reasoning"] = json!({"effort": reasoning_effort});
     }
+    if let Some(previous_response_id) = request.get("previous_response_id") {
+        body["previous_response_id"] = previous_response_id.clone();
+    }
     if let Some(tools) = request.get("tools").and_then(Value::as_array) {
         body["tools"] = Value::Array(tools.iter().filter_map(responses_tool).collect());
     }

--- a/src/router/responses_protocol.rs
+++ b/src/router/responses_protocol.rs
@@ -35,8 +35,11 @@ fn response_content_blocks(content: &Value, role: &str) -> Vec<Value> {
                         .map(|text| json!({"type": text_type, "text": text})),
                     "image_url" => item
                         .get("image_url")
-                        .and_then(|image| image.get("url").or(Some(image)))
-                        .cloned()
+                        .and_then(|image| {
+                            image
+                                .as_str()
+                                .or_else(|| image.get("url").and_then(Value::as_str))
+                        })
                         .map(|image_url| json!({"type": "input_image", "image_url": image_url})),
                     "input_image" => Some(item.clone()),
                     _ => None,
@@ -50,24 +53,34 @@ fn response_content_blocks(content: &Value, role: &str) -> Vec<Value> {
 
 fn responses_tool(tool: &Value) -> Option<Value> {
     if tool.get("type").and_then(Value::as_str) != Some("function") {
+        return None;
+    }
+    if tool.get("name").and_then(Value::as_str).is_some() {
         return Some(tool.clone());
     }
     let function = tool.get("function")?.as_object()?;
+    function.get("name")?.as_str()?;
     let mut converted = function.clone();
     converted.insert("type".to_string(), Value::String("function".to_string()));
     Some(Value::Object(converted))
 }
 
-fn responses_tool_choice(choice: &Value) -> Value {
-    let Some(function) = choice.get("function").and_then(Value::as_object) else {
-        return choice.clone();
-    };
+fn responses_tool_choice(choice: &Value) -> Option<Value> {
+    if choice.is_string() {
+        return Some(choice.clone());
+    }
+    if choice.get("type").and_then(Value::as_str) != Some("function") {
+        return None;
+    }
+    if choice.get("name").and_then(Value::as_str).is_some() {
+        return Some(choice.clone());
+    }
+    let function = choice.get("function").and_then(Value::as_object)?;
+    let name = function.get("name")?.as_str()?;
     let mut converted = Map::new();
     converted.insert("type".to_string(), Value::String("function".to_string()));
-    if let Some(name) = function.get("name") {
-        converted.insert("name".to_string(), name.clone());
-    }
-    Value::Object(converted)
+    converted.insert("name".to_string(), Value::String(name.to_string()));
+    Some(Value::Object(converted))
 }
 
 /// Convert an OpenAI Chat Completions request into an upstream Responses request.
@@ -82,6 +95,7 @@ pub(super) fn openai_chat_request_to_responses(request: &Value, model: &str) -> 
         let role = message
             .get("role")
             .and_then(Value::as_str)
+            .map(|role| if role == "system" { "developer" } else { role })
             .unwrap_or("user");
         if role == "tool" {
             input.push(json!({
@@ -118,6 +132,7 @@ pub(super) fn openai_chat_request_to_responses(request: &Value, model: &str) -> 
                         .unwrap_or("function"),
                     "arguments": function
                         .get("arguments")
+                        .filter(|value| !value.is_null())
                         .map(content_text)
                         .unwrap_or_else(|| "{}".to_string())
                 }));
@@ -141,7 +156,9 @@ pub(super) fn openai_chat_request_to_responses(request: &Value, model: &str) -> 
         body["tools"] = Value::Array(tools.iter().filter_map(responses_tool).collect());
     }
     if let Some(tool_choice) = request.get("tool_choice") {
-        body["tool_choice"] = responses_tool_choice(tool_choice);
+        if let Some(tool_choice) = responses_tool_choice(tool_choice) {
+            body["tool_choice"] = tool_choice;
+        }
     }
     Ok(body)
 }
@@ -150,6 +167,16 @@ fn response_text(response: &Value) -> String {
     let mut text = String::new();
     if let Some(output) = response.get("output").and_then(Value::as_array) {
         for item in output {
+            if item.get("type").and_then(Value::as_str) == Some("refusal") {
+                if let Some(value) = item
+                    .get("refusal")
+                    .or_else(|| item.get("text"))
+                    .and_then(Value::as_str)
+                {
+                    text.push_str(value);
+                }
+                continue;
+            }
             if item.get("type").and_then(Value::as_str) != Some("message") {
                 continue;
             }
@@ -157,9 +184,13 @@ fn response_text(response: &Value) -> String {
                 for part in content {
                     if matches!(
                         part.get("type").and_then(Value::as_str),
-                        Some("output_text" | "text")
+                        Some("output_text" | "text" | "refusal")
                     ) {
-                        if let Some(value) = part.get("text").and_then(Value::as_str) {
+                        if let Some(value) = part
+                            .get("text")
+                            .or_else(|| part.get("refusal"))
+                            .and_then(Value::as_str)
+                        {
                             text.push_str(value);
                         }
                     }
@@ -188,13 +219,14 @@ fn response_tool_calls(response: &Value) -> Vec<Value> {
         .map(|item| {
             let arguments = item
                 .get("arguments")
+                .filter(|value| !value.is_null())
                 .map(content_text)
                 .unwrap_or_else(|| "{}".to_string());
             json!({
                 "id": item
                     .get("call_id")
-                    .or_else(|| item.get("id"))
                     .and_then(Value::as_str)
+                    .or_else(|| item.get("id").and_then(Value::as_str))
                     .unwrap_or("call_unknown"),
                 "type": "function",
                 "function": {
@@ -211,7 +243,7 @@ fn response_tool_calls(response: &Value) -> Vec<Value> {
 
 /// Convert a completed Responses API payload to OpenAI Chat Completions JSON.
 pub(super) fn responses_response_to_openai_chat(response: &Value, model: &str) -> Result<Value> {
-    if let Some(error) = response.get("error") {
+    if let Some(error) = response.get("error").filter(|error| !error.is_null()) {
         return Err(anyhow!("Responses provider returned an error: {error}"));
     }
     let output = response
@@ -237,8 +269,12 @@ pub(super) fn responses_response_to_openai_chat(response: &Value, model: &str) -
         .and_then(Value::as_str);
     let finish_reason = if !tool_calls.is_empty() {
         "tool_calls"
-    } else if incomplete_reason == Some("max_output_tokens") {
-        "length"
+    } else if let Some(reason) = incomplete_reason {
+        match reason {
+            "max_output_tokens" => "length",
+            "content_filter" => "content_filter",
+            _ => "stop",
+        }
     } else {
         "stop"
     };
@@ -255,7 +291,14 @@ pub(super) fn responses_response_to_openai_chat(response: &Value, model: &str) -
     Ok(json!({
         "id": response.get("id").and_then(Value::as_str).unwrap_or("resp_unknown"),
         "object": "chat.completion",
-        "created": response.get("created_at").and_then(Value::as_i64).unwrap_or_default(),
+        "created": response
+            .get("created_at")
+            .and_then(|created| {
+                created
+                    .as_i64()
+                    .or_else(|| created.as_str().and_then(|value| value.parse().ok()))
+            })
+            .unwrap_or_default(),
         "model": response.get("model").and_then(Value::as_str).unwrap_or(model),
         "choices": [{
             "index": 0,
@@ -298,12 +341,58 @@ mod tests {
     }
 
     #[test]
+    fn normalizes_system_role_and_supported_tools() {
+        let request = json!({
+            "messages": [
+                {"role": "system", "content": "Be concise"},
+                {"role": "user", "content": [
+                    {"type": "image_url", "image_url": {}},
+                    {"type": "image_url", "image_url": {"url": "https://example.test/a.png"}}
+                ]},
+                {"role": "assistant", "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "flat", "arguments": null}
+                }]}
+            ],
+            "tools": [
+                {"type": "function", "name": "flat", "parameters": {"type": "object"}},
+                {"type": "function", "function": {"name": "nested", "parameters": {}}},
+                {"type": "code_interpreter"}
+            ],
+            "tool_choice": {"type": "function", "function": {"name": "nested"}}
+        });
+
+        let converted = openai_chat_request_to_responses(&request, "muse").unwrap();
+
+        assert_eq!(converted["input"][0]["role"], "developer");
+        assert_eq!(
+            converted["input"][1]["content"].as_array().unwrap().len(),
+            1
+        );
+        assert_eq!(
+            converted["input"][1]["content"][0]["image_url"],
+            "https://example.test/a.png"
+        );
+        assert_eq!(converted["tools"].as_array().unwrap().len(), 2);
+        assert_eq!(converted["tools"][0]["name"], "flat");
+        assert_eq!(converted["tools"][1]["name"], "nested");
+        assert_eq!(
+            converted["tool_choice"],
+            json!({"type": "function", "name": "nested"})
+        );
+        assert_eq!(converted["input"][2]["arguments"], "{}");
+    }
+
+    #[test]
     fn converts_responses_text_and_usage_to_chat_shape() {
         let response = json!({
             "id": "resp_meta_1",
             "object": "response",
             "created_at": 42,
             "status": "completed",
+            "error": null,
+            "incomplete_details": null,
             "model": "muse-spark-1.1",
             "output": [{
                 "type": "message",
@@ -331,9 +420,10 @@ mod tests {
             "model": "muse-spark-1.1",
             "output": [{
                 "type": "function_call",
-                "call_id": "call_7",
+                "call_id": null,
+                "id": "call_7",
                 "name": "run_check",
-                "arguments": "{\"target\":\"tests\"}"
+                "arguments": null
             }]
         });
 
@@ -347,6 +437,33 @@ mod tests {
         assert_eq!(
             converted["choices"][0]["message"]["tool_calls"][0]["function"]["name"],
             "run_check"
+        );
+        assert_eq!(
+            converted["choices"][0]["message"]["tool_calls"][0]["function"]["arguments"],
+            "{}"
+        );
+    }
+
+    #[test]
+    fn preserves_refusal_text_and_content_filter_reason() {
+        let response = json!({
+            "id": "resp_refusal",
+            "created_at": "42",
+            "status": "incomplete",
+            "incomplete_details": {"reason": "content_filter"},
+            "output": [{
+                "type": "message",
+                "content": [{"type": "refusal", "refusal": "I cannot help with that."}]
+            }]
+        });
+
+        let converted = responses_response_to_openai_chat(&response, "muse").unwrap();
+
+        assert_eq!(converted["created"], 42);
+        assert_eq!(converted["choices"][0]["finish_reason"], "content_filter");
+        assert_eq!(
+            converted["choices"][0]["message"]["content"],
+            "I cannot help with that."
         );
     }
 }

--- a/src/router/streaming.rs
+++ b/src/router/streaming.rs
@@ -577,14 +577,20 @@ pub async fn stream_anthropic_response_with_tracking(
 /// Emit a complete Anthropic response as a sequence of SSE events.
 ///
 /// Used when `forceNonStreaming` is true but the client requested `stream: true`.
-fn emit_anthropic_sse_events(resp: &AnthropicResponse) -> Vec<String> {
+fn emit_anthropic_sse_events(
+    resp: &AnthropicResponse,
+    include_unsigned_reasoning: bool,
+) -> Vec<String> {
     let mut events = Vec::new();
-    let reasoning = resp.reasoning_content.as_deref().filter(|_| {
-        !resp
-            .content
-            .iter()
-            .any(|block| matches!(block, AnthropicContentBlock::Thinking { .. }))
-    });
+    let reasoning = include_unsigned_reasoning
+        .then_some(resp.reasoning_content.as_deref())
+        .flatten()
+        .filter(|_| {
+            !resp
+                .content
+                .iter()
+                .any(|block| matches!(block, AnthropicContentBlock::Thinking { .. }))
+        });
     let reasoning_offset = usize::from(reasoning.is_some());
 
     // message_start
@@ -756,7 +762,10 @@ fn emit_anthropic_sse_events(resp: &AnthropicResponse) -> Vec<String> {
 /// Reads the response body, parses it as an `AnthropicResponse`, and re-emits it
 /// as SSE events that Claude CLI can parse. Falls through to the original response
 /// if parsing fails.
-pub(super) async fn wrap_json_response_as_sse(response: Response) -> Response {
+pub(super) async fn wrap_json_response_as_sse(
+    response: Response,
+    include_unsigned_reasoning: bool,
+) -> Response {
     let (mut parts, body) = response.into_parts();
 
     // Only wrap successful JSON responses
@@ -777,7 +786,7 @@ pub(super) async fn wrap_json_response_as_sse(response: Response) -> Response {
 
     // Try to parse as AnthropicResponse
     if let Ok(anthropic_resp) = serde_json::from_slice::<AnthropicResponse>(&bytes) {
-        let sse_events = emit_anthropic_sse_events(&anthropic_resp);
+        let sse_events = emit_anthropic_sse_events(&anthropic_resp, include_unsigned_reasoning);
         let sse_body = sse_events.join("");
         parts.headers.insert(
             axum::http::header::CONTENT_TYPE,
@@ -830,7 +839,7 @@ mod tests {
                 .insert(name, axum::http::HeaderValue::from_str(value).unwrap());
         }
 
-        let rewritten = wrap_json_response_as_sse(response).await;
+        let rewritten = wrap_json_response_as_sse(response, false).await;
 
         assert_eq!(
             rewritten.headers().get(axum::http::header::CONTENT_TYPE),
@@ -873,7 +882,7 @@ mod tests {
             reasoning_content: None,
         };
 
-        let events = emit_anthropic_sse_events(&resp);
+        let events = emit_anthropic_sse_events(&resp, true);
         let joined = events.join("");
 
         // Must contain message_start
@@ -928,7 +937,7 @@ mod tests {
             reasoning_content: None,
         };
 
-        let events = emit_anthropic_sse_events(&resp);
+        let events = emit_anthropic_sse_events(&resp, true);
         let joined = events.join("");
 
         assert!(joined.contains("thinking_delta"), "missing thinking_delta");
@@ -944,6 +953,34 @@ mod tests {
         assert!(joined.contains("text_delta"), "missing text_delta");
         assert!(joined.contains("\"cache_read_input_tokens\":7"));
         assert!(joined.contains("\"reasoning_tokens\":11"));
+    }
+
+    #[test]
+    fn unsigned_reasoning_is_only_emitted_for_openai_adapters() {
+        let resp = AnthropicResponse {
+            id: "msg_unsigned".to_string(),
+            response_type: "message".to_string(),
+            role: "assistant".to_string(),
+            content: vec![AnthropicContentBlock::Text {
+                text: "answer".to_string(),
+            }],
+            model: "responses-model".to_string(),
+            stop_reason: Some("end_turn".to_string()),
+            usage: AnthropicUsage {
+                input_tokens: 3,
+                output_tokens: 2,
+                ..Default::default()
+            },
+            reasoning_content: Some("unsigned summary".to_string()),
+        };
+
+        let native_events = emit_anthropic_sse_events(&resp, false).join("");
+        assert!(!native_events.contains("thinking_delta"));
+        assert!(!native_events.contains("unsigned summary"));
+
+        let adapter_events = emit_anthropic_sse_events(&resp, true).join("");
+        assert!(adapter_events.contains("thinking_delta"));
+        assert!(adapter_events.contains("unsigned summary"));
     }
 
     #[test]
@@ -977,7 +1014,7 @@ mod tests {
             reasoning_content: None,
         };
 
-        let events = emit_anthropic_sse_events(&resp);
+        let events = emit_anthropic_sse_events(&resp, true);
         let joined = events.join("");
 
         // Both tool IDs must be present

--- a/src/router/streaming.rs
+++ b/src/router/streaming.rs
@@ -602,21 +602,28 @@ fn emit_anthropic_sse_events(
     if let Some(cached_tokens) = resp.usage.cache_read_input_tokens {
         start_usage["cache_read_input_tokens"] = serde_json::json!(cached_tokens);
     }
+    let mut message = serde_json::json!({
+        "id": resp.id,
+        "type": "message",
+        "role": "assistant",
+        "content": [],
+        "model": resp.model,
+        "stop_reason": null,
+        "stop_sequence": null,
+        "usage": start_usage
+    });
+    if let Some(refusal) = &resp.refusal {
+        message["refusal"] = serde_json::Value::String(refusal.clone());
+    }
+    if let Some(response_status) = &resp.response_status {
+        message["response_status"] = serde_json::Value::String(response_status.clone());
+    }
+    if let Some(incomplete_details) = &resp.incomplete_details {
+        message["incomplete_details"] = incomplete_details.clone();
+    }
     let start_msg = serde_json::json!({
         "type": "message_start",
-        "message": {
-            "id": resp.id,
-            "type": "message",
-            "role": "assistant",
-            "content": [],
-            "model": resp.model,
-            "stop_reason": null,
-            "stop_sequence": null,
-            "refusal": resp.refusal,
-            "response_status": resp.response_status,
-            "incomplete_details": resp.incomplete_details,
-            "usage": start_usage
-        }
+        "message": message
     });
     events.push(format!("event: message_start\ndata: {}\n\n", start_msg));
 
@@ -1001,6 +1008,35 @@ mod tests {
         };
         let whitespace_events = emit_anthropic_sse_events(&whitespace_resp, true).join("");
         assert!(!whitespace_events.contains("thinking_delta"));
+    }
+
+    #[test]
+    fn pseudo_stream_omits_absent_responses_metadata() {
+        let resp = AnthropicResponse {
+            id: "msg_plain".to_string(),
+            response_type: "message".to_string(),
+            role: "assistant".to_string(),
+            content: vec![],
+            model: "plain-model".to_string(),
+            stop_reason: Some("end_turn".to_string()),
+            usage: AnthropicUsage::default(),
+            reasoning_content: None,
+            refusal: None,
+            response_status: None,
+            incomplete_details: None,
+        };
+
+        let first = emit_anthropic_sse_events(&resp, false)
+            .into_iter()
+            .next()
+            .unwrap();
+        let payload = first.split_once("data: ").unwrap().1.trim();
+        let event: serde_json::Value = serde_json::from_str(payload).unwrap();
+        let message = event["message"].as_object().unwrap();
+
+        assert!(!message.contains_key("refusal"));
+        assert!(!message.contains_key("response_status"));
+        assert!(!message.contains_key("incomplete_details"));
     }
 
     #[test]

--- a/src/router/streaming.rs
+++ b/src/router/streaming.rs
@@ -621,9 +621,6 @@ fn emit_anthropic_sse_events(
     if let Some(incomplete_details) = &resp.incomplete_details {
         message["incomplete_details"] = incomplete_details.clone();
     }
-    if let Some(responses_output) = &resp.responses_output {
-        message[super::RESPONSES_OUTPUT_PASSTHROUGH_KEY] = responses_output.clone();
-    }
     let start_msg = serde_json::json!({
         "type": "message_start",
         "message": message
@@ -897,7 +894,6 @@ mod tests {
             refusal: None,
             response_status: None,
             incomplete_details: None,
-            responses_output: None,
         };
 
         let events = emit_anthropic_sse_events(&resp, true);
@@ -956,7 +952,6 @@ mod tests {
             refusal: None,
             response_status: None,
             incomplete_details: None,
-            responses_output: None,
         };
 
         let events = emit_anthropic_sse_events(&resp, true);
@@ -997,7 +992,6 @@ mod tests {
             refusal: None,
             response_status: None,
             incomplete_details: None,
-            responses_output: None,
         };
 
         let native_events = emit_anthropic_sse_events(&resp, false).join("");
@@ -1030,7 +1024,6 @@ mod tests {
             refusal: None,
             response_status: None,
             incomplete_details: None,
-            responses_output: None,
         };
 
         let first = emit_anthropic_sse_events(&resp, false)
@@ -1060,7 +1053,6 @@ mod tests {
             refusal: Some("I cannot help with that.".to_string()),
             response_status: Some("incomplete".to_string()),
             incomplete_details: Some(serde_json::json!({"reason": "content_filter"})),
-            responses_output: None,
         };
 
         let events = emit_anthropic_sse_events(&resp, true).join("");
@@ -1102,7 +1094,6 @@ mod tests {
             refusal: None,
             response_status: None,
             incomplete_details: None,
-            responses_output: None,
         };
 
         let events = emit_anthropic_sse_events(&resp, true);

--- a/src/router/streaming.rs
+++ b/src/router/streaming.rs
@@ -585,6 +585,7 @@ fn emit_anthropic_sse_events(
     let reasoning = include_unsigned_reasoning
         .then_some(resp.reasoning_content.as_deref())
         .flatten()
+        .filter(|reasoning| !reasoning.trim().is_empty())
         .filter(|_| {
             !resp
                 .content
@@ -880,6 +881,7 @@ mod tests {
                 ..Default::default()
             },
             reasoning_content: None,
+            refusal: None,
         };
 
         let events = emit_anthropic_sse_events(&resp, true);
@@ -935,6 +937,7 @@ mod tests {
                 reasoning_tokens: Some(11),
             },
             reasoning_content: None,
+            refusal: None,
         };
 
         let events = emit_anthropic_sse_events(&resp, true);
@@ -972,6 +975,7 @@ mod tests {
                 ..Default::default()
             },
             reasoning_content: Some("unsigned summary".to_string()),
+            refusal: None,
         };
 
         let native_events = emit_anthropic_sse_events(&resp, false).join("");
@@ -981,6 +985,13 @@ mod tests {
         let adapter_events = emit_anthropic_sse_events(&resp, true).join("");
         assert!(adapter_events.contains("thinking_delta"));
         assert!(adapter_events.contains("unsigned summary"));
+
+        let whitespace_resp = AnthropicResponse {
+            reasoning_content: Some("  \n".to_string()),
+            ..resp
+        };
+        let whitespace_events = emit_anthropic_sse_events(&whitespace_resp, true).join("");
+        assert!(!whitespace_events.contains("thinking_delta"));
     }
 
     #[test]
@@ -1012,6 +1023,7 @@ mod tests {
                 ..Default::default()
             },
             reasoning_content: None,
+            refusal: None,
         };
 
         let events = emit_anthropic_sse_events(&resp, true);

--- a/src/router/streaming.rs
+++ b/src/router/streaming.rs
@@ -703,15 +703,7 @@ fn emit_anthropic_sse_events(resp: &AnthropicResponse) -> Vec<String> {
     });
     events.push(format!("event: message_delta\ndata: {}\n\n", msg_delta));
 
-    // message_stop carries the complete usage so OpenAI compatibility clients
-    // can receive the standard terminal `choices: []` usage chunk.
-    let message_stop = serde_json::json!({
-        "type": "message_stop",
-        "usage": {
-            "input_tokens": resp.usage.input_tokens,
-            "output_tokens": resp.usage.output_tokens
-        }
-    });
+    let message_stop = serde_json::json!({"type": "message_stop"});
     events.push(format!("event: message_stop\ndata: {}\n\n", message_stop));
 
     events
@@ -724,7 +716,7 @@ fn emit_anthropic_sse_events(resp: &AnthropicResponse) -> Vec<String> {
 /// as SSE events that Claude CLI can parse. Falls through to the original response
 /// if parsing fails.
 pub(super) async fn wrap_json_response_as_sse(response: Response) -> Response {
-    let (parts, body) = response.into_parts();
+    let (mut parts, body) = response.into_parts();
 
     // Only wrap successful JSON responses
     if parts.status != StatusCode::OK {
@@ -746,16 +738,16 @@ pub(super) async fn wrap_json_response_as_sse(response: Response) -> Response {
     if let Ok(anthropic_resp) = serde_json::from_slice::<AnthropicResponse>(&bytes) {
         let sse_events = emit_anthropic_sse_events(&anthropic_resp);
         let sse_body = sse_events.join("");
-
-        Response::builder()
-            .status(StatusCode::OK)
-            .header("content-type", "text/event-stream")
-            .header("cache-control", "no-cache")
-            .body(Body::from(sse_body))
-            .unwrap_or_else(|_| {
-                // Fallback: return original bytes if SSE build fails
-                Response::from_parts(parts, Body::from(bytes))
-            })
+        parts.headers.insert(
+            axum::http::header::CONTENT_TYPE,
+            axum::http::HeaderValue::from_static("text/event-stream"),
+        );
+        parts.headers.insert(
+            axum::http::header::CACHE_CONTROL,
+            axum::http::HeaderValue::from_static("no-cache"),
+        );
+        parts.headers.remove(axum::http::header::CONTENT_LENGTH);
+        Response::from_parts(parts, Body::from(sse_body))
     } else {
         // Can't parse as Anthropic — return original response unchanged
         Response::from_parts(parts, Body::from(bytes))

--- a/src/router/streaming.rs
+++ b/src/router/streaming.rs
@@ -612,6 +612,9 @@ fn emit_anthropic_sse_events(
             "model": resp.model,
             "stop_reason": null,
             "stop_sequence": null,
+            "refusal": resp.refusal,
+            "response_status": resp.response_status,
+            "incomplete_details": resp.incomplete_details,
             "usage": start_usage
         }
     });
@@ -882,6 +885,8 @@ mod tests {
             },
             reasoning_content: None,
             refusal: None,
+            response_status: None,
+            incomplete_details: None,
         };
 
         let events = emit_anthropic_sse_events(&resp, true);
@@ -938,6 +943,8 @@ mod tests {
             },
             reasoning_content: None,
             refusal: None,
+            response_status: None,
+            incomplete_details: None,
         };
 
         let events = emit_anthropic_sse_events(&resp, true);
@@ -976,6 +983,8 @@ mod tests {
             },
             reasoning_content: Some("unsigned summary".to_string()),
             refusal: None,
+            response_status: None,
+            incomplete_details: None,
         };
 
         let native_events = emit_anthropic_sse_events(&resp, false).join("");
@@ -992,6 +1001,29 @@ mod tests {
         };
         let whitespace_events = emit_anthropic_sse_events(&whitespace_resp, true).join("");
         assert!(!whitespace_events.contains("thinking_delta"));
+    }
+
+    #[test]
+    fn pseudo_stream_carries_responses_refusal_and_terminal_metadata() {
+        let resp = AnthropicResponse {
+            id: "msg_refusal".to_string(),
+            response_type: "message".to_string(),
+            role: "assistant".to_string(),
+            content: vec![],
+            model: "responses-model".to_string(),
+            stop_reason: Some("stop_sequence".to_string()),
+            usage: AnthropicUsage::default(),
+            reasoning_content: None,
+            refusal: Some("I cannot help with that.".to_string()),
+            response_status: Some("incomplete".to_string()),
+            incomplete_details: Some(serde_json::json!({"reason": "content_filter"})),
+        };
+
+        let events = emit_anthropic_sse_events(&resp, true).join("");
+
+        assert!(events.contains("I cannot help with that."));
+        assert!(events.contains("\"response_status\":\"incomplete\""));
+        assert!(events.contains("\"reason\":\"content_filter\""));
     }
 
     #[test]
@@ -1024,6 +1056,8 @@ mod tests {
             },
             reasoning_content: None,
             refusal: None,
+            response_status: None,
+            incomplete_details: None,
         };
 
         let events = emit_anthropic_sse_events(&resp, true);

--- a/src/router/streaming.rs
+++ b/src/router/streaming.rs
@@ -218,6 +218,7 @@ pub async fn stream_response_translated(
             Some(AnthropicUsage {
                 input_tokens,
                 output_tokens,
+                ..Default::default()
             })
         } else {
             // Estimate from accumulated content if no usage reported
@@ -225,6 +226,7 @@ pub async fn stream_response_translated(
             Some(AnthropicUsage {
                 input_tokens,
                 output_tokens: estimated_output as u64,
+                ..Default::default()
             })
         };
 
@@ -586,6 +588,13 @@ fn emit_anthropic_sse_events(resp: &AnthropicResponse) -> Vec<String> {
     let reasoning_offset = usize::from(reasoning.is_some());
 
     // message_start
+    let mut start_usage = serde_json::json!({
+        "input_tokens": resp.usage.input_tokens,
+        "output_tokens": 0
+    });
+    if let Some(cached_tokens) = resp.usage.cache_read_input_tokens {
+        start_usage["cache_read_input_tokens"] = serde_json::json!(cached_tokens);
+    }
     let start_msg = serde_json::json!({
         "type": "message_start",
         "message": {
@@ -596,10 +605,7 @@ fn emit_anthropic_sse_events(resp: &AnthropicResponse) -> Vec<String> {
             "model": resp.model,
             "stop_reason": null,
             "stop_sequence": null,
-            "usage": {
-                "input_tokens": resp.usage.input_tokens,
-                "output_tokens": 0
-            }
+            "usage": start_usage
         }
     });
     events.push(format!("event: message_start\ndata: {}\n\n", start_msg));
@@ -722,15 +728,19 @@ fn emit_anthropic_sse_events(resp: &AnthropicResponse) -> Vec<String> {
     }
 
     // message_delta
+    let mut delta_usage = serde_json::json!({
+        "output_tokens": resp.usage.output_tokens
+    });
+    if let Some(reasoning_tokens) = resp.usage.reasoning_tokens {
+        delta_usage["reasoning_tokens"] = serde_json::json!(reasoning_tokens);
+    }
     let msg_delta = serde_json::json!({
         "type": "message_delta",
         "delta": {
             "stop_reason": resp.stop_reason,
             "stop_sequence": null
         },
-        "usage": {
-            "output_tokens": resp.usage.output_tokens
-        }
+        "usage": delta_usage
     });
     events.push(format!("event: message_delta\ndata: {}\n\n", msg_delta));
 
@@ -858,6 +868,7 @@ mod tests {
             usage: AnthropicUsage {
                 input_tokens: 100,
                 output_tokens: 20,
+                ..Default::default()
             },
             reasoning_content: None,
         };
@@ -911,6 +922,8 @@ mod tests {
             usage: AnthropicUsage {
                 input_tokens: 50,
                 output_tokens: 30,
+                cache_read_input_tokens: Some(7),
+                reasoning_tokens: Some(11),
             },
             reasoning_content: None,
         };
@@ -929,6 +942,8 @@ mod tests {
         );
         assert!(joined.contains("sig123"), "missing signature content");
         assert!(joined.contains("text_delta"), "missing text_delta");
+        assert!(joined.contains("\"cache_read_input_tokens\":7"));
+        assert!(joined.contains("\"reasoning_tokens\":11"));
     }
 
     #[test]
@@ -957,6 +972,7 @@ mod tests {
             usage: AnthropicUsage {
                 input_tokens: 100,
                 output_tokens: 40,
+                ..Default::default()
             },
             reasoning_content: None,
         };

--- a/src/router/streaming.rs
+++ b/src/router/streaming.rs
@@ -703,8 +703,16 @@ fn emit_anthropic_sse_events(resp: &AnthropicResponse) -> Vec<String> {
     });
     events.push(format!("event: message_delta\ndata: {}\n\n", msg_delta));
 
-    // message_stop
-    events.push("event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n".to_string());
+    // message_stop carries the complete usage so OpenAI compatibility clients
+    // can receive the standard terminal `choices: []` usage chunk.
+    let message_stop = serde_json::json!({
+        "type": "message_stop",
+        "usage": {
+            "input_tokens": resp.usage.input_tokens,
+            "output_tokens": resp.usage.output_tokens
+        }
+    });
+    events.push(format!("event: message_stop\ndata: {}\n\n", message_stop));
 
     events
 }

--- a/src/router/streaming.rs
+++ b/src/router/streaming.rs
@@ -621,6 +621,9 @@ fn emit_anthropic_sse_events(
     if let Some(incomplete_details) = &resp.incomplete_details {
         message["incomplete_details"] = incomplete_details.clone();
     }
+    if let Some(responses_output) = &resp.responses_output {
+        message[super::RESPONSES_OUTPUT_PASSTHROUGH_KEY] = responses_output.clone();
+    }
     let start_msg = serde_json::json!({
         "type": "message_start",
         "message": message
@@ -894,6 +897,7 @@ mod tests {
             refusal: None,
             response_status: None,
             incomplete_details: None,
+            responses_output: None,
         };
 
         let events = emit_anthropic_sse_events(&resp, true);
@@ -952,6 +956,7 @@ mod tests {
             refusal: None,
             response_status: None,
             incomplete_details: None,
+            responses_output: None,
         };
 
         let events = emit_anthropic_sse_events(&resp, true);
@@ -992,6 +997,7 @@ mod tests {
             refusal: None,
             response_status: None,
             incomplete_details: None,
+            responses_output: None,
         };
 
         let native_events = emit_anthropic_sse_events(&resp, false).join("");
@@ -1024,6 +1030,7 @@ mod tests {
             refusal: None,
             response_status: None,
             incomplete_details: None,
+            responses_output: None,
         };
 
         let first = emit_anthropic_sse_events(&resp, false)
@@ -1053,6 +1060,7 @@ mod tests {
             refusal: Some("I cannot help with that.".to_string()),
             response_status: Some("incomplete".to_string()),
             incomplete_details: Some(serde_json::json!({"reason": "content_filter"})),
+            responses_output: None,
         };
 
         let events = emit_anthropic_sse_events(&resp, true).join("");
@@ -1094,6 +1102,7 @@ mod tests {
             refusal: None,
             response_status: None,
             incomplete_details: None,
+            responses_output: None,
         };
 
         let events = emit_anthropic_sse_events(&resp, true);

--- a/src/router/streaming.rs
+++ b/src/router/streaming.rs
@@ -72,6 +72,8 @@ pub async fn stream_response_translated(
         let mut accumulated_tool_calls: Vec<(String, String, String)> = Vec::new();
         let mut input_tokens: u64 = 0;
         let mut output_tokens: u64 = 0;
+        let mut cache_read_input_tokens: Option<u64> = None;
+        let mut reasoning_tokens: Option<u64> = None;
         let stream_start = verify_ctx.as_ref().map(|ctx| ctx.stream_start);
         let tier_name = verify_ctx
             .as_ref()
@@ -120,6 +122,18 @@ pub async fn stream_response_translated(
                                     if let Some(ref usage) = chunk.usage {
                                         input_tokens = usage.prompt_tokens;
                                         output_tokens = usage.completion_tokens;
+                                        cache_read_input_tokens = usage
+                                            .prompt_tokens_details
+                                            .as_ref()
+                                            .and_then(|details| details.get("cached_tokens"))
+                                            .and_then(|value| value.as_u64())
+                                            .or(cache_read_input_tokens);
+                                        reasoning_tokens = usage
+                                            .completion_tokens_details
+                                            .as_ref()
+                                            .and_then(|details| details.get("reasoning_tokens"))
+                                            .and_then(|value| value.as_u64())
+                                            .or(reasoning_tokens);
                                     }
 
                                     let was_first = translation_state.is_first;
@@ -218,7 +232,8 @@ pub async fn stream_response_translated(
             Some(AnthropicUsage {
                 input_tokens,
                 output_tokens,
-                ..Default::default()
+                cache_read_input_tokens,
+                reasoning_tokens,
             })
         } else {
             // Estimate from accumulated content if no usage reported
@@ -226,7 +241,8 @@ pub async fn stream_response_translated(
             Some(AnthropicUsage {
                 input_tokens,
                 output_tokens: estimated_output as u64,
-                ..Default::default()
+                cache_read_input_tokens,
+                reasoning_tokens,
             })
         };
 
@@ -296,7 +312,7 @@ pub async fn stream_response_translated(
                     &ctx.tier_name,
                     usage.input_tokens,
                     usage.output_tokens,
-                    0,
+                    usage.cache_read_input_tokens.unwrap_or(0),
                     0,
                 );
                 verify_token_usage(&ctx.tier_name, ctx.local_estimate, input_tokens);
@@ -822,6 +838,53 @@ pub(super) async fn wrap_json_response_as_sse(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn translated_live_stream_preserves_usage_token_details() {
+        let first = serde_json::json!({
+            "id": "chatcmpl-usage-details",
+            "object": "chat.completion.chunk",
+            "created": 42,
+            "model": "test-model",
+            "choices": [{
+                "index": 0,
+                "delta": {"content": "ok"},
+                "finish_reason": "stop"
+            }]
+        });
+        let usage = serde_json::json!({
+            "id": "chatcmpl-usage-details",
+            "object": "chat.completion.chunk",
+            "created": 42,
+            "model": "test-model",
+            "choices": [],
+            "usage": {
+                "prompt_tokens": 12,
+                "completion_tokens": 7,
+                "total_tokens": 19,
+                "prompt_tokens_details": {"cached_tokens": 5},
+                "completion_tokens_details": {"reasoning_tokens": 3}
+            }
+        });
+        let payload = format!("data: {first}\n\ndata: {usage}\n\ndata: [DONE]\n\n");
+        let byte_stream: BoxByteStream =
+            Box::pin(futures::stream::iter([Ok::<Bytes, reqwest::Error>(
+                Bytes::from(payload),
+            )]));
+
+        let response =
+            stream_response_translated(byte_stream, 8, None, "test-model", TransformerChain::new())
+                .await;
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let body = String::from_utf8(body.to_vec()).unwrap();
+
+        assert!(body.contains("\"input_tokens\":12"));
+        assert!(body.contains("\"output_tokens\":7"));
+        assert!(body.contains("\"cache_read_input_tokens\":5"));
+        assert!(body.contains("\"reasoning_tokens\":3"));
+    }
 
     #[tokio::test]
     async fn json_to_sse_rewrite_removes_stale_entity_headers() {

--- a/src/router/streaming.rs
+++ b/src/router/streaming.rs
@@ -879,11 +879,22 @@ mod tests {
             .await
             .unwrap();
         let body = String::from_utf8(body.to_vec()).unwrap();
+        let usage = body
+            .split("\n\n")
+            .filter_map(|frame| {
+                frame
+                    .lines()
+                    .find_map(|line| line.strip_prefix("data: "))
+                    .and_then(|data| serde_json::from_str::<serde_json::Value>(data).ok())
+            })
+            .find(|event| event["type"] == "message_delta")
+            .and_then(|event| event.get("usage").cloned())
+            .expect("message_delta should carry structured usage");
 
-        assert!(body.contains("\"input_tokens\":12"));
-        assert!(body.contains("\"output_tokens\":7"));
-        assert!(body.contains("\"cache_read_input_tokens\":5"));
-        assert!(body.contains("\"reasoning_tokens\":3"));
+        assert_eq!(usage["input_tokens"], 12);
+        assert_eq!(usage["output_tokens"], 7);
+        assert_eq!(usage["cache_read_input_tokens"], 5);
+        assert_eq!(usage["reasoning_tokens"], 3);
     }
 
     #[tokio::test]

--- a/src/router/streaming.rs
+++ b/src/router/streaming.rs
@@ -577,6 +577,13 @@ pub async fn stream_anthropic_response_with_tracking(
 /// Used when `forceNonStreaming` is true but the client requested `stream: true`.
 fn emit_anthropic_sse_events(resp: &AnthropicResponse) -> Vec<String> {
     let mut events = Vec::new();
+    let reasoning = resp.reasoning_content.as_deref().filter(|_| {
+        !resp
+            .content
+            .iter()
+            .any(|block| matches!(block, AnthropicContentBlock::Thinking { .. }))
+    });
+    let reasoning_offset = usize::from(reasoning.is_some());
 
     // message_start
     let start_msg = serde_json::json!({
@@ -597,8 +604,32 @@ fn emit_anthropic_sse_events(resp: &AnthropicResponse) -> Vec<String> {
     });
     events.push(format!("event: message_start\ndata: {}\n\n", start_msg));
 
+    if let Some(reasoning) = reasoning {
+        let block_start = serde_json::json!({
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "thinking", "thinking": ""}
+        });
+        let delta = serde_json::json!({
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "thinking_delta", "thinking": reasoning}
+        });
+        let block_stop = serde_json::json!({"type": "content_block_stop", "index": 0});
+        events.push(format!(
+            "event: content_block_start\ndata: {}\n\n",
+            block_start
+        ));
+        events.push(format!("event: content_block_delta\ndata: {}\n\n", delta));
+        events.push(format!(
+            "event: content_block_stop\ndata: {}\n\n",
+            block_stop
+        ));
+    }
+
     // Emit content blocks (text, tool_use, and thinking).
-    for (idx, block) in resp.content.iter().enumerate() {
+    for (content_idx, block) in resp.content.iter().enumerate() {
+        let idx = content_idx + reasoning_offset;
         match block {
             AnthropicContentBlock::Text { text } => {
                 // content_block_start

--- a/src/router/streaming.rs
+++ b/src/router/streaming.rs
@@ -747,6 +747,10 @@ pub(super) async fn wrap_json_response_as_sse(response: Response) -> Response {
             axum::http::HeaderValue::from_static("no-cache"),
         );
         parts.headers.remove(axum::http::header::CONTENT_LENGTH);
+        parts.headers.remove(axum::http::header::CONTENT_ENCODING);
+        parts.headers.remove(axum::http::header::TRANSFER_ENCODING);
+        parts.headers.remove(axum::http::header::ETAG);
+        parts.headers.remove(axum::http::header::LAST_MODIFIED);
         Response::from_parts(parts, Body::from(sse_body))
     } else {
         // Can't parse as Anthropic — return original response unchanged
@@ -757,6 +761,50 @@ pub(super) async fn wrap_json_response_as_sse(response: Response) -> Response {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn json_to_sse_rewrite_removes_stale_entity_headers() {
+        let payload = serde_json::json!({
+            "id": "msg_test",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "ok"}],
+            "model": "test-model",
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 1, "output_tokens": 1}
+        });
+        let mut response = Response::new(Body::from(payload.to_string()));
+        for (name, value) in [
+            (axum::http::header::CONTENT_LENGTH, "10"),
+            (axum::http::header::CONTENT_ENCODING, "gzip"),
+            (axum::http::header::TRANSFER_ENCODING, "chunked"),
+            (axum::http::header::ETAG, "\"old\""),
+            (
+                axum::http::header::LAST_MODIFIED,
+                "Fri, 01 Aug 2025 00:00:00 GMT",
+            ),
+        ] {
+            response
+                .headers_mut()
+                .insert(name, axum::http::HeaderValue::from_str(value).unwrap());
+        }
+
+        let rewritten = wrap_json_response_as_sse(response).await;
+
+        assert_eq!(
+            rewritten.headers().get(axum::http::header::CONTENT_TYPE),
+            Some(&axum::http::HeaderValue::from_static("text/event-stream"))
+        );
+        for name in [
+            axum::http::header::CONTENT_LENGTH,
+            axum::http::header::CONTENT_ENCODING,
+            axum::http::header::TRANSFER_ENCODING,
+            axum::http::header::ETAG,
+            axum::http::header::LAST_MODIFIED,
+        ] {
+            assert!(rewritten.headers().get(name).is_none());
+        }
+    }
 
     #[test]
     fn test_emit_anthropic_sse_events_tool_use() {

--- a/src/router/translate_response.rs
+++ b/src/router/translate_response.rs
@@ -106,9 +106,19 @@ pub(super) fn translate_response_openai_to_anthropic(
 
     let usage = openai_resp
         .usage
-        .map(|u| AnthropicUsage {
-            input_tokens: u.prompt_tokens,
-            output_tokens: u.completion_tokens,
+        .map(|openai_usage| AnthropicUsage {
+            input_tokens: openai_usage.prompt_tokens,
+            output_tokens: openai_usage.completion_tokens,
+            cache_read_input_tokens: openai_usage
+                .prompt_tokens_details
+                .as_ref()
+                .and_then(|details| details.get("cached_tokens"))
+                .and_then(serde_json::Value::as_u64),
+            reasoning_tokens: openai_usage
+                .completion_tokens_details
+                .as_ref()
+                .and_then(|details| details.get("reasoning_tokens"))
+                .and_then(serde_json::Value::as_u64),
         })
         .unwrap_or_default();
 

--- a/src/router/translate_response.rs
+++ b/src/router/translate_response.rs
@@ -30,7 +30,6 @@ pub(super) fn translate_response_openai_to_anthropic(
         .and_then(|choice| choice.message.refusal.clone());
     let response_status = openai_resp.response_status.clone();
     let incomplete_details = openai_resp.incomplete_details.clone();
-    let responses_output = openai_resp.responses_output.clone();
 
     let content = if let Some(choice) = openai_resp.choices.first() {
         let mut blocks: Vec<AnthropicContentBlock> = Vec::new();
@@ -149,7 +148,6 @@ pub(super) fn translate_response_openai_to_anthropic(
         refusal,
         response_status,
         incomplete_details,
-        responses_output,
     }
 }
 

--- a/src/router/translate_response.rs
+++ b/src/router/translate_response.rs
@@ -28,6 +28,8 @@ pub(super) fn translate_response_openai_to_anthropic(
         .choices
         .first()
         .and_then(|choice| choice.message.refusal.clone());
+    let response_status = openai_resp.response_status.clone();
+    let incomplete_details = openai_resp.incomplete_details.clone();
 
     let content = if let Some(choice) = openai_resp.choices.first() {
         let mut blocks: Vec<AnthropicContentBlock> = Vec::new();
@@ -144,6 +146,8 @@ pub(super) fn translate_response_openai_to_anthropic(
         }),
         reasoning_content,
         refusal,
+        response_status,
+        incomplete_details,
     }
 }
 

--- a/src/router/translate_response.rs
+++ b/src/router/translate_response.rs
@@ -30,6 +30,7 @@ pub(super) fn translate_response_openai_to_anthropic(
         .and_then(|choice| choice.message.refusal.clone());
     let response_status = openai_resp.response_status.clone();
     let incomplete_details = openai_resp.incomplete_details.clone();
+    let responses_output = openai_resp.responses_output.clone();
 
     let content = if let Some(choice) = openai_resp.choices.first() {
         let mut blocks: Vec<AnthropicContentBlock> = Vec::new();
@@ -148,6 +149,7 @@ pub(super) fn translate_response_openai_to_anthropic(
         refusal,
         response_status,
         incomplete_details,
+        responses_output,
     }
 }
 

--- a/src/router/translate_response.rs
+++ b/src/router/translate_response.rs
@@ -340,7 +340,7 @@ pub(super) fn create_stream_stop_events(
         index: None,
         content_block: None,
         delta: Some(serde_json::json!({"stop_reason": stop_reason})),
-        usage: Some(usage.clone()),
+        usage: Some(usage),
         stop_reason: None,
     });
 
@@ -350,7 +350,7 @@ pub(super) fn create_stream_stop_events(
         index: None,
         content_block: None,
         delta: None,
-        usage: Some(usage),
+        usage: None,
         stop_reason: None,
     });
 

--- a/src/router/translate_response.rs
+++ b/src/router/translate_response.rs
@@ -24,6 +24,10 @@ pub(super) fn translate_response_openai_to_anthropic(
         .choices
         .first()
         .and_then(|choice| choice.message.reasoning_content.clone());
+    let refusal = openai_resp
+        .choices
+        .first()
+        .and_then(|choice| choice.message.refusal.clone());
 
     let content = if let Some(choice) = openai_resp.choices.first() {
         let mut blocks: Vec<AnthropicContentBlock> = Vec::new();
@@ -139,6 +143,7 @@ pub(super) fn translate_response_openai_to_anthropic(
             })
         }),
         reasoning_content,
+        refusal,
     }
 }
 

--- a/src/router/types.rs
+++ b/src/router/types.rs
@@ -166,8 +166,6 @@ pub struct OpenAIResponse {
     pub response_status: Option<String>,
     #[serde(default)]
     pub incomplete_details: Option<serde_json::Value>,
-    #[serde(default, rename = "__ccr_responses_output")]
-    pub responses_output: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -302,13 +300,6 @@ pub struct AnthropicResponse {
     /// Original Responses API incomplete metadata carried through the adapter pipeline.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub incomplete_details: Option<serde_json::Value>,
-    /// Original output items retained only for an internal Responses-client bridge.
-    #[serde(
-        default,
-        rename = "__ccr_responses_output",
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub responses_output: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/router/types.rs
+++ b/src/router/types.rs
@@ -162,6 +162,10 @@ pub struct OpenAIResponse {
     pub model: String,
     pub choices: Vec<OpenAIChoice>,
     pub usage: Option<OpenAIUsage>,
+    #[serde(default)]
+    pub response_status: Option<String>,
+    #[serde(default)]
+    pub incomplete_details: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -290,6 +294,12 @@ pub struct AnthropicResponse {
     /// OpenAI Responses refusal metadata carried through the internal Anthropic shape.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub refusal: Option<String>,
+    /// Original Responses API terminal status carried through the adapter pipeline.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub response_status: Option<String>,
+    /// Original Responses API incomplete metadata carried through the adapter pipeline.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub incomplete_details: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/router/types.rs
+++ b/src/router/types.rs
@@ -181,6 +181,8 @@ pub struct OpenAIResponseMessage {
     #[serde(default, rename = "reasoning_content", alias = "reasoning")]
     pub reasoning_content: Option<String>,
     #[serde(default)]
+    pub refusal: Option<String>,
+    #[serde(default)]
     pub tool_calls: Option<Vec<OpenAIToolCall>>,
 }
 
@@ -285,6 +287,9 @@ pub struct AnthropicResponse {
     /// Serialized back to OpenAI format instead of thinking blocks
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_content: Option<String>,
+    /// OpenAI Responses refusal metadata carried through the internal Anthropic shape.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub refusal: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/router/types.rs
+++ b/src/router/types.rs
@@ -166,6 +166,8 @@ pub struct OpenAIResponse {
     pub response_status: Option<String>,
     #[serde(default)]
     pub incomplete_details: Option<serde_json::Value>,
+    #[serde(default, rename = "__ccr_responses_output")]
+    pub responses_output: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -300,6 +302,13 @@ pub struct AnthropicResponse {
     /// Original Responses API incomplete metadata carried through the adapter pipeline.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub incomplete_details: Option<serde_json::Value>,
+    /// Original output items retained only for an internal Responses-client bridge.
+    #[serde(
+        default,
+        rename = "__ccr_responses_output",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub responses_output: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/router/types.rs
+++ b/src/router/types.rs
@@ -209,8 +209,9 @@ pub struct OpenAIUsage {
     #[serde(default)]
     pub completion_tokens: u64,
     #[serde(default)]
-    #[allow(dead_code)]
     pub prompt_tokens_details: Option<serde_json::Value>,
+    #[serde(default)]
+    pub completion_tokens_details: Option<serde_json::Value>,
 }
 
 /// OpenAI streaming response chunk.
@@ -305,6 +306,10 @@ pub enum AnthropicContentBlock {
 pub struct AnthropicUsage {
     pub input_tokens: u64,
     pub output_tokens: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_read_input_tokens: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_tokens: Option<u64>,
 }
 
 /// Anthropic streaming event types.

--- a/src/transform/anthropic_to_openai.rs
+++ b/src/transform/anthropic_to_openai.rs
@@ -336,6 +336,10 @@ fn transform_streaming_event(anthropic_event: Value) -> Result<Value> {
         }
         "content_block_start" => {
             // Start of a content block
+            let block_index = anthropic_event
+                .get("index")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
             let content_block = anthropic_event
                 .get("content_block")
                 .cloned()
@@ -363,7 +367,7 @@ fn transform_streaming_event(anthropic_event: Value) -> Result<Value> {
 
                     serde_json::json!({
                         "tool_calls": [{
-                            "index": 0,
+                            "index": block_index,
                             "id": id,
                             "type": "function",
                             "function": {
@@ -390,6 +394,10 @@ fn transform_streaming_event(anthropic_event: Value) -> Result<Value> {
         }
         "content_block_delta" => {
             // Delta within a content block
+            let block_index = anthropic_event
+                .get("index")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
             let delta = anthropic_event
                 .get("delta")
                 .cloned()
@@ -403,7 +411,7 @@ fn transform_streaming_event(anthropic_event: Value) -> Result<Value> {
                 // Tool use partial JSON
                 serde_json::json!({
                     "tool_calls": [{
-                        "index": 0,
+                        "index": block_index,
                         "function": {
                             "arguments": partial_json
                         }
@@ -721,7 +729,30 @@ mod tests {
         let tool_calls = result["choices"][0]["delta"]["tool_calls"]
             .as_array()
             .unwrap();
+        assert_eq!(tool_calls[0]["index"], 1);
         assert_eq!(tool_calls[0]["function"]["arguments"], "{\"a\": 1}");
+    }
+
+    #[test]
+    fn test_transform_streaming_tool_use_start_preserves_block_index() {
+        let transformer = AnthropicToOpenAiResponseTransformer;
+        let anthropic_event = serde_json::json!({
+            "type": "content_block_start",
+            "index": 2,
+            "content_block": {
+                "type": "tool_use",
+                "id": "toolu_second",
+                "name": "second_tool",
+                "input": {}
+            }
+        });
+
+        let result = transformer.transform_response(anthropic_event).unwrap();
+        let tool_call = &result["choices"][0]["delta"]["tool_calls"][0];
+
+        assert_eq!(tool_call["index"], 2);
+        assert_eq!(tool_call["id"], "toolu_second");
+        assert_eq!(tool_call["function"]["name"], "second_tool");
     }
 
     #[test]

--- a/src/transform/anthropic_to_openai.rs
+++ b/src/transform/anthropic_to_openai.rs
@@ -509,11 +509,22 @@ fn anthropic_usage_to_openai(usage: &Value) -> Value {
         .get("output_tokens")
         .and_then(Value::as_u64)
         .unwrap_or_default();
-    serde_json::json!({
+    let mut openai_usage = serde_json::json!({
         "prompt_tokens": prompt_tokens,
         "completion_tokens": completion_tokens,
         "total_tokens": prompt_tokens.saturating_add(completion_tokens)
-    })
+    });
+    if let Some(cached_tokens) = usage.get("cache_read_input_tokens").and_then(Value::as_u64) {
+        openai_usage["prompt_tokens_details"] = serde_json::json!({
+            "cached_tokens": cached_tokens
+        });
+    }
+    if let Some(reasoning_tokens) = usage.get("reasoning_tokens").and_then(Value::as_u64) {
+        openai_usage["completion_tokens_details"] = serde_json::json!({
+            "reasoning_tokens": reasoning_tokens
+        });
+    }
+    openai_usage
 }
 
 /// Get current Unix timestamp.

--- a/src/transform/anthropic_to_openai.rs
+++ b/src/transform/anthropic_to_openai.rs
@@ -354,9 +354,6 @@ fn transform_streaming_event(anthropic_event: Value) -> Result<Value> {
             {
                 event["incomplete_details"] = incomplete_details.clone();
             }
-            if let Some(responses_output) = message.get("__ccr_responses_output") {
-                event["__ccr_responses_output"] = responses_output.clone();
-            }
             event
         }
         "content_block_start" => {

--- a/src/transform/anthropic_to_openai.rs
+++ b/src/transform/anthropic_to_openai.rs
@@ -464,7 +464,7 @@ fn transform_streaming_event(anthropic_event: Value) -> Result<Value> {
             })
         }
         "message_stop" => {
-            // OpenAI's usage-bearing terminal stream chunk has no choices.
+            // The stream adapter attaches collected usage to this terminal chunk.
             serde_json::json!({
                 "id": "chatcmpl-stream",
                 "object": "chat.completion.chunk",

--- a/src/transform/anthropic_to_openai.rs
+++ b/src/transform/anthropic_to_openai.rs
@@ -341,10 +341,17 @@ fn transform_streaming_event(anthropic_event: Value) -> Result<Value> {
                 event["choices"][0]["delta"]["refusal"] =
                     serde_json::Value::String(refusal.to_string());
             }
-            if let Some(status) = message.get("response_status") {
-                event["response_status"] = status.clone();
+            if let Some(status) = message
+                .get("response_status")
+                .and_then(|value| value.as_str())
+                .filter(|status| !status.is_empty())
+            {
+                event["response_status"] = serde_json::Value::String(status.to_string());
             }
-            if let Some(incomplete_details) = message.get("incomplete_details") {
+            if let Some(incomplete_details) = message
+                .get("incomplete_details")
+                .filter(|value| !value.is_null())
+            {
                 event["incomplete_details"] = incomplete_details.clone();
             }
             event
@@ -712,6 +719,27 @@ mod tests {
         );
         assert!(result["choices"][0]["finish_reason"].is_null());
         assert!(result.get("usage").is_none());
+    }
+
+    #[test]
+    fn test_transform_streaming_message_start_omits_null_metadata() {
+        let transformer = AnthropicToOpenAiResponseTransformer;
+        let anthropic_event = serde_json::json!({
+            "type": "message_start",
+            "message": {
+                "id": "msg_stream123",
+                "model": "claude-sonnet-4-6",
+                "refusal": null,
+                "response_status": null,
+                "incomplete_details": null
+            }
+        });
+
+        let result = transformer.transform_response(anthropic_event).unwrap();
+
+        assert!(result["choices"][0]["delta"].get("refusal").is_none());
+        assert!(result.get("response_status").is_none());
+        assert!(result.get("incomplete_details").is_none());
     }
 
     #[test]

--- a/src/transform/anthropic_to_openai.rs
+++ b/src/transform/anthropic_to_openai.rs
@@ -40,6 +40,7 @@ impl Transformer for AnthropicToOpenAiResponseTransformer {
                 == Some("content_block_start")
             || anthropic_response.get("type").and_then(|t| t.as_str())
                 == Some("content_block_delta")
+            || anthropic_response.get("type").and_then(|t| t.as_str()) == Some("content_block_stop")
             || anthropic_response.get("type").and_then(|t| t.as_str()) == Some("message_delta")
             || anthropic_response.get("type").and_then(|t| t.as_str()) == Some("message_stop")
         {
@@ -99,7 +100,7 @@ fn transform_non_streaming_response(anthropic_response: Value) -> Result<Value> 
     // Add usage if present
     let mut response_obj = openai_response;
     if let Some(usage) = anthropic_response.get("usage") {
-        response_obj["usage"] = usage.clone();
+        response_obj["usage"] = anthropic_usage_to_openai(usage);
     }
 
     debug!(
@@ -321,8 +322,7 @@ fn transform_streaming_event(anthropic_event: Value) -> Result<Value> {
                 .get("message")
                 .cloned()
                 .unwrap_or_else(|| serde_json::json!({}));
-
-            serde_json::json!({
+            let mut chunk = serde_json::json!({
                 "id": message.get("id").and_then(|v| v.as_str()).unwrap_or("chatcmpl-unknown"),
                 "object": "chat.completion.chunk",
                 "created": current_timestamp(),
@@ -332,7 +332,11 @@ fn transform_streaming_event(anthropic_event: Value) -> Result<Value> {
                     "delta": {"role": "assistant"},
                     "finish_reason": null
                 }]
-            })
+            });
+            if let Some(usage) = message.get("usage") {
+                chunk["usage"] = anthropic_usage_to_openai(usage);
+            }
+            chunk
         }
         "content_block_start" => {
             // Start of a content block
@@ -437,7 +441,7 @@ fn transform_streaming_event(anthropic_event: Value) -> Result<Value> {
                 .and_then(|v| v.as_str())
                 .map(map_anthropic_stop_reason);
 
-            serde_json::json!({
+            let mut chunk = serde_json::json!({
                 "id": "chatcmpl-stream",
                 "object": "chat.completion.chunk",
                 "created": current_timestamp(),
@@ -447,10 +451,14 @@ fn transform_streaming_event(anthropic_event: Value) -> Result<Value> {
                     "delta": {},
                     "finish_reason": stop_reason
                 }]
-            })
+            });
+            if let Some(usage) = anthropic_event.get("usage") {
+                chunk["usage"] = anthropic_usage_to_openai(usage);
+            }
+            chunk
         }
-        "message_stop" | "content_block_stop" => {
-            // End of message or content block - no delta needed
+        "content_block_stop" => {
+            // End of a content block - no delta needed.
             serde_json::json!({
                 "id": "chatcmpl-stream",
                 "object": "chat.completion.chunk",
@@ -462,6 +470,20 @@ fn transform_streaming_event(anthropic_event: Value) -> Result<Value> {
                     "finish_reason": null
                 }]
             })
+        }
+        "message_stop" => {
+            // OpenAI's usage-bearing terminal stream chunk has no choices.
+            let mut chunk = serde_json::json!({
+                "id": "chatcmpl-stream",
+                "object": "chat.completion.chunk",
+                "created": current_timestamp(),
+                "model": "unknown",
+                "choices": []
+            });
+            if let Some(usage) = anthropic_event.get("usage") {
+                chunk["usage"] = anthropic_usage_to_openai(usage);
+            }
+            chunk
         }
         _ => {
             // Unknown event type - return empty delta
@@ -480,6 +502,22 @@ fn transform_streaming_event(anthropic_event: Value) -> Result<Value> {
     };
 
     Ok(openai_event)
+}
+
+fn anthropic_usage_to_openai(usage: &Value) -> Value {
+    let prompt_tokens = usage
+        .get("input_tokens")
+        .and_then(Value::as_u64)
+        .unwrap_or_default();
+    let completion_tokens = usage
+        .get("output_tokens")
+        .and_then(Value::as_u64)
+        .unwrap_or_default();
+    serde_json::json!({
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "total_tokens": prompt_tokens.saturating_add(completion_tokens)
+    })
 }
 
 /// Get current Unix timestamp.
@@ -541,7 +579,9 @@ mod tests {
         assert_eq!(result["choices"][0]["message"]["role"], "assistant");
         assert_eq!(result["choices"][0]["message"]["content"], "Hello, world!");
         assert_eq!(result["choices"][0]["finish_reason"], "stop");
-        assert_eq!(result["usage"]["input_tokens"], 10);
+        assert_eq!(result["usage"]["prompt_tokens"], 10);
+        assert_eq!(result["usage"]["completion_tokens"], 5);
+        assert_eq!(result["usage"]["total_tokens"], 15);
     }
 
     #[test]
@@ -637,6 +677,8 @@ mod tests {
         assert_eq!(result["id"], "msg_stream123");
         assert_eq!(result["choices"][0]["delta"]["role"], "assistant");
         assert!(result["choices"][0]["finish_reason"].is_null());
+        assert_eq!(result["usage"]["prompt_tokens"], 10);
+        assert_eq!(result["usage"]["completion_tokens"], 1);
     }
 
     #[test]
@@ -656,6 +698,21 @@ mod tests {
 
         assert_eq!(result["object"], "chat.completion.chunk");
         assert_eq!(result["choices"][0]["delta"]["content"], "Hello");
+    }
+
+    #[test]
+    fn test_transform_streaming_content_block_stop() {
+        let transformer = AnthropicToOpenAiResponseTransformer;
+        let anthropic_event = serde_json::json!({
+            "type": "content_block_stop",
+            "index": 0
+        });
+
+        let result = transformer.transform_response(anthropic_event).unwrap();
+
+        assert_eq!(result["object"], "chat.completion.chunk");
+        assert!(result["choices"][0]["delta"].is_object());
+        assert!(result["choices"][0]["finish_reason"].is_null());
     }
 
     #[test]
@@ -698,6 +755,25 @@ mod tests {
 
         assert_eq!(result["object"], "chat.completion.chunk");
         assert_eq!(result["choices"][0]["finish_reason"], "stop");
+        assert_eq!(result["usage"]["prompt_tokens"], 0);
+        assert_eq!(result["usage"]["completion_tokens"], 50);
+    }
+
+    #[test]
+    fn test_transform_streaming_message_stop_emits_terminal_usage_chunk() {
+        let transformer = AnthropicToOpenAiResponseTransformer;
+        let anthropic_event = serde_json::json!({
+            "type": "message_stop",
+            "usage": {"input_tokens": 120, "output_tokens": 30}
+        });
+
+        let result = transformer.transform_response(anthropic_event).unwrap();
+
+        assert_eq!(result["object"], "chat.completion.chunk");
+        assert_eq!(result["choices"].as_array().unwrap().len(), 0);
+        assert_eq!(result["usage"]["prompt_tokens"], 120);
+        assert_eq!(result["usage"]["completion_tokens"], 30);
+        assert_eq!(result["usage"]["total_tokens"], 150);
     }
 
     #[test]

--- a/src/transform/anthropic_to_openai.rs
+++ b/src/transform/anthropic_to_openai.rs
@@ -322,7 +322,7 @@ fn transform_streaming_event(anthropic_event: Value) -> Result<Value> {
                 .get("message")
                 .cloned()
                 .unwrap_or_else(|| serde_json::json!({}));
-            serde_json::json!({
+            let mut event = serde_json::json!({
                 "id": message.get("id").and_then(|v| v.as_str()).unwrap_or("chatcmpl-unknown"),
                 "object": "chat.completion.chunk",
                 "created": current_timestamp(),
@@ -332,7 +332,22 @@ fn transform_streaming_event(anthropic_event: Value) -> Result<Value> {
                     "delta": {"role": "assistant"},
                     "finish_reason": null
                 }]
-            })
+            });
+            if let Some(refusal) = message
+                .get("refusal")
+                .and_then(|value| value.as_str())
+                .filter(|refusal| !refusal.is_empty())
+            {
+                event["choices"][0]["delta"]["refusal"] =
+                    serde_json::Value::String(refusal.to_string());
+            }
+            if let Some(status) = message.get("response_status") {
+                event["response_status"] = status.clone();
+            }
+            if let Some(incomplete_details) = message.get("incomplete_details") {
+                event["incomplete_details"] = incomplete_details.clone();
+            }
+            event
         }
         "content_block_start" => {
             // Start of a content block
@@ -674,6 +689,9 @@ mod tests {
                 "content": [],
                 "stop_reason": null,
                 "stop_sequence": null,
+                "refusal": "I cannot help with that.",
+                "response_status": "incomplete",
+                "incomplete_details": {"reason": "content_filter"},
                 "usage": {"input_tokens": 10, "output_tokens": 1}
             }
         });
@@ -683,6 +701,15 @@ mod tests {
         assert_eq!(result["object"], "chat.completion.chunk");
         assert_eq!(result["id"], "msg_stream123");
         assert_eq!(result["choices"][0]["delta"]["role"], "assistant");
+        assert_eq!(
+            result["choices"][0]["delta"]["refusal"],
+            "I cannot help with that."
+        );
+        assert_eq!(result["response_status"], "incomplete");
+        assert_eq!(
+            result["incomplete_details"],
+            serde_json::json!({"reason": "content_filter"})
+        );
         assert!(result["choices"][0]["finish_reason"].is_null());
         assert!(result.get("usage").is_none());
     }

--- a/src/transform/anthropic_to_openai.rs
+++ b/src/transform/anthropic_to_openai.rs
@@ -322,7 +322,7 @@ fn transform_streaming_event(anthropic_event: Value) -> Result<Value> {
                 .get("message")
                 .cloned()
                 .unwrap_or_else(|| serde_json::json!({}));
-            let mut chunk = serde_json::json!({
+            serde_json::json!({
                 "id": message.get("id").and_then(|v| v.as_str()).unwrap_or("chatcmpl-unknown"),
                 "object": "chat.completion.chunk",
                 "created": current_timestamp(),
@@ -332,11 +332,7 @@ fn transform_streaming_event(anthropic_event: Value) -> Result<Value> {
                     "delta": {"role": "assistant"},
                     "finish_reason": null
                 }]
-            });
-            if let Some(usage) = message.get("usage") {
-                chunk["usage"] = anthropic_usage_to_openai(usage);
-            }
-            chunk
+            })
         }
         "content_block_start" => {
             // Start of a content block
@@ -441,7 +437,7 @@ fn transform_streaming_event(anthropic_event: Value) -> Result<Value> {
                 .and_then(|v| v.as_str())
                 .map(map_anthropic_stop_reason);
 
-            let mut chunk = serde_json::json!({
+            serde_json::json!({
                 "id": "chatcmpl-stream",
                 "object": "chat.completion.chunk",
                 "created": current_timestamp(),
@@ -451,11 +447,7 @@ fn transform_streaming_event(anthropic_event: Value) -> Result<Value> {
                     "delta": {},
                     "finish_reason": stop_reason
                 }]
-            });
-            if let Some(usage) = anthropic_event.get("usage") {
-                chunk["usage"] = anthropic_usage_to_openai(usage);
-            }
-            chunk
+            })
         }
         "content_block_stop" => {
             // End of a content block - no delta needed.
@@ -473,17 +465,13 @@ fn transform_streaming_event(anthropic_event: Value) -> Result<Value> {
         }
         "message_stop" => {
             // OpenAI's usage-bearing terminal stream chunk has no choices.
-            let mut chunk = serde_json::json!({
+            serde_json::json!({
                 "id": "chatcmpl-stream",
                 "object": "chat.completion.chunk",
                 "created": current_timestamp(),
                 "model": "unknown",
                 "choices": []
-            });
-            if let Some(usage) = anthropic_event.get("usage") {
-                chunk["usage"] = anthropic_usage_to_openai(usage);
-            }
-            chunk
+            })
         }
         _ => {
             // Unknown event type - return empty delta
@@ -677,8 +665,7 @@ mod tests {
         assert_eq!(result["id"], "msg_stream123");
         assert_eq!(result["choices"][0]["delta"]["role"], "assistant");
         assert!(result["choices"][0]["finish_reason"].is_null());
-        assert_eq!(result["usage"]["prompt_tokens"], 10);
-        assert_eq!(result["usage"]["completion_tokens"], 1);
+        assert!(result.get("usage").is_none());
     }
 
     #[test]
@@ -755,12 +742,11 @@ mod tests {
 
         assert_eq!(result["object"], "chat.completion.chunk");
         assert_eq!(result["choices"][0]["finish_reason"], "stop");
-        assert_eq!(result["usage"]["prompt_tokens"], 0);
-        assert_eq!(result["usage"]["completion_tokens"], 50);
+        assert!(result.get("usage").is_none());
     }
 
     #[test]
-    fn test_transform_streaming_message_stop_emits_terminal_usage_chunk() {
+    fn test_transform_streaming_message_stop_has_empty_choices() {
         let transformer = AnthropicToOpenAiResponseTransformer;
         let anthropic_event = serde_json::json!({
             "type": "message_stop",
@@ -771,9 +757,7 @@ mod tests {
 
         assert_eq!(result["object"], "chat.completion.chunk");
         assert_eq!(result["choices"].as_array().unwrap().len(), 0);
-        assert_eq!(result["usage"]["prompt_tokens"], 120);
-        assert_eq!(result["usage"]["completion_tokens"], 30);
-        assert_eq!(result["usage"]["total_tokens"], 150);
+        assert!(result.get("usage").is_none());
     }
 
     #[test]

--- a/src/transform/anthropic_to_openai.rs
+++ b/src/transform/anthropic_to_openai.rs
@@ -354,6 +354,9 @@ fn transform_streaming_event(anthropic_event: Value) -> Result<Value> {
             {
                 event["incomplete_details"] = incomplete_details.clone();
             }
+            if let Some(responses_output) = message.get("__ccr_responses_output") {
+                event["__ccr_responses_output"] = responses_output.clone();
+            }
             event
         }
         "content_block_start" => {

--- a/tests/integration_codex.rs
+++ b/tests/integration_codex.rs
@@ -174,6 +174,74 @@ async fn test_codex_request_detection_by_user_agent() {
 }
 
 #[tokio::test]
+async fn test_codex_unwraps_openai_success_envelope() {
+    if skip_if_localhost_bind_unavailable() {
+        return;
+    }
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "success": true,
+            "data": {
+                "id": "chatcmpl-wrapped",
+                "object": "chat.completion",
+                "created": 1234567890,
+                "model": "test-model",
+                "choices": [{
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "wrapped-response-ok"
+                    },
+                    "finish_reason": "stop"
+                }],
+                "usage": {
+                    "prompt_tokens": 20,
+                    "completion_tokens": 4
+                }
+            }
+        })))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let config_json = make_test_config(&mock_server.uri());
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.json");
+    std::fs::write(&config_path, &config_json).unwrap();
+
+    let config = ccr_rust::config::Config::from_file(config_path.to_str().unwrap()).unwrap();
+    let app = build_app(config);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(&codex_request_body()).unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let response_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(
+        response_json["choices"][0]["message"]["content"],
+        "wrapped-response-ok"
+    );
+    assert!(response_json.get("success").is_none());
+}
+
+#[tokio::test]
 async fn test_models_endpoint_includes_route_ids_for_codex() {
     if skip_if_localhost_bind_unavailable() {
         return;

--- a/tests/integration_codex_openai_stream.rs
+++ b/tests/integration_codex_openai_stream.rs
@@ -288,6 +288,12 @@ async fn test_codex_stream_reassembles_fragmented_openai_sse_frames() {
         "Anthropic lifecycle frames must not leak to OpenAI clients"
     );
     let terminal = json_events.last().expect("terminal OpenAI usage chunk");
+    assert!(
+        json_events[..json_events.len() - 1]
+            .iter()
+            .all(|event| event.get("usage").is_none()),
+        "usage must appear only on the terminal OpenAI chunk"
+    );
     assert_eq!(terminal["choices"].as_array().unwrap().len(), 0);
     assert_eq!(terminal["usage"]["prompt_tokens"], 12);
     assert_eq!(terminal["usage"]["completion_tokens"], 4);

--- a/tests/integration_codex_openai_stream.rs
+++ b/tests/integration_codex_openai_stream.rs
@@ -212,7 +212,11 @@ async fn test_codex_stream_reassembles_fragmented_openai_sse_frames() {
                 "index": 0,
                 "delta": {},
                 "finish_reason": "stop"
-            }]
+            }],
+            "usage": {
+                "prompt_tokens": 12,
+                "completion_tokens": 4
+            }
         })
     );
 
@@ -273,6 +277,20 @@ async fn test_codex_stream_reassembles_fragmented_openai_sse_frames() {
         .map(|frame| serde_json::from_str(frame).unwrap())
         .collect();
 
+    assert!(
+        json_events.iter().all(|event| event["choices"].is_array()),
+        "every OpenAI SSE frame must satisfy the OpenAI chunk contract: {json_events:?}"
+    );
+    assert!(
+        json_events
+            .iter()
+            .all(|event| event["type"].as_str() != Some("content_block_stop")),
+        "Anthropic lifecycle frames must not leak to OpenAI clients"
+    );
+    let terminal = json_events.last().expect("terminal OpenAI usage chunk");
+    assert_eq!(terminal["choices"].as_array().unwrap().len(), 0);
+    assert_eq!(terminal["usage"]["prompt_tokens"], 12);
+    assert_eq!(terminal["usage"]["completion_tokens"], 4);
     assert!(
         json_events
             .iter()

--- a/tests/integration_codex_stream.rs
+++ b/tests/integration_codex_stream.rs
@@ -347,11 +347,16 @@ async fn test_anthropic_stream_emits_first_assistant_delta_before_completion() {
     assert!(!first_text.contains("[DONE]"));
 
     release_tail.notify_one();
-    let mut rest = String::new();
-    while let Some(chunk) = stream.next().await {
-        let chunk = chunk.unwrap();
-        rest.push_str(std::str::from_utf8(&chunk).unwrap());
-    }
+    let rest = timeout(Duration::from_secs(5), async {
+        let mut rest = String::new();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.unwrap();
+            rest.push_str(std::str::from_utf8(&chunk).unwrap());
+        }
+        rest
+    })
+    .await
+    .expect("stream should complete after the upstream tail is released");
     let full_stream = format!("{first_text}{rest}");
 
     let assistant_index = full_stream

--- a/tests/integration_codex_stream.rs
+++ b/tests/integration_codex_stream.rs
@@ -114,19 +114,33 @@ fn parse_sse_data_frames(payload: &str) -> Vec<String> {
 }
 
 async fn start_anthropic_stream_server(chunks: Vec<(Bytes, u64)>) -> String {
+    start_anthropic_stream_server_with_gate(chunks, None).await
+}
+
+async fn start_anthropic_stream_server_with_gate(
+    chunks: Vec<(Bytes, u64)>,
+    tail_gate: Option<std::sync::Arc<tokio::sync::Notify>>,
+) -> String {
     let chunks = std::sync::Arc::new(chunks);
     let app = Router::new().route(
         "/messages",
         post({
             let chunks = chunks.clone();
+            let tail_gate = tail_gate.clone();
             move || {
                 let chunks = chunks.clone();
+                let tail_gate = tail_gate.clone();
                 async move {
                     let (tx, rx) = tokio::sync::mpsc::channel::<Result<Bytes, std::io::Error>>(8);
                     tokio::spawn(async move {
-                        for (chunk, delay_ms) in chunks.iter() {
+                        for (index, (chunk, delay_ms)) in chunks.iter().enumerate() {
                             if tx.send(Ok(chunk.clone())).await.is_err() {
                                 return;
+                            }
+                            if index == 0 {
+                                if let Some(gate) = &tail_gate {
+                                    gate.notified().await;
+                                }
                             }
                             if *delay_ms > 0 {
                                 tokio::time::sleep(Duration::from_millis(*delay_ms)).await;
@@ -286,7 +300,7 @@ async fn test_anthropic_stream_emits_first_assistant_delta_before_completion() {
                     }
                 }),
             )),
-            1200,
+            0,
         ),
         (
             Bytes::from(sse_event(
@@ -305,7 +319,9 @@ async fn test_anthropic_stream_emits_first_assistant_delta_before_completion() {
         ),
     ];
 
-    let upstream_url = start_anthropic_stream_server(stream_chunks).await;
+    let release_tail = std::sync::Arc::new(tokio::sync::Notify::new());
+    let upstream_url =
+        start_anthropic_stream_server_with_gate(stream_chunks, Some(release_tail.clone())).await;
     let config_json = make_anthropic_test_config(&upstream_url);
     let dir = tempfile::tempdir().unwrap();
     let config_path = dir.path().join("config.json");
@@ -314,13 +330,13 @@ async fn test_anthropic_stream_emits_first_assistant_delta_before_completion() {
     let config = ccr_rust::config::Config::from_file(config_path.to_str().unwrap()).unwrap();
     let app = build_app(config);
 
-    let resp = timeout(Duration::from_millis(700), make_codex_stream_request(&app))
+    let resp = timeout(Duration::from_secs(5), make_codex_stream_request(&app))
         .await
         .expect("response should start before upstream stream completes");
     assert_eq!(resp.status(), StatusCode::OK);
 
     let mut stream = resp.into_body().into_data_stream();
-    let first_chunk = timeout(Duration::from_millis(700), stream.next())
+    let first_chunk = timeout(Duration::from_secs(5), stream.next())
         .await
         .expect("first chunk should arrive before stream completion")
         .expect("stream should contain first chunk")
@@ -330,6 +346,7 @@ async fn test_anthropic_stream_emits_first_assistant_delta_before_completion() {
     assert!(first_text.contains("\"role\":\"assistant\""));
     assert!(!first_text.contains("[DONE]"));
 
+    release_tail.notify_one();
     let mut rest = String::new();
     while let Some(chunk) = stream.next().await {
         let chunk = chunk.unwrap();

--- a/tests/integration_meta_responses.rs
+++ b/tests/integration_meta_responses.rs
@@ -467,7 +467,7 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
                 "total_tokens": 12
             }
         })))
-        .expect(4)
+        .expect(5)
         .mount(&upstream)
         .await;
 
@@ -713,6 +713,7 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
     assert!(!native_stream.contains("Reasoning survives adapters"));
 
     let response = app
+        .clone()
         .oneshot(
             Request::builder()
                 .method("POST")
@@ -780,6 +781,35 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
     );
     assert_eq!(response_json["text"], json!({"format": {"type": "text"}}));
 
+    let computer_output = json!({
+        "type": "computer_screenshot",
+        "image_url": "data:image/png;base64,c2NyZWVuc2hvdA=="
+    });
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/responses")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "model": "auto",
+                        "previous_response_id": "resp_computer_previous",
+                        "input": [{
+                            "type": "computer_call_output",
+                            "call_id": "call_computer_1",
+                            "output": computer_output
+                        }],
+                        "stream": false
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
     let requests = upstream.received_requests().await.unwrap();
     assert!(requests.iter().all(|request| {
         let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
@@ -810,6 +840,16 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
                         })
                 })
             })
+    }));
+    assert!(requests.iter().any(|request| {
+        let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+        body["previous_response_id"] == "resp_computer_previous"
+            && body["input"]
+                == json!([{
+                    "type": "computer_call_output",
+                    "call_id": "call_computer_1",
+                    "output": computer_output
+                }])
     }));
     assert!(requests.iter().any(|request| {
         let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();

--- a/tests/integration_meta_responses.rs
+++ b/tests/integration_meta_responses.rs
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//! End-to-end coverage for Responses API upstream providers such as Meta Muse.
+
+use axum::body::{to_bytes, Body};
+use axum::http::{Request, StatusCode};
+use axum::routing::post;
+use axum::Router;
+use serde_json::json;
+use tower::ServiceExt;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn build_app(config: ccr_rust::config::Config) -> Router {
+    let state = ccr_rust::router::AppState {
+        config,
+        ewma_tracker: std::sync::Arc::new(ccr_rust::routing::EwmaTracker::new()),
+        gp_router: None,
+        transformer_registry: std::sync::Arc::new(ccr_rust::transformer::TransformerRegistry::new()),
+        active_streams: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+        max_streams: 0,
+        ratelimit_tracker: std::sync::Arc::new(ccr_rust::ratelimit::RateLimitTracker::new()),
+        shutdown_timeout: 30,
+        debug_capture: None,
+    };
+
+    Router::new()
+        .route("/v1/messages", post(ccr_rust::router::handle_messages))
+        .with_state(state)
+}
+
+fn localhost_bind_available() -> bool {
+    std::net::TcpListener::bind("127.0.0.1:0").is_ok()
+}
+
+#[tokio::test]
+async fn meta_muse_uses_responses_endpoint_and_returns_anthropic_json() {
+    if !localhost_bind_available() {
+        eprintln!("Skipping test: localhost bind unavailable");
+        return;
+    }
+    let upstream = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/responses"))
+        .and(header("authorization", "Bearer meta-test-key"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "resp_meta_1",
+            "object": "response",
+            "created_at": 42,
+            "status": "completed",
+            "model": "muse-spark-1.1",
+            "output": [{
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "Meta Muse is routed."}]
+            }],
+            "usage": {"input_tokens": 9, "output_tokens": 5, "total_tokens": 14}
+        })))
+        .expect(1)
+        .mount(&upstream)
+        .await;
+
+    let config_json = json!({
+        "Providers": [{
+            "name": "meta-muse",
+            "api_base_url": upstream.uri(),
+            "api_key": "meta-test-key",
+            "models": ["muse-spark-1.1"],
+            "protocol": "responses",
+            "tier_name": "ccr-meta-muse"
+        }],
+        "Router": {
+            "default": "meta-muse,muse-spark-1.1",
+            "tiers": ["meta-muse,muse-spark-1.1"],
+            "forceNonStreaming": true
+        },
+        "API_TIMEOUT_MS": 5000
+    });
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.json");
+    std::fs::write(&config_path, serde_json::to_vec(&config_json).unwrap()).unwrap();
+    let config = ccr_rust::config::Config::from_file(config_path.to_str().unwrap()).unwrap();
+    let app = build_app(config);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/messages")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "model": "auto",
+                        "max_tokens": 64,
+                        "messages": [{"role": "user", "content": "Route this through Muse"}],
+                        "stream": false
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get("x-ccr-tier").unwrap(),
+        "ccr-meta-muse"
+    );
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let payload: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(payload["content"][0]["text"], "Meta Muse is routed.");
+    assert_eq!(payload["usage"]["input_tokens"], 9);
+    assert_eq!(payload["usage"]["output_tokens"], 5);
+
+    let requests = upstream.received_requests().await.unwrap();
+    let upstream_body: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
+    assert_eq!(upstream_body["model"], "muse-spark-1.1");
+    assert_eq!(upstream_body["stream"], false);
+    assert_eq!(upstream_body["max_output_tokens"], 64);
+    assert_eq!(upstream_body["input"][0]["role"], "user");
+    assert_eq!(
+        upstream_body["input"][0]["content"][0],
+        json!({"type": "input_text", "text": "Route this through Muse"})
+    );
+    assert!(upstream_body.get("messages").is_none());
+}
+
+#[tokio::test]
+async fn meta_muse_wraps_completed_response_for_streaming_clients() {
+    if !localhost_bind_available() {
+        eprintln!("Skipping test: localhost bind unavailable");
+        return;
+    }
+    let upstream = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/responses"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "resp_meta_stream",
+            "object": "response",
+            "created_at": 43,
+            "status": "completed",
+            "model": "muse-spark-1.1",
+            "output": [{
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "wrapped for stream"}]
+            }],
+            "usage": {"input_tokens": 7, "output_tokens": 3, "total_tokens": 10}
+        })))
+        .expect(1)
+        .mount(&upstream)
+        .await;
+
+    let config_json = json!({
+        "Providers": [{
+            "name": "meta-muse",
+            "api_base_url": upstream.uri(),
+            "api_key": "meta-test-key",
+            "models": ["muse-spark-1.1"],
+            "protocol": "responses",
+            "tier_name": "ccr-meta-muse"
+        }],
+        "Router": {
+            "default": "meta-muse,muse-spark-1.1",
+            "tiers": ["meta-muse,muse-spark-1.1"],
+            "forceNonStreaming": false
+        },
+        "API_TIMEOUT_MS": 5000
+    });
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.json");
+    std::fs::write(&config_path, serde_json::to_vec(&config_json).unwrap()).unwrap();
+    let config = ccr_rust::config::Config::from_file(config_path.to_str().unwrap()).unwrap();
+
+    let response = build_app(config)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/messages")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "model": "auto",
+                        "max_tokens": 32,
+                        "messages": [{"role": "user", "content": "Stream this"}],
+                        "stream": true
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get("content-type").unwrap(),
+        "text/event-stream"
+    );
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let text = String::from_utf8(body.to_vec()).unwrap();
+    assert!(text.contains("event: message_start"));
+    assert!(text.contains("wrapped for stream"));
+    assert!(text.contains("event: message_stop"));
+
+    let requests = upstream.received_requests().await.unwrap();
+    let upstream_body: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
+    assert_eq!(upstream_body["stream"], false);
+}

--- a/tests/integration_meta_responses.rs
+++ b/tests/integration_meta_responses.rs
@@ -54,6 +54,61 @@ fn sse_json_events(payload: &str) -> Result<Vec<serde_json::Value>, serde_json::
 }
 
 #[tokio::test]
+async fn native_responses_rejects_transformers_before_upstream_dispatch() {
+    if !localhost_bind_available() {
+        eprintln!("Skipping test: localhost bind unavailable");
+        return;
+    }
+    let upstream = MockServer::start().await;
+    let config_json = json!({
+        "Providers": [{
+            "name": "meta-muse",
+            "api_base_url": upstream.uri(),
+            "api_key": "meta-test-key",
+            "models": ["muse-spark-1.1"],
+            "protocol": "responses",
+            "tier_name": "ccr-meta-muse",
+            "transformer": {"use": ["identity"]}
+        }],
+        "Router": {
+            "default": "meta-muse,muse-spark-1.1",
+            "tiers": ["meta-muse,muse-spark-1.1"]
+        },
+        "API_TIMEOUT_MS": 5000
+    });
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.json");
+    std::fs::write(&config_path, serde_json::to_vec(&config_json).unwrap()).unwrap();
+    let config = ccr_rust::config::Config::from_file(config_path.to_str().unwrap()).unwrap();
+    let app = build_app(config);
+    let request = json!({
+        "model": "auto",
+        "input": [{
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_file", "file_id": "file_123"}]
+        }],
+        "metadata": {"trace": "must-not-be-lost"},
+        "stream": false
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/responses")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&request).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    assert!(upstream.received_requests().await.unwrap().is_empty());
+}
+
+#[tokio::test]
 async fn meta_muse_uses_responses_endpoint_and_returns_anthropic_json() {
     if !localhost_bind_available() {
         eprintln!("Skipping test: localhost bind unavailable");

--- a/tests/integration_meta_responses.rs
+++ b/tests/integration_meta_responses.rs
@@ -480,7 +480,7 @@ async fn meta_muse_preserves_reasoning_refusal_and_incomplete_status() {
             }],
             "usage": {"input_tokens": 5, "output_tokens": 2, "total_tokens": 7}
         })))
-        .expect(2)
+        .expect(4)
         .mount(&upstream)
         .await;
 
@@ -518,6 +518,7 @@ async fn meta_muse_preserves_reasoning_refusal_and_incomplete_status() {
                             "model": "auto",
                             "input": "refuse this",
                             "reasoning": {"effort": "high", "summary": "detailed"},
+                            "previous_response_id": "resp_previous",
                             "stream": stream
                         }))
                         .unwrap(),
@@ -564,9 +565,56 @@ async fn meta_muse_preserves_reasoning_refusal_and_incomplete_status() {
         }
     }
 
+    for stream in [false, true] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/messages")
+                    .header("content-type", "application/json")
+                    .header("anthropic-version", "2023-06-01")
+                    .body(Body::from(
+                        serde_json::to_vec(&json!({
+                            "model": "auto",
+                            "max_tokens": 64,
+                            "messages": [{"role": "user", "content": "refuse this"}],
+                            "stream": stream
+                        }))
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        if stream {
+            let text = String::from_utf8(body.to_vec()).unwrap();
+            assert!(text.contains("I cannot help with that."));
+            assert!(text.contains("text_delta"));
+        } else {
+            let payload: serde_json::Value = serde_json::from_slice(&body).unwrap();
+            assert_eq!(
+                payload["content"][0],
+                json!({"type": "text", "text": "I cannot help with that."})
+            );
+        }
+    }
+
     let requests = upstream.received_requests().await.unwrap();
-    assert!(requests.iter().all(|request| {
+    let continued_requests = requests
+        .iter()
+        .filter(|request| {
+            let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+            body.get("previous_response_id").is_some()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(continued_requests.len(), 2);
+    assert!(continued_requests.iter().all(|request| {
         let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
         body["reasoning"] == json!({"effort": "high", "summary": "detailed"})
+            && body["previous_response_id"] == "resp_previous"
     }));
 }

--- a/tests/integration_meta_responses.rs
+++ b/tests/integration_meta_responses.rs
@@ -25,6 +25,11 @@ fn build_app(config: ccr_rust::config::Config) -> Router {
 
     Router::new()
         .route("/v1/messages", post(ccr_rust::router::handle_messages))
+        .route(
+            "/v1/chat/completions",
+            post(ccr_rust::router::handle_chat_completions),
+        )
+        .route("/v1/responses", post(ccr_rust::router::handle_responses))
         .with_state(state)
 }
 
@@ -47,6 +52,8 @@ async fn meta_muse_uses_responses_endpoint_and_returns_anthropic_json() {
             "object": "response",
             "created_at": 42,
             "status": "completed",
+            "error": null,
+            "incomplete_details": null,
             "model": "muse-spark-1.1",
             "output": [{
                 "type": "message",
@@ -206,4 +213,95 @@ async fn meta_muse_wraps_completed_response_for_streaming_clients() {
     let requests = upstream.received_requests().await.unwrap();
     let upstream_body: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
     assert_eq!(upstream_body["stream"], false);
+}
+
+#[tokio::test]
+async fn meta_muse_preserves_streaming_for_openai_frontends() {
+    if !localhost_bind_available() {
+        eprintln!("Skipping test: localhost bind unavailable");
+        return;
+    }
+    let upstream = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/responses"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "resp_meta_openai_stream",
+            "object": "response",
+            "created_at": 44,
+            "status": "completed",
+            "error": null,
+            "incomplete_details": null,
+            "model": "muse-spark-1.1",
+            "output": [{
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "streamed through adapters"}]
+            }],
+            "usage": {"input_tokens": 8, "output_tokens": 4, "total_tokens": 12}
+        })))
+        .expect(2)
+        .mount(&upstream)
+        .await;
+
+    let config_json = json!({
+        "Providers": [{
+            "name": "meta-muse",
+            "api_base_url": upstream.uri(),
+            "api_key": "meta-test-key",
+            "models": ["muse-spark-1.1"],
+            "protocol": "responses",
+            "tier_name": "ccr-meta-muse"
+        }],
+        "Router": {
+            "default": "meta-muse,muse-spark-1.1",
+            "tiers": ["meta-muse,muse-spark-1.1"]
+        },
+        "API_TIMEOUT_MS": 5000
+    });
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.json");
+    std::fs::write(&config_path, serde_json::to_vec(&config_json).unwrap()).unwrap();
+    let config = ccr_rust::config::Config::from_file(config_path.to_str().unwrap()).unwrap();
+    let app = build_app(config);
+
+    for (uri, payload) in [
+        (
+            "/v1/chat/completions",
+            json!({
+                "model": "auto",
+                "messages": [{"role": "user", "content": "stream chat"}],
+                "stream": true
+            }),
+        ),
+        (
+            "/v1/responses",
+            json!({"model": "auto", "input": "stream responses", "stream": true}),
+        ),
+    ] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(uri)
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&payload).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.headers()["content-type"], "text/event-stream");
+        assert_eq!(response.headers()["x-ccr-tier"], "ccr-meta-muse");
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        assert!(String::from_utf8(body.to_vec())
+            .unwrap()
+            .contains("streamed through adapters"));
+    }
+
+    let requests = upstream.received_requests().await.unwrap();
+    assert!(requests.iter().all(|request| {
+        serde_json::from_slice::<serde_json::Value>(&request.body).unwrap()["stream"] == false
+    }));
 }

--- a/tests/integration_meta_responses.rs
+++ b/tests/integration_meta_responses.rs
@@ -37,12 +37,19 @@ fn localhost_bind_available() -> bool {
     std::net::TcpListener::bind("127.0.0.1:0").is_ok()
 }
 
-fn sse_json_events(payload: &str) -> Vec<serde_json::Value> {
+fn sse_json_events(payload: &str) -> Result<Vec<serde_json::Value>, serde_json::Error> {
     payload
         .split("\n\n")
-        .filter_map(|frame| frame.lines().find_map(|line| line.strip_prefix("data: ")))
-        .filter(|data| *data != "[DONE]")
-        .filter_map(|data| serde_json::from_str(data).ok())
+        .filter_map(|frame| {
+            let data = frame
+                .lines()
+                .filter_map(|line| line.strip_prefix("data:"))
+                .map(|line| line.strip_prefix(' ').unwrap_or(line))
+                .collect::<Vec<_>>()
+                .join("\n");
+            (!data.is_empty() && data != "[DONE]").then_some(data)
+        })
+        .map(|data| serde_json::from_str(&data))
         .collect()
 }
 
@@ -249,7 +256,13 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
                 "role": "assistant",
                 "content": [{"type": "output_text", "text": "streamed through adapters"}]
             }],
-            "usage": {"input_tokens": 8, "output_tokens": 4, "total_tokens": 12}
+            "usage": {
+                "input_tokens": 8,
+                "input_tokens_details": {"cached_tokens": 2},
+                "output_tokens": 4,
+                "output_tokens_details": {"reasoning_tokens": 3},
+                "total_tokens": 12
+            }
         })))
         .expect(3)
         .mount(&upstream)
@@ -312,7 +325,7 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
         assert!(text.contains("Reasoning survives adapters"));
 
         if uri == "/v1/responses" {
-            let events = sse_json_events(&text);
+            let events = sse_json_events(&text).expect("Responses SSE data should be valid JSON");
             let completed = events
                 .iter()
                 .find(|event| event["type"] == "response.completed")
@@ -320,6 +333,7 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
             let output = completed["response"]["output"]
                 .as_array()
                 .expect("completed Responses output should be an array");
+            assert_eq!(output.len(), 2, "reasoning and message items are required");
             assert_eq!(output[0]["type"], "reasoning");
             assert_eq!(
                 output[0]["summary"][0],
@@ -335,6 +349,14 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
                     "type": "output_text",
                     "text": "streamed through adapters"
                 }])
+            );
+            assert_eq!(
+                completed["response"]["usage"]["input_tokens_details"]["cached_tokens"],
+                2
+            );
+            assert_eq!(
+                completed["response"]["usage"]["output_tokens_details"]["reasoning_tokens"],
+                3
             );
         }
     }
@@ -373,6 +395,14 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
             "type": "output_text",
             "text": "streamed through adapters"
         }])
+    );
+    assert_eq!(
+        response_json["usage"]["input_tokens_details"]["cached_tokens"],
+        2
+    );
+    assert_eq!(
+        response_json["usage"]["output_tokens_details"]["reasoning_tokens"],
+        3
     );
 
     let requests = upstream.received_requests().await.unwrap();

--- a/tests/integration_meta_responses.rs
+++ b/tests/integration_meta_responses.rs
@@ -467,7 +467,7 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
                 "total_tokens": 12
             }
         })))
-        .expect(5)
+        .expect(6)
         .mount(&upstream)
         .await;
 
@@ -781,34 +781,46 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
     );
     assert_eq!(response_json["text"], json!({"format": {"type": "text"}}));
 
-    let computer_output = json!({
-        "type": "computer_screenshot",
-        "image_url": "data:image/png;base64,c2NyZWVuc2hvdA=="
-    });
-    let response = app
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/v1/responses")
-                .header("content-type", "application/json")
-                .body(Body::from(
-                    serde_json::to_vec(&json!({
-                        "model": "auto",
-                        "previous_response_id": "resp_computer_previous",
-                        "input": [{
-                            "type": "computer_call_output",
-                            "call_id": "call_computer_1",
-                            "output": computer_output
-                        }],
-                        "stream": false
-                    }))
+    let continuation_requests = [
+        json!({
+            "model": "auto",
+            "previous_response_id": "resp_computer_previous",
+            "input": [{
+                "type": "computer_call_output",
+                "call_id": "call_computer_1",
+                "output": {
+                    "type": "computer_screenshot",
+                    "image_url": "data:image/png;base64,c2NyZWVuc2hvdA=="
+                }
+            }],
+            "stream": false
+        }),
+        json!({
+            "model": "auto",
+            "previous_response_id": "resp_shell_previous",
+            "input": [{
+                "type": "local_shell_call_output",
+                "id": "call_shell_1",
+                "output": "{\"stdout\":\"done\"}"
+            }],
+            "stream": false
+        }),
+    ];
+    for request in &continuation_requests {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/responses")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(request).unwrap()))
                     .unwrap(),
-                ))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(response.status(), StatusCode::OK);
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
 
     let requests = upstream.received_requests().await.unwrap();
     assert!(requests.iter().all(|request| {
@@ -841,16 +853,13 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
                 })
             })
     }));
-    assert!(requests.iter().any(|request| {
-        let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
-        body["previous_response_id"] == "resp_computer_previous"
-            && body["input"]
-                == json!([{
-                    "type": "computer_call_output",
-                    "call_id": "call_computer_1",
-                    "output": computer_output
-                }])
-    }));
+    for continuation in continuation_requests {
+        assert!(requests.iter().any(|request| {
+            let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+            body["previous_response_id"] == continuation["previous_response_id"]
+                && body["input"] == continuation["input"]
+        }));
+    }
     assert!(requests.iter().any(|request| {
         let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
         body["text"]["format"]

--- a/tests/integration_meta_responses.rs
+++ b/tests/integration_meta_responses.rs
@@ -37,6 +37,15 @@ fn localhost_bind_available() -> bool {
     std::net::TcpListener::bind("127.0.0.1:0").is_ok()
 }
 
+fn sse_json_events(payload: &str) -> Vec<serde_json::Value> {
+    payload
+        .split("\n\n")
+        .filter_map(|frame| frame.lines().find_map(|line| line.strip_prefix("data: ")))
+        .filter(|data| *data != "[DONE]")
+        .filter_map(|data| serde_json::from_str(data).ok())
+        .collect()
+}
+
 #[tokio::test]
 async fn meta_muse_uses_responses_endpoint_and_returns_anthropic_json() {
     if !localhost_bind_available() {
@@ -242,7 +251,7 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
             }],
             "usage": {"input_tokens": 8, "output_tokens": 4, "total_tokens": 12}
         })))
-        .expect(2)
+        .expect(3)
         .mount(&upstream)
         .await;
 
@@ -301,15 +310,86 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
         let text = String::from_utf8(body.to_vec()).unwrap();
         assert!(text.contains("streamed through adapters"));
         assert!(text.contains("Reasoning survives adapters"));
+
+        if uri == "/v1/responses" {
+            let events = sse_json_events(&text);
+            let completed = events
+                .iter()
+                .find(|event| event["type"] == "response.completed")
+                .expect("Responses stream should contain response.completed");
+            let output = completed["response"]["output"]
+                .as_array()
+                .expect("completed Responses output should be an array");
+            assert_eq!(output[0]["type"], "reasoning");
+            assert_eq!(
+                output[0]["summary"][0],
+                json!({
+                    "type": "summary_text",
+                    "text": "Reasoning survives adapters"
+                })
+            );
+            assert_eq!(output[1]["type"], "message");
+            assert_eq!(
+                output[1]["content"],
+                json!([{
+                    "type": "output_text",
+                    "text": "streamed through adapters"
+                }])
+            );
+        }
     }
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/responses")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "model": "auto",
+                        "input": "non-stream responses",
+                        "stream": false
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let response_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(response_json["output"][0]["type"], "reasoning");
+    assert_eq!(
+        response_json["output"][0]["summary"][0]["text"],
+        "Reasoning survives adapters"
+    );
+    assert_eq!(response_json["output"][1]["type"], "message");
+    assert_eq!(
+        response_json["output"][1]["content"],
+        json!([{
+            "type": "output_text",
+            "text": "streamed through adapters"
+        }])
+    );
 
     let requests = upstream.received_requests().await.unwrap();
     assert!(requests.iter().all(|request| {
         serde_json::from_slice::<serde_json::Value>(&request.body).unwrap()["stream"] == false
     }));
     assert!(requests.iter().any(|request| {
-        serde_json::from_slice::<serde_json::Value>(&request.body).unwrap()["input"]
-            .to_string()
-            .contains("stream responses")
+        let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+        body["input"].as_array().is_some_and(|items| {
+            items.iter().any(|item| {
+                item["role"] == "user"
+                    && item["content"].as_array().is_some_and(|content| {
+                        content.iter().any(|part| {
+                            part["type"] == "input_text" && part["text"] == "stream responses"
+                        })
+                    })
+            })
+        })
     }));
 }

--- a/tests/integration_meta_responses.rs
+++ b/tests/integration_meta_responses.rs
@@ -453,3 +453,120 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
         })
     }));
 }
+
+#[tokio::test]
+async fn meta_muse_preserves_reasoning_refusal_and_incomplete_status() {
+    if !localhost_bind_available() {
+        eprintln!("Skipping test: localhost bind unavailable");
+        return;
+    }
+    let upstream = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/responses"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "resp_meta_refusal",
+            "object": "response",
+            "created_at": 45,
+            "status": "incomplete",
+            "incomplete_details": {"reason": "content_filter"},
+            "model": "muse-spark-1.1",
+            "output": [{
+                "type": "message",
+                "role": "assistant",
+                "content": [{
+                    "type": "refusal",
+                    "refusal": "I cannot help with that."
+                }]
+            }],
+            "usage": {"input_tokens": 5, "output_tokens": 2, "total_tokens": 7}
+        })))
+        .expect(2)
+        .mount(&upstream)
+        .await;
+
+    let config_json = json!({
+        "Providers": [{
+            "name": "meta-muse",
+            "api_base_url": upstream.uri(),
+            "api_key": "meta-test-key",
+            "models": ["muse-spark-1.1"],
+            "protocol": "responses",
+            "tier_name": "ccr-meta-muse"
+        }],
+        "Router": {
+            "default": "meta-muse,muse-spark-1.1",
+            "tiers": ["meta-muse,muse-spark-1.1"]
+        },
+        "API_TIMEOUT_MS": 5000
+    });
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.json");
+    std::fs::write(&config_path, serde_json::to_vec(&config_json).unwrap()).unwrap();
+    let config = ccr_rust::config::Config::from_file(config_path.to_str().unwrap()).unwrap();
+    let app = build_app(config);
+
+    for stream in [false, true] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/responses")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&json!({
+                            "model": "auto",
+                            "input": "refuse this",
+                            "reasoning": {"effort": "high", "summary": "detailed"},
+                            "stream": stream
+                        }))
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        if stream {
+            let text = String::from_utf8(body.to_vec()).unwrap();
+            let events = sse_json_events(&text).expect("Responses SSE data should be valid JSON");
+            let incomplete = events
+                .iter()
+                .find(|event| event["type"] == "response.incomplete")
+                .expect("Responses stream should preserve incomplete status");
+            assert_eq!(
+                incomplete["response"]["output"][0]["content"][0],
+                json!({
+                    "type": "refusal",
+                    "refusal": "I cannot help with that."
+                })
+            );
+            assert_eq!(
+                incomplete["response"]["incomplete_details"],
+                json!({"reason": "content_filter"})
+            );
+        } else {
+            let payload: serde_json::Value = serde_json::from_slice(&body).unwrap();
+            assert_eq!(payload["status"], "incomplete");
+            assert_eq!(
+                payload["incomplete_details"],
+                json!({"reason": "content_filter"})
+            );
+            assert_eq!(
+                payload["output"][0]["content"][0],
+                json!({
+                    "type": "refusal",
+                    "refusal": "I cannot help with that."
+                })
+            );
+        }
+    }
+
+    let requests = upstream.received_requests().await.unwrap();
+    assert!(requests.iter().all(|request| {
+        let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+        body["reasoning"] == json!({"effort": "high", "summary": "detailed"})
+    }));
+}

--- a/tests/integration_meta_responses.rs
+++ b/tests/integration_meta_responses.rs
@@ -435,6 +435,7 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
             "tools": [{"type": "web_search", "search_context_size": "low"}],
             "text": {"format": {"type": "text"}},
             "output": [{
+                "id": "rs_native",
                 "type": "reasoning",
                 "summary": [{"type": "summary_text", "text": "Reasoning survives adapters"}]
             }, {
@@ -443,6 +444,7 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
                 "status": "completed",
                 "action": {"type": "search", "query": "adapter citations"}
             }, {
+                "id": "msg_native",
                 "type": "message",
                 "role": "assistant",
                 "content": [{
@@ -613,6 +615,20 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
                     _ => assert_eq!(added[output_index]["item"], *item),
                 }
             }
+            let reasoning_delta = events
+                .iter()
+                .find(|event| event["type"] == "response.reasoning_text.delta")
+                .expect("reasoning delta should be replayed with item identity");
+            assert_eq!(reasoning_delta["output_index"], 0);
+            assert_eq!(reasoning_delta["item_id"], "rs_native");
+            assert_eq!(reasoning_delta["content_index"], 0);
+            let output_text_delta = events
+                .iter()
+                .find(|event| event["type"] == "response.output_text.delta")
+                .expect("output text delta should be replayed with item identity");
+            assert_eq!(output_text_delta["output_index"], 2);
+            assert_eq!(output_text_delta["item_id"], "msg_native");
+            assert_eq!(output_text_delta["content_index"], 0);
             assert_eq!(output[0]["type"], "reasoning");
             assert_eq!(
                 output[0]["summary"][0],

--- a/tests/integration_meta_responses.rs
+++ b/tests/integration_meta_responses.rs
@@ -71,6 +71,12 @@ async fn meta_muse_uses_responses_endpoint_and_returns_anthropic_json() {
             "error": null,
             "incomplete_details": null,
             "model": "muse-spark-1.1",
+            "metadata": {"campaign": "native-envelope"},
+            "previous_response_id": "resp_previous",
+            "instructions": "Keep the native response envelope.",
+            "tools": [{"type": "web_search", "search_context_size": "low"}],
+            "text": {"format": {"type": "text"}},
+            "__ccr_responses_response": {"id": "provider-injected"},
             "output": [{
                 "type": "message",
                 "role": "assistant",
@@ -134,6 +140,8 @@ async fn meta_muse_uses_responses_endpoint_and_returns_anthropic_json() {
     assert_eq!(payload["content"][0]["text"], "Meta Muse is routed.");
     assert_eq!(payload["usage"]["input_tokens"], 9);
     assert_eq!(payload["usage"]["output_tokens"], 5);
+    assert!(payload.get("metadata").is_none());
+    assert!(payload.get("__ccr_responses_response").is_none());
 
     let requests = upstream.received_requests().await.unwrap();
     let upstream_body: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
@@ -248,6 +256,11 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
             "error": null,
             "incomplete_details": null,
             "model": "muse-spark-1.1",
+            "metadata": {"campaign": "native-envelope"},
+            "previous_response_id": "resp_previous",
+            "instructions": "Keep the native response envelope.",
+            "tools": [{"type": "web_search", "search_context_size": "low"}],
+            "text": {"format": {"type": "text"}},
             "output": [{
                 "type": "reasoning",
                 "summary": [{"type": "summary_text", "text": "Reasoning survives adapters"}]
@@ -311,10 +324,24 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
                 "model": "auto",
                 "messages": [{"role": "user", "content": "stream chat"}],
                 "stream": true,
+                "response_format": {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "chat_answer",
+                        "schema": {
+                            "type": "object",
+                            "properties": {"answer": {"type": "string"}},
+                            "required": ["answer"],
+                            "additionalProperties": false
+                        },
+                        "strict": true
+                    }
+                },
                 "__ccr_responses_request": {
                     "model": "spoofed",
                     "input": "do not forward this"
-                }
+                },
+                "__ccr_responses_response": {"id": "spoofed-response"}
             }),
         ),
         (
@@ -386,6 +413,22 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
                 3,
                 "reasoning, native tool, and message items are required"
             );
+            let added = events
+                .iter()
+                .filter(|event| event["type"] == "response.output_item.added")
+                .collect::<Vec<_>>();
+            let done = events
+                .iter()
+                .filter(|event| event["type"] == "response.output_item.done")
+                .collect::<Vec<_>>();
+            assert_eq!(added.len(), output.len());
+            assert_eq!(done.len(), output.len());
+            for (output_index, item) in output.iter().enumerate() {
+                assert_eq!(added[output_index]["output_index"], output_index);
+                assert_eq!(added[output_index]["item"], *item);
+                assert_eq!(done[output_index]["output_index"], output_index);
+                assert_eq!(done[output_index]["item"], *item);
+            }
             assert_eq!(output[0]["type"], "reasoning");
             assert_eq!(
                 output[0]["summary"][0],
@@ -419,6 +462,26 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
             assert_eq!(
                 completed["response"]["usage"]["output_tokens_details"]["reasoning_tokens"],
                 3
+            );
+            assert_eq!(
+                completed["response"]["metadata"],
+                json!({"campaign": "native-envelope"})
+            );
+            assert_eq!(
+                completed["response"]["previous_response_id"],
+                "resp_previous"
+            );
+            assert_eq!(
+                completed["response"]["instructions"],
+                "Keep the native response envelope."
+            );
+            assert_eq!(
+                completed["response"]["tools"],
+                json!([{"type": "web_search", "search_context_size": "low"}])
+            );
+            assert_eq!(
+                completed["response"]["text"],
+                json!({"format": {"type": "text"}})
             );
         }
     }
@@ -506,6 +569,20 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
         response_json["usage"]["output_tokens_details"]["reasoning_tokens"],
         3
     );
+    assert_eq!(
+        response_json["metadata"],
+        json!({"campaign": "native-envelope"})
+    );
+    assert_eq!(response_json["previous_response_id"], "resp_previous");
+    assert_eq!(
+        response_json["instructions"],
+        "Keep the native response envelope."
+    );
+    assert_eq!(
+        response_json["tools"],
+        json!([{"type": "web_search", "search_context_size": "low"}])
+    );
+    assert_eq!(response_json["text"], json!({"format": {"type": "text"}}));
 
     let requests = upstream.received_requests().await.unwrap();
     assert!(requests.iter().all(|request| {
@@ -513,6 +590,7 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
         body["stream"] == false
             && body.get("__ccr_responses_request").is_none()
             && body.get("__ccr_responses_output").is_none()
+            && body.get("__ccr_responses_response").is_none()
             && body["model"] != "spoofed"
             && !body
                 .get("tool_choice")
@@ -535,6 +613,21 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
                             })
                         })
                 })
+            })
+    }));
+    assert!(requests.iter().any(|request| {
+        let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+        body["text"]["format"]
+            == json!({
+                "type": "json_schema",
+                "name": "chat_answer",
+                "schema": {
+                    "type": "object",
+                    "properties": {"answer": {"type": "string"}},
+                    "required": ["answer"],
+                    "additionalProperties": false
+                },
+                "strict": true
             })
     }));
 }

--- a/tests/integration_meta_responses.rs
+++ b/tests/integration_meta_responses.rs
@@ -300,7 +300,13 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
         ),
         (
             "/v1/responses",
-            json!({"model": "auto", "input": "stream responses", "stream": true}),
+            json!({
+                "model": "auto",
+                "input": "stream responses",
+                "stream": true,
+                "tools": [{"type": "web_search", "search_context_size": "low"}],
+                "tool_choice": {"type": "web_search"}
+            }),
         ),
     ] {
         let response = app
@@ -441,16 +447,18 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
     }));
     assert!(requests.iter().any(|request| {
         let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
-        body["input"].as_array().is_some_and(|items| {
-            items.iter().any(|item| {
-                item["role"] == "user"
-                    && item["content"].as_array().is_some_and(|content| {
-                        content.iter().any(|part| {
-                            part["type"] == "input_text" && part["text"] == "stream responses"
+        body["tools"] == json!([{"type": "web_search", "search_context_size": "low"}])
+            && body["tool_choice"] == json!({"type": "web_search"})
+            && body["input"].as_array().is_some_and(|items| {
+                items.iter().any(|item| {
+                    item["role"] == "user"
+                        && item["content"].as_array().is_some_and(|content| {
+                            content.iter().any(|part| {
+                                part["type"] == "input_text" && part["text"] == "stream responses"
+                            })
                         })
-                    })
+                })
             })
-        })
     }));
 }
 
@@ -600,6 +608,7 @@ async fn meta_muse_preserves_reasoning_refusal_and_incomplete_status() {
                 payload["content"][0],
                 json!({"type": "text", "text": "I cannot help with that."})
             );
+            assert!(payload.get("refusal").is_none());
         }
     }
 

--- a/tests/integration_meta_responses.rs
+++ b/tests/integration_meta_responses.rs
@@ -157,6 +157,76 @@ async fn meta_muse_uses_responses_endpoint_and_returns_anthropic_json() {
 }
 
 #[tokio::test]
+async fn native_background_response_preserves_queued_empty_envelope() {
+    if !localhost_bind_available() {
+        eprintln!("Skipping test: localhost bind unavailable");
+        return;
+    }
+    let upstream = MockServer::start().await;
+    let queued_response = json!({
+        "id": "resp_background",
+        "object": "response",
+        "created_at": 45,
+        "status": "queued",
+        "background": true,
+        "model": "muse-spark-1.1",
+        "metadata": {"campaign": "background"},
+        "output": []
+    });
+    Mock::given(method("POST"))
+        .and(path("/responses"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(queued_response.clone()))
+        .expect(1)
+        .mount(&upstream)
+        .await;
+
+    let config_json = json!({
+        "Providers": [{
+            "name": "meta-muse",
+            "api_base_url": upstream.uri(),
+            "api_key": "meta-test-key",
+            "models": ["muse-spark-1.1"],
+            "protocol": "responses",
+            "tier_name": "ccr-meta-muse"
+        }],
+        "Router": {
+            "default": "meta-muse,muse-spark-1.1",
+            "tiers": ["meta-muse,muse-spark-1.1"]
+        },
+        "API_TIMEOUT_MS": 5000
+    });
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.json");
+    std::fs::write(&config_path, serde_json::to_vec(&config_json).unwrap()).unwrap();
+    let config = ccr_rust::config::Config::from_file(config_path.to_str().unwrap()).unwrap();
+
+    let response = build_app(config)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/responses")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "model": "auto",
+                        "input": "run in the background",
+                        "background": true,
+                        "stream": false
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let payload: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(payload, queued_response);
+}
+
+#[tokio::test]
 async fn meta_muse_wraps_completed_response_for_streaming_clients() {
     if !localhost_bind_available() {
         eprintln!("Skipping test: localhost bind unavailable");

--- a/tests/integration_meta_responses.rs
+++ b/tests/integration_meta_responses.rs
@@ -264,7 +264,7 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
                 "total_tokens": 12
             }
         })))
-        .expect(3)
+        .expect(4)
         .mount(&upstream)
         .await;
 
@@ -360,6 +360,36 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
             );
         }
     }
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/messages")
+                .header("content-type", "application/json")
+                .header("anthropic-version", "2023-06-01")
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "model": "auto",
+                        "messages": [{"role": "user", "content": "native stream"}],
+                        "max_tokens": 256,
+                        "stream": true
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.headers()["content-type"], "text/event-stream");
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let native_stream = String::from_utf8(body.to_vec()).unwrap();
+    assert!(native_stream.contains("streamed through adapters"));
+    assert!(!native_stream.contains("thinking_delta"));
+    assert!(!native_stream.contains("Reasoning survives adapters"));
 
     let response = app
         .oneshot(

--- a/tests/integration_meta_responses.rs
+++ b/tests/integration_meta_responses.rs
@@ -615,13 +615,9 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
                     _ => assert_eq!(added[output_index]["item"], *item),
                 }
             }
-            let reasoning_delta = events
+            assert!(!events
                 .iter()
-                .find(|event| event["type"] == "response.reasoning_text.delta")
-                .expect("reasoning delta should be replayed with item identity");
-            assert_eq!(reasoning_delta["output_index"], 0);
-            assert_eq!(reasoning_delta["item_id"], "rs_native");
-            assert_eq!(reasoning_delta["content_index"], 0);
+                .any(|event| event["type"] == "response.reasoning_text.delta"));
             let output_text_delta = events
                 .iter()
                 .find(|event| event["type"] == "response.output_text.delta")

--- a/tests/integration_meta_responses.rs
+++ b/tests/integration_meta_responses.rs
@@ -233,6 +233,9 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
             "incomplete_details": null,
             "model": "muse-spark-1.1",
             "output": [{
+                "type": "reasoning",
+                "summary": [{"type": "summary_text", "text": "Reasoning survives adapters"}]
+            }, {
                 "type": "message",
                 "role": "assistant",
                 "content": [{"type": "output_text", "text": "streamed through adapters"}]
@@ -295,13 +298,18 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
         assert_eq!(response.headers()["content-type"], "text/event-stream");
         assert_eq!(response.headers()["x-ccr-tier"], "ccr-meta-muse");
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
-        assert!(String::from_utf8(body.to_vec())
-            .unwrap()
-            .contains("streamed through adapters"));
+        let text = String::from_utf8(body.to_vec()).unwrap();
+        assert!(text.contains("streamed through adapters"));
+        assert!(text.contains("Reasoning survives adapters"));
     }
 
     let requests = upstream.received_requests().await.unwrap();
     assert!(requests.iter().all(|request| {
         serde_json::from_slice::<serde_json::Value>(&request.body).unwrap()["stream"] == false
+    }));
+    assert!(requests.iter().any(|request| {
+        serde_json::from_slice::<serde_json::Value>(&request.body).unwrap()["input"]
+            .to_string()
+            .contains("stream responses")
     }));
 }

--- a/tests/integration_meta_responses.rs
+++ b/tests/integration_meta_responses.rs
@@ -252,9 +252,24 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
                 "type": "reasoning",
                 "summary": [{"type": "summary_text", "text": "Reasoning survives adapters"}]
             }, {
+                "type": "web_search_call",
+                "id": "ws_1",
+                "status": "completed",
+                "action": {"type": "search", "query": "adapter citations"}
+            }, {
                 "type": "message",
                 "role": "assistant",
-                "content": [{"type": "output_text", "text": "streamed through adapters"}]
+                "content": [{
+                    "type": "output_text",
+                    "text": "streamed through adapters",
+                    "annotations": [{
+                        "type": "url_citation",
+                        "start_index": 0,
+                        "end_index": 8,
+                        "title": "Adapter source",
+                        "url": "https://example.test/source"
+                    }]
+                }]
             }],
             "usage": {
                 "input_tokens": 8,
@@ -295,17 +310,44 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
             json!({
                 "model": "auto",
                 "messages": [{"role": "user", "content": "stream chat"}],
-                "stream": true
+                "stream": true,
+                "__ccr_responses_request": {
+                    "model": "spoofed",
+                    "input": "do not forward this"
+                }
             }),
         ),
         (
             "/v1/responses",
             json!({
                 "model": "auto",
-                "input": "stream responses",
+                "input": [{
+                    "type": "message",
+                    "role": "user",
+                    "content": [{
+                        "type": "input_text",
+                        "text": "stream responses"
+                    }, {
+                        "type": "input_file",
+                        "file_id": "file_123"
+                    }]
+                }],
                 "stream": true,
                 "tools": [{"type": "web_search", "search_context_size": "low"}],
-                "tool_choice": {"type": "web_search"}
+                "tool_choice": {"type": "web_search"},
+                "text": {
+                    "format": {
+                        "type": "json_schema",
+                        "name": "answer",
+                        "schema": {
+                            "type": "object",
+                            "properties": {"answer": {"type": "string"}},
+                            "required": ["answer"],
+                            "additionalProperties": false
+                        },
+                        "strict": true
+                    }
+                }
             }),
         ),
     ] {
@@ -339,7 +381,11 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
             let output = completed["response"]["output"]
                 .as_array()
                 .expect("completed Responses output should be an array");
-            assert_eq!(output.len(), 2, "reasoning and message items are required");
+            assert_eq!(
+                output.len(),
+                3,
+                "reasoning, native tool, and message items are required"
+            );
             assert_eq!(output[0]["type"], "reasoning");
             assert_eq!(
                 output[0]["summary"][0],
@@ -348,12 +394,22 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
                     "text": "Reasoning survives adapters"
                 })
             );
-            assert_eq!(output[1]["type"], "message");
+            assert_eq!(output[1]["type"], "web_search_call");
+            assert_eq!(output[1]["id"], "ws_1");
+            assert_eq!(output[1]["action"]["query"], "adapter citations");
+            assert_eq!(output[2]["type"], "message");
             assert_eq!(
-                output[1]["content"],
+                output[2]["content"],
                 json!([{
                     "type": "output_text",
-                    "text": "streamed through adapters"
+                    "text": "streamed through adapters",
+                    "annotations": [{
+                        "type": "url_citation",
+                        "start_index": 0,
+                        "end_index": 8,
+                        "title": "Adapter source",
+                        "url": "https://example.test/source"
+                    }]
                 }])
             );
             assert_eq!(
@@ -407,7 +463,8 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
                     serde_json::to_vec(&json!({
                         "model": "auto",
                         "input": "non-stream responses",
-                        "stream": false
+                        "stream": false,
+                        "tool_choice": null
                     }))
                     .unwrap(),
                 ))
@@ -424,12 +481,21 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
         response_json["output"][0]["summary"][0]["text"],
         "Reasoning survives adapters"
     );
-    assert_eq!(response_json["output"][1]["type"], "message");
+    assert_eq!(response_json["output"][1]["type"], "web_search_call");
+    assert_eq!(response_json["output"][1]["id"], "ws_1");
+    assert_eq!(response_json["output"][2]["type"], "message");
     assert_eq!(
-        response_json["output"][1]["content"],
+        response_json["output"][2]["content"],
         json!([{
             "type": "output_text",
-            "text": "streamed through adapters"
+            "text": "streamed through adapters",
+            "annotations": [{
+                "type": "url_citation",
+                "start_index": 0,
+                "end_index": 8,
+                "title": "Adapter source",
+                "url": "https://example.test/source"
+            }]
         }])
     );
     assert_eq!(
@@ -443,18 +509,29 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
 
     let requests = upstream.received_requests().await.unwrap();
     assert!(requests.iter().all(|request| {
-        serde_json::from_slice::<serde_json::Value>(&request.body).unwrap()["stream"] == false
+        let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+        body["stream"] == false
+            && body.get("__ccr_responses_request").is_none()
+            && body.get("__ccr_responses_output").is_none()
+            && body["model"] != "spoofed"
+            && !body
+                .get("tool_choice")
+                .is_some_and(|choice| choice.is_null())
     }));
     assert!(requests.iter().any(|request| {
         let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
         body["tools"] == json!([{"type": "web_search", "search_context_size": "low"}])
             && body["tool_choice"] == json!({"type": "web_search"})
+            && body["text"]["format"]["type"] == "json_schema"
+            && body["text"]["format"]["name"] == "answer"
             && body["input"].as_array().is_some_and(|items| {
                 items.iter().any(|item| {
                     item["role"] == "user"
                         && item["content"].as_array().is_some_and(|content| {
                             content.iter().any(|part| {
                                 part["type"] == "input_text" && part["text"] == "stream responses"
+                            }) && content.iter().any(|part| {
+                                part["type"] == "input_file" && part["file_id"] == "file_123"
                             })
                         })
                 })

--- a/tests/integration_meta_responses.rs
+++ b/tests/integration_meta_responses.rs
@@ -176,6 +176,110 @@ async fn native_background_response_preserves_queued_empty_envelope() {
     Mock::given(method("POST"))
         .and(path("/responses"))
         .respond_with(ResponseTemplate::new(200).set_body_json(queued_response.clone()))
+        .expect(2)
+        .mount(&upstream)
+        .await;
+
+    let config_json = json!({
+        "Providers": [{
+            "name": "meta-muse",
+            "api_base_url": upstream.uri(),
+            "api_key": "meta-test-key",
+            "models": ["muse-spark-1.1"],
+            "protocol": "responses",
+            "tier_name": "ccr-meta-muse"
+        }],
+        "Router": {
+            "default": "meta-muse,muse-spark-1.1",
+            "tiers": ["meta-muse,muse-spark-1.1"]
+        },
+        "API_TIMEOUT_MS": 5000
+    });
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.json");
+    std::fs::write(&config_path, serde_json::to_vec(&config_json).unwrap()).unwrap();
+    let config = ccr_rust::config::Config::from_file(config_path.to_str().unwrap()).unwrap();
+
+    let app = build_app(config);
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/responses")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "model": "auto",
+                        "input": "run in the background",
+                        "background": true,
+                        "stream": false
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let payload: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(payload, queued_response);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/responses")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "model": "auto",
+                        "input": "stream the background receipt",
+                        "background": true,
+                        "stream": true
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.headers()["content-type"], "text/event-stream");
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let events = sse_json_events(std::str::from_utf8(&body).unwrap()).unwrap();
+    let queued = events
+        .iter()
+        .find(|event| event["type"] == "response.queued")
+        .expect("queued stream event should preserve the pollable envelope");
+    assert_eq!(queued["response"], queued_response);
+    assert!(!events
+        .iter()
+        .any(|event| event["type"] == "response.incomplete"));
+}
+
+#[tokio::test]
+async fn native_failed_response_preserves_tracking_envelope() {
+    if !localhost_bind_available() {
+        eprintln!("Skipping test: localhost bind unavailable");
+        return;
+    }
+    let upstream = MockServer::start().await;
+    let failed_response = json!({
+        "id": "resp_failed",
+        "object": "response",
+        "created_at": 46,
+        "status": "failed",
+        "model": "muse-spark-1.1",
+        "error": {"code": "upstream_error", "message": "generation failed"},
+        "output": []
+    });
+    Mock::given(method("POST"))
+        .and(path("/responses"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(failed_response.clone()))
         .expect(1)
         .mount(&upstream)
         .await;
@@ -209,8 +313,7 @@ async fn native_background_response_preserves_queued_empty_envelope() {
                 .body(Body::from(
                     serde_json::to_vec(&json!({
                         "model": "auto",
-                        "input": "run in the background",
-                        "background": true,
+                        "input": "fail with a tracking receipt",
                         "stream": false
                     }))
                     .unwrap(),
@@ -223,7 +326,7 @@ async fn native_background_response_preserves_queued_empty_envelope() {
     assert_eq!(response.status(), StatusCode::OK);
     let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
     let payload: serde_json::Value = serde_json::from_slice(&body).unwrap();
-    assert_eq!(payload, queued_response);
+    assert_eq!(payload, failed_response);
 }
 
 #[tokio::test]
@@ -495,9 +598,20 @@ async fn meta_muse_preserves_streaming_for_openai_frontends() {
             assert_eq!(done.len(), output.len());
             for (output_index, item) in output.iter().enumerate() {
                 assert_eq!(added[output_index]["output_index"], output_index);
-                assert_eq!(added[output_index]["item"], *item);
                 assert_eq!(done[output_index]["output_index"], output_index);
                 assert_eq!(done[output_index]["item"], *item);
+                match item["type"].as_str() {
+                    Some("reasoning") => {
+                        assert_eq!(added[output_index]["item"]["summary"], json!([]));
+                    }
+                    Some("message") => {
+                        assert_eq!(added[output_index]["item"]["content"], json!([]));
+                    }
+                    Some("function_call") => {
+                        assert_eq!(added[output_index]["item"]["arguments"], "");
+                    }
+                    _ => assert_eq!(added[output_index]["item"], *item),
+                }
             }
             assert_eq!(output[0]["type"], "reasoning");
             assert_eq!(

--- a/tests/integration_responses.rs
+++ b/tests/integration_responses.rs
@@ -60,7 +60,10 @@ async fn start_gated_openai_stream_server(
                     if tx.send(Ok(Bytes::from(first))).await.is_err() {
                         return;
                     }
-                    tail_gate.notified().await;
+                    tokio::select! {
+                        _ = tail_gate.notified() => {}
+                        _ = tx.closed() => return,
+                    }
                     let tail = format!(
                         "data: {}\n\ndata: [DONE]\n\n",
                         json!({
@@ -742,9 +745,15 @@ async fn test_responses_stream_emits_delta_before_upstream_completion() {
     .await
     .expect("first translated delta should not wait for upstream EOF");
 
-    assert!(prefix.contains("event: response.output_text.delta"));
-    assert!(prefix.contains("\"delta\":\"first\""));
-    assert!(!prefix.contains("event: response.completed"));
+    let prefix_events = parse_sse_events(&prefix);
+    let first_delta = prefix_events
+        .iter()
+        .find(|event| event.event == "response.output_text.delta")
+        .expect("prefix should contain a translated text delta");
+    assert_eq!(first_delta.data["delta"], "first");
+    assert!(!prefix_events
+        .iter()
+        .any(|event| event.event == "response.completed"));
 
     tail_gate.notify_one();
     let suffix = timeout(Duration::from_secs(5), async {
@@ -759,8 +768,15 @@ async fn test_responses_stream_emits_delta_before_upstream_completion() {
     .await
     .expect("stream should complete after releasing the upstream tail");
 
-    assert!(suffix.contains("\"delta\":\" tail\""));
-    assert!(suffix.contains("event: response.completed"));
+    let suffix_events = parse_sse_events(&suffix);
+    let tail_delta = suffix_events
+        .iter()
+        .find(|event| event.event == "response.output_text.delta")
+        .expect("suffix should contain the released tail delta");
+    assert_eq!(tail_delta.data["delta"], " tail");
+    assert!(suffix_events
+        .iter()
+        .any(|event| event.event == "response.completed"));
 }
 
 #[tokio::test]

--- a/tests/integration_responses.rs
+++ b/tests/integration_responses.rs
@@ -3,9 +3,15 @@
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
+use axum::response::Response;
 use axum::routing::post;
 use axum::Router;
+use bytes::Bytes;
+use futures::StreamExt;
 use serde_json::json;
+use tokio::net::TcpListener;
+use tokio::time::{timeout, Duration};
+use tokio_stream::wrappers::ReceiverStream;
 use tower::ServiceExt;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -25,6 +31,68 @@ fn build_openai_sse(chunks: &[serde_json::Value]) -> String {
     }
     sse.push_str("data: [DONE]\n\n");
     sse
+}
+
+async fn start_gated_openai_stream_server(
+    tail_gate: std::sync::Arc<tokio::sync::Notify>,
+) -> String {
+    let app = Router::new().route(
+        "/chat/completions",
+        post(move || {
+            let tail_gate = tail_gate.clone();
+            async move {
+                let (tx, rx) = tokio::sync::mpsc::channel::<Result<Bytes, std::io::Error>>(4);
+                tokio::spawn(async move {
+                    let first = format!(
+                        "data: {}\n\n",
+                        json!({
+                            "id": "chatcmpl-gated",
+                            "object": "chat.completion.chunk",
+                            "created": 1730000002,
+                            "model": "test-model",
+                            "choices": [{
+                                "index": 0,
+                                "delta": {"content": "first"},
+                                "finish_reason": null
+                            }]
+                        })
+                    );
+                    if tx.send(Ok(Bytes::from(first))).await.is_err() {
+                        return;
+                    }
+                    tail_gate.notified().await;
+                    let tail = format!(
+                        "data: {}\n\ndata: [DONE]\n\n",
+                        json!({
+                            "id": "chatcmpl-gated",
+                            "object": "chat.completion.chunk",
+                            "created": 1730000002,
+                            "model": "test-model",
+                            "choices": [{
+                                "index": 0,
+                                "delta": {"content": " tail"},
+                                "finish_reason": "stop"
+                            }]
+                        })
+                    );
+                    let _ = tx.send(Ok(Bytes::from(tail))).await;
+                });
+
+                Response::builder()
+                    .status(StatusCode::OK)
+                    .header("content-type", "text/event-stream")
+                    .body(Body::from_stream(ReceiverStream::new(rx)))
+                    .unwrap()
+            }
+        }),
+    );
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    format!("http://{addr}")
 }
 
 fn parse_sse_events(body: &str) -> Vec<SseEvent> {
@@ -621,6 +689,81 @@ async fn test_responses_stream_emits_required_events() {
 }
 
 #[tokio::test]
+async fn test_responses_stream_emits_delta_before_upstream_completion() {
+    if skip_if_localhost_bind_unavailable(
+        "test_responses_stream_emits_delta_before_upstream_completion",
+    ) {
+        return;
+    }
+    let tail_gate = std::sync::Arc::new(tokio::sync::Notify::new());
+    let mock_url = start_gated_openai_stream_server(tail_gate.clone()).await;
+
+    let config_json = make_test_config(&mock_url);
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.json");
+    std::fs::write(&config_path, &config_json).unwrap();
+    let config = ccr_rust::config::Config::from_file(config_path.to_str().unwrap()).unwrap();
+    let app = build_app(config);
+
+    let request = json!({
+        "model": "mock,test-model",
+        "input": "Stream without waiting for EOF",
+        "stream": true
+    });
+    let resp = timeout(
+        Duration::from_secs(5),
+        app.oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/responses")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&request).unwrap()))
+                .unwrap(),
+        ),
+    )
+    .await
+    .expect("Responses headers should arrive before the upstream tail")
+    .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let mut body = resp.into_body().into_data_stream();
+    let prefix = timeout(Duration::from_secs(5), async {
+        let mut prefix = String::new();
+        while !prefix.contains("first") {
+            let chunk = body
+                .next()
+                .await
+                .expect("stream should remain open before the tail")
+                .expect("stream prefix should be readable");
+            prefix.push_str(&String::from_utf8_lossy(&chunk));
+        }
+        prefix
+    })
+    .await
+    .expect("first translated delta should not wait for upstream EOF");
+
+    assert!(prefix.contains("event: response.output_text.delta"));
+    assert!(prefix.contains("\"delta\":\"first\""));
+    assert!(!prefix.contains("event: response.completed"));
+
+    tail_gate.notify_one();
+    let suffix = timeout(Duration::from_secs(5), async {
+        let mut suffix = String::new();
+        while let Some(chunk) = body.next().await {
+            suffix.push_str(&String::from_utf8_lossy(
+                &chunk.expect("stream suffix should be readable"),
+            ));
+        }
+        suffix
+    })
+    .await
+    .expect("stream should complete after releasing the upstream tail");
+
+    assert!(suffix.contains("\"delta\":\" tail\""));
+    assert!(suffix.contains("event: response.completed"));
+}
+
+#[tokio::test]
 async fn test_responses_stream_merges_tool_call_deltas_across_chunks() {
     if skip_if_localhost_bind_unavailable(
         "test_responses_stream_merges_tool_call_deltas_across_chunks",
@@ -1063,6 +1206,68 @@ async fn test_responses_stream_maps_errors_to_response_failed() {
         .as_str()
         .is_some());
     assert_eq!(failed.data["response"]["error"]["code"], "upstream_error");
+}
+
+#[tokio::test]
+async fn test_responses_stream_preserves_exhausted_tier_rate_limit() {
+    if skip_if_localhost_bind_unavailable(
+        "test_responses_stream_preserves_exhausted_tier_rate_limit",
+    ) {
+        return;
+    }
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(429)
+                .insert_header("retry-after", "17")
+                .set_body_json(json!({
+                    "error": {
+                        "type": "rate_limit_error",
+                        "message": "upstream rate limit",
+                        "code": "rate_limited"
+                    }
+                })),
+        )
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let config_json = make_test_config(&mock_server.uri());
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.json");
+    std::fs::write(&config_path, &config_json).unwrap();
+    let config = ccr_rust::config::Config::from_file(config_path.to_str().unwrap()).unwrap();
+    let app = build_app(config);
+
+    let request = json!({
+        "model": "mock,test-model",
+        "input": "Rate limit case",
+        "stream": true
+    });
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/responses")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&request).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+    assert_eq!(resp.headers().get("retry-after").unwrap(), "17");
+    assert_eq!(resp.headers().get("x-ccr-tier").unwrap(), "mock");
+
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(body["error"]["type"], "rate_limit_error");
+    assert_eq!(body["error"]["code"], "rate_limited");
 }
 
 #[tokio::test]

--- a/tests/integration_responses.rs
+++ b/tests/integration_responses.rs
@@ -1347,6 +1347,8 @@ async fn test_responses_stream_recovers_when_upstream_sends_anthropic_events() {
         .find(|e| e.event == "response.completed")
         .expect("expected response.completed event");
     assert_eq!(completed.data["response"]["status"], "completed");
+    assert_eq!(completed.data["response"]["usage"]["input_tokens"], 3);
+    assert_eq!(completed.data["response"]["usage"]["output_tokens"], 2);
 
     let joined_deltas = events
         .iter()

--- a/tests/integration_responses.rs
+++ b/tests/integration_responses.rs
@@ -961,10 +961,21 @@ async fn test_responses_stream_complex_mixed_content_and_tools() {
         .expect("Tool 1 added");
     assert_eq!(tool1_added.data["item"]["name"], "calculator");
 
+    let added_events = events
+        .iter()
+        .filter(|event| event.event == "response.output_item.added")
+        .collect::<Vec<_>>();
+    assert!(added_events
+        .iter()
+        .all(|event| event.data["output_index"].as_u64().is_some()));
+
     let done_events: Vec<&SseEvent> = events
         .iter()
         .filter(|e| e.event == "response.output_item.done")
         .collect();
+    assert!(done_events
+        .iter()
+        .all(|event| event.data["output_index"].as_u64().is_some()));
 
     let done_debug: Vec<String> = done_events.iter().map(|e| e.data.to_string()).collect();
     assert!(

--- a/tests/test_stream_error_detection.rs
+++ b/tests/test_stream_error_detection.rs
@@ -296,10 +296,10 @@ async fn string_error_in_non_streaming_200_cascades() {
     let recovery_server = MockServer::start().await;
     Mock::given(method("POST"))
         .and(path("/chat/completions"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_json(json!({"error": "rate limited", "output": []})),
-        )
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "success": true,
+            "data": {"error": "rate limited", "output": []}
+        })))
         .expect(1)
         .mount(&broken_server)
         .await;

--- a/tests/test_stream_error_detection.rs
+++ b/tests/test_stream_error_detection.rs
@@ -286,6 +286,97 @@ async fn overload_error_in_200_cascades() {
     assert_eq!(resp.status(), StatusCode::OK);
 }
 
+#[tokio::test]
+async fn string_error_in_non_streaming_200_cascades() {
+    if skip_if_localhost_bind_unavailable("string_error_in_non_streaming_200_cascades") {
+        return;
+    }
+
+    let broken_server = MockServer::start().await;
+    let recovery_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(json!({"error": "rate limited", "output": []})),
+        )
+        .expect(1)
+        .mount(&broken_server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "chatcmpl-recovered",
+            "object": "chat.completion",
+            "created": 1234567890,
+            "model": "m1",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "recovered"},
+                "finish_reason": "stop"
+            }],
+            "usage": {"prompt_tokens": 3, "completion_tokens": 1}
+        })))
+        .expect(1)
+        .mount(&recovery_server)
+        .await;
+
+    let config = json!({
+        "Providers": [{
+            "name": "broken",
+            "api_base_url": broken_server.uri(),
+            "api_key": "k",
+            "models": ["m0"],
+            "tier_name": "broken"
+        }, {
+            "name": "recovery",
+            "api_base_url": recovery_server.uri(),
+            "api_key": "k",
+            "models": ["m1"],
+            "tier_name": "recovery"
+        }],
+        "Router": {
+            "default": "broken,m0",
+            "tiers": ["broken,m0", "recovery,m1"],
+            "tierRetries": {
+                "broken": {"max_retries": 0},
+                "recovery": {"max_retries": 0}
+            }
+        },
+        "API_TIMEOUT_MS": 5000
+    });
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.json");
+    std::fs::write(&config_path, serde_json::to_vec(&config).unwrap()).unwrap();
+    let cfg = ccr_rust::config::Config::from_file(config_path.to_str().unwrap()).unwrap();
+    let app = build_app(cfg);
+    let request = json!({
+        "model": "broken,m0",
+        "messages": [{"role": "user", "content": "recover"}],
+        "max_tokens": 32,
+        "stream": false
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/messages")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&request).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let response: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(response["content"][0]["text"], "recovered");
+}
+
 /// A valid response from tier-0 should NOT be treated as an error.
 #[tokio::test]
 async fn valid_200_response_not_treated_as_error() {


### PR DESCRIPTION
Update token optimization examples to use the supported Rust Index CLI rather than the retired legacy wrapper.

Verification: documentation-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenAI Responses API support, including native requests, response conversion, streaming, tools, reasoning, refusals, and continuations.
  * Preserved response status, incomplete details, response IDs, usage breakdowns, cached-token counts, and reasoning-token metadata.
  * Improved compatibility across OpenAI, Anthropic, and Codex integrations, including envelope handling and tool-call indexing.

* **Bug Fixes**
  * Improved validation, error handling, rate-limit responses, stream completion, and recovery between providers.

* **Documentation**
  * Updated the changelog and token-optimization example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->