### PR TITLE
docs: use Rust Index CLI in examples

### DIFF
--- a/docs/token_optimization.md
+++ b/docs/token_optimization.md
@@ -173,7 +173,7 @@ When CCR-Rust aggregates tool catalogs from multiple MCP backends, the combined 
 ```bash
 ccr-rust mcp --level medium \
   --wrap "npx @anthropic/mcp-server-filesystem" \
-  --wrap "npx @zilliz/claude-context-mcp@latest"
+  --wrap "contrib/rust_sindexer/target/release/sindexer"
 ```
 
 ### Recommendation


### PR DESCRIPTION
Update token optimization examples to use the supported Rust Index CLI rather than the retired wrapper.