### PR TITLE
feat: force provider reasoning effort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Forced provider reasoning effort** — OpenAI-compatible providers may set
   `force_reasoning_effort`; CCR applies it immediately before upstream
   dispatch so caller defaults cannot weaken a provider's required reasoning
-  level while the original OpenAI request fields remain intact. Configuration
+  level while all other original OpenAI request fields remain intact. Configuration
   loading rejects unsupported values and non-OpenAI provider protocols.
 
 - **Cached-input token accounting** — `/v1/usage` now reports aggregate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Forced provider reasoning effort** — OpenAI-compatible providers may set
   `force_reasoning_effort`; CCR applies it immediately before upstream
   dispatch so caller defaults cannot weaken a provider's required reasoning
-  level while the original OpenAI request fields remain intact.
+  level while the original OpenAI request fields remain intact. Configuration
+  loading rejects unsupported values and non-OpenAI provider protocols.
 
 - **Cached-input token accounting** — `/v1/usage` now reports aggregate
   `total_cache_read_tokens` and `total_cache_creation_tokens` alongside the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Forced provider reasoning effort** — OpenAI-compatible providers may set
+  `force_reasoning_effort`; CCR applies it immediately before upstream
+  dispatch so caller defaults cannot weaken a provider's required reasoning
+  level while the original OpenAI request fields remain intact.
+
 - **Cached-input token accounting** — `/v1/usage` now reports aggregate
   `total_cache_read_tokens` and `total_cache_creation_tokens` alongside the
   existing per-tier cache splits, persisted across restarts like the other

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,6 +121,11 @@ Each provider entry configures an upstream API endpoint.
 | `pricing` | object | No | - | Provider-default input/output prices in USD per million tokens, with optional cached-input rates. |
 | `model_pricing` | object | No | - | Model-keyed price overrides using the same rate fields. |
 | `transformer` | object | No | - | Request/response transformation configuration. |
+| `force_reasoning_effort` | string | No | - | Force `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max` on every OpenAI-protocol request. |
+
+`force_reasoning_effort` is valid only for the default `openai` provider
+protocol. Configuration validation rejects unsupported values and other
+protocols before the router starts.
 
 ### Provider and Model Pricing
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -10,6 +10,35 @@ use std::sync::Arc;
 
 use crate::debug_capture::DebugCaptureConfig;
 
+const REASONING_EFFORT_VALUES: &[&str] =
+    &["none", "minimal", "low", "medium", "high", "xhigh", "max"];
+
+/// Validate cross-field provider requirements before the router accepts traffic.
+fn validate_provider_contracts(providers: &[Provider]) -> Result<()> {
+    for provider in providers {
+        let Some(reasoning_effort) = provider.force_reasoning_effort.as_deref() else {
+            continue;
+        };
+        if provider.protocol != ProviderProtocol::Openai {
+            anyhow::bail!(
+                "provider '{}' force_reasoning_effort requires protocol 'openai'",
+                provider.name
+            );
+        }
+        if reasoning_effort.trim() != reasoning_effort
+            || !REASONING_EFFORT_VALUES.contains(&reasoning_effort)
+        {
+            anyhow::bail!(
+                "provider '{}' has invalid force_reasoning_effort '{}'; expected one of: {}",
+                provider.name,
+                reasoning_effort,
+                REASONING_EFFORT_VALUES.join(", ")
+            );
+        }
+    }
+    Ok(())
+}
+
 /// Named routing preset with optional parameter overrides.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct PresetConfig {
@@ -171,6 +200,7 @@ impl Config {
             });
         let file: ConfigFile =
             serde_json::from_str(&content).context("Failed to parse config JSON")?;
+        validate_provider_contracts(&file.providers)?;
 
         // Build a single shared reqwest::Client with a properly-sized connection pool.
         let mut client_builder = reqwest::Client::builder()
@@ -563,6 +593,42 @@ mod tests {
         );
 
         assert_eq!(p.force_reasoning_effort.as_deref(), Some("max"));
+        validate_provider_contracts(&[p]).unwrap();
+    }
+
+    #[test]
+    fn forced_reasoning_effort_requires_openai_protocol() {
+        let p = parse_provider(
+            r#"{
+                "name": "bad-responses",
+                "api_base_url": "https://api.example.test/v1",
+                "api_key": "test",
+                "models": ["model"],
+                "protocol": "responses",
+                "force_reasoning_effort": "max"
+            }"#,
+        );
+
+        let error = validate_provider_contracts(&[p]).unwrap_err();
+
+        assert!(error.to_string().contains("requires protocol 'openai'"));
+    }
+
+    #[test]
+    fn forced_reasoning_effort_rejects_unknown_values() {
+        let p = parse_provider(
+            r#"{
+                "name": "bad-effort",
+                "api_base_url": "https://api.example.test/v1",
+                "api_key": "test",
+                "models": ["model"],
+                "force_reasoning_effort": "maximum"
+            }"#,
+        );
+
+        let error = validate_provider_contracts(&[p]).unwrap_err();
+
+        assert!(error.to_string().contains("invalid force_reasoning_effort"));
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -551,6 +551,21 @@ mod tests {
     }
 
     #[test]
+    fn provider_with_forced_reasoning_effort() {
+        let p = parse_provider(
+            r#"{
+                "name": "upstage",
+                "api_base_url": "https://api.upstage.ai/v1",
+                "api_key": "up-test",
+                "models": ["solar-pro4"],
+                "force_reasoning_effort": "max"
+            }"#,
+        );
+
+        assert_eq!(p.force_reasoning_effort.as_deref(), Some("max"));
+    }
+
+    #[test]
     fn should_bypass_logic() {
         let t = parse_transformer(r#"{"use": ["anthropic"]}"#);
         assert!(t.should_bypass("anthropic", "some-model"));

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -25,9 +25,7 @@ fn validate_provider_contracts(providers: &[Provider]) -> Result<()> {
                 provider.name
             );
         }
-        if reasoning_effort.trim() != reasoning_effort
-            || !REASONING_EFFORT_VALUES.contains(&reasoning_effort)
-        {
+        if !REASONING_EFFORT_VALUES.contains(&reasoning_effort) {
             anyhow::bail!(
                 "provider '{}' has invalid force_reasoning_effort '{}'; expected one of: {}",
                 provider.name,

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -348,6 +348,13 @@ pub struct Provider {
     /// non-streaming mode causes excessive latency (e.g. Gemini).
     #[serde(default)]
     pub allow_streaming: bool,
+
+    /// Force one OpenAI Chat Completions reasoning effort for every request.
+    ///
+    /// Applied after frontend normalization so caller defaults cannot weaken
+    /// a provider-specific requirement.
+    #[serde(default)]
+    pub force_reasoning_effort: Option<String>,
 }
 
 fn default_honor_ratelimit_headers() -> bool {

--- a/src/router/dispatch.rs
+++ b/src/router/dispatch.rs
@@ -451,6 +451,32 @@ pub(super) fn provider_openai_chat_completions_url(provider: &crate::config::Pro
     provider_endpoint_url(provider, "chat/completions")
 }
 
+fn apply_provider_request_overrides(
+    provider: &crate::config::Provider,
+    request: &mut serde_json::Value,
+) -> Result<(), TryRequestError> {
+    let Some(reasoning_effort) = provider.force_reasoning_effort.as_deref() else {
+        return Ok(());
+    };
+    if provider.protocol != ProviderProtocol::Openai {
+        return Err(TryRequestError::Other(anyhow::anyhow!(
+            "provider '{}' force_reasoning_effort requires protocol 'openai'",
+            provider.name
+        )));
+    }
+    let object = request.as_object_mut().ok_or_else(|| {
+        TryRequestError::Other(anyhow::anyhow!(
+            "provider '{}' request override requires a JSON object",
+            provider.name
+        ))
+    })?;
+    object.insert(
+        "reasoning_effort".to_string(),
+        serde_json::Value::String(reasoning_effort.to_string()),
+    );
+    Ok(())
+}
+
 pub(super) fn provider_anthropic_messages_url(provider: &crate::config::Provider) -> String {
     provider_endpoint_url(provider, "messages")
 }
@@ -678,7 +704,7 @@ pub(super) async fn try_request_via_openai_protocol(
             object.remove(super::RESPONSES_REQUEST_PASSTHROUGH_KEY);
         }
     }
-    let (request_value, stream_flag) = if provider.protocol == ProviderProtocol::Responses {
+    let (mut request_value, stream_flag) = if provider.protocol == ProviderProtocol::Responses {
         (
             openai_chat_request_to_responses(&openai_request_value, model_name)
                 .map_err(TryRequestError::Other)?,
@@ -687,6 +713,7 @@ pub(super) async fn try_request_via_openai_protocol(
     } else {
         (openai_request_value, stream_flag)
     };
+    apply_provider_request_overrides(provider, &mut request_value)?;
 
     // Set up capture if enabled for this provider
     let capture_builder = if let Some(ref capture) = debug_capture {
@@ -1387,6 +1414,41 @@ mod tests {
 
         assert_eq!(headers.get("authorization").unwrap(), "Bearer ak-test");
         assert!(headers.get("x-api-key").is_none());
+    }
+
+    #[test]
+    fn provider_reasoning_effort_override_is_forced() {
+        let provider: Provider = serde_json::from_value(serde_json::json!({
+            "name": "upstage",
+            "api_base_url": "https://api.upstage.ai/v1",
+            "api_key": "up-test",
+            "models": ["solar-pro4"],
+            "force_reasoning_effort": "max"
+        }))
+        .unwrap();
+        let mut request = serde_json::json!({"reasoning_effort": "low"});
+
+        apply_provider_request_overrides(&provider, &mut request).unwrap();
+
+        assert_eq!(request["reasoning_effort"], "max");
+    }
+
+    #[test]
+    fn provider_reasoning_effort_override_rejects_non_openai_protocol() {
+        let provider: Provider = serde_json::from_value(serde_json::json!({
+            "name": "test-responses",
+            "api_base_url": "https://api.example.test/v1",
+            "api_key": "test",
+            "models": ["model"],
+            "protocol": "responses",
+            "force_reasoning_effort": "max"
+        }))
+        .unwrap();
+        let mut request = serde_json::json!({});
+
+        let error = apply_provider_request_overrides(&provider, &mut request).unwrap_err();
+
+        assert!(error.to_string().contains("requires protocol 'openai'"));
     }
 
     #[test]

--- a/src/router/dispatch.rs
+++ b/src/router/dispatch.rs
@@ -451,6 +451,7 @@ pub(super) fn provider_openai_chat_completions_url(provider: &crate::config::Pro
     provider_endpoint_url(provider, "chat/completions")
 }
 
+/// Apply validated provider-level request requirements immediately before dispatch.
 fn apply_provider_request_overrides(
     provider: &crate::config::Provider,
     request: &mut serde_json::Value,
@@ -473,6 +474,11 @@ fn apply_provider_request_overrides(
     object.insert(
         "reasoning_effort".to_string(),
         serde_json::Value::String(reasoning_effort.to_string()),
+    );
+    trace!(
+        provider = %provider.name,
+        reasoning_effort,
+        "forced provider reasoning effort"
     );
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add an optional `force_reasoning_effort` provider setting for OpenAI Chat Completions upstreams
- apply the configured effort immediately before dispatch, overriding weaker caller values without losing passthrough request fields
- validate protocol and supported values during config loading, with a defensive runtime guard and trace evidence

## Verification
- `cargo fmt --check`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo test --all-features` (414 unit tests plus all integration suites)
- `cargo build --release`
- installed/release SHA-256 match: `80cff04ab43c0956615ba5f8f59da7bd41836ca151cb6b5e695498ff9ff24302`
- live Upstage `solar-pro4` request succeeded through CCR with the forced-max provider config

## Dependency
Stacked on #28 so the root AlphaHENG submodule can advance from the cached-usage series without duplicating that diff.